### PR TITLE
Add tide chart navigation from home

### DIFF
--- a/docs/team/worklog/2026-08-28-23-head-dev.md
+++ b/docs/team/worklog/2026-08-28-23-head-dev.md
@@ -1,0 +1,7 @@
+### 2026-08-28 | head-dev | 20m
+- Added a large Open tide chart button to the home page so the merged chart is reachable without typing its address.
+- Confirmed the production build contains the link and `/tides` responds successfully.
+- GitHub audit: tide design PR #2 and React chart PR #4 are merged; COO handoff PR #3 remains open and is unrelated to navigation.
+- Vercel redirects both current deployment URLs to Vercel sign-in before the app runs. Deployment Protection must be changed in Vercel if the preview should be public.
+- Checks: lint, TypeScript, webpack production build, home-link response, and `/tides` HTTP 200.
+- Files: `src/app/page.tsx`, `docs/team/worklog/2026-08-28-23-head-dev.md`.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
@@ -36,8 +37,17 @@ export default async function Home() {
     <main className="flex min-h-screen flex-col items-center justify-center gap-8 bg-background p-8 font-ui text-text-primary">
       <div className="text-center">
         <h1 className="text-h1 font-bold tracking-tight">Fish Log Book</h1>
-        <p className="mt-2 text-caption text-text-muted">Next.js + Supabase</p>
+        <p className="mt-2 text-caption text-text-muted">
+          Read the tide, then build an honest fishing history.
+        </p>
       </div>
+
+      <Link
+        href="/tides"
+        className="inline-flex min-h-touch-floor items-center justify-center rounded-md border border-signal-orange bg-signal-orange px-6 py-3 text-label font-semibold text-ink-on-orange transition-colors hover:bg-signal-orange-pressed focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+      >
+        Open tide chart
+      </Link>
 
       <div className="w-full max-w-md rounded-md border border-hairline bg-surface p-5">
         <div className="flex items-center gap-3">


### PR DESCRIPTION
- Adds a clear Open tide chart action on the home page
- Makes the existing /tides route discoverable in deployed builds
- Verified with npm run lint and npx next build --webpack