### PR TITLE
feat: add phone-first Tackle Box

### DIFF
--- a/docs/design/08-tackle-box.md
+++ b/docs/design/08-tackle-box.md
@@ -1,0 +1,43 @@
+# 08 — Tackle Box
+
+**Status:** Built as a session-only web prototype · **Date:** 2026-08-30
+
+## Job
+
+Before a trip, an angler needs to name the lures they actually carry once, then find the
+right one quickly when setting a rig. The page is a personal lure library, not a product
+catalogue, social feed, or fishing-performance dashboard.
+
+## First slice
+
+- `/tackle` lists explicit local fixtures and any lures added during the open browser
+  session. It states clearly that nothing is synced or saved after a refresh.
+- Favorites form a compact horizontal "Ready to rig" rail, followed by the complete
+  library. A favorite button remains independent from the card content so a wet-finger
+  mis-tap cannot accidentally open or edit an item.
+- Search covers name, canonical class, color, and size. All/Salt/Fresh filters retain
+  all-water lures in either water view.
+- Add lure uses a native modal dialog: user name and canonical lure class are required;
+  color and size are optional. A short chip set serves the common choices and a native
+  select exposes the full vocabulary. The dialog has a labeled 48px close action and a
+  68px primary action.
+
+## Scope boundary
+
+`tackle_item` already carries only the personal lure name, canonical `lure_class`, optional
+color/size, and favorite state. Rod, reel, line, and leader are the separate Roadmap A5
+gear-loadout proposal; this page does not add or imply those fields. Persistence is deferred
+until the offline store/query lane is available, so views never reach Supabase directly.
+
+## Phone and accessibility rules
+
+- Every interactive target is 48px or larger; primary add/save action is 68px.
+- Filter and class choices are real buttons with `aria-pressed`; favorite state is readable
+as text, not color alone. Search has a visible label and validation connects errors to the
+field.
+- The native dialog owns focus while open; Escape and the visible Close button both return
+the user to the page. No core action relies on a gesture, and nonessential transitions honor
+reduced motion.
+- At 320px, controls wrap rather than compress below the touch floor. The favorites rail is
+the only intentional horizontal scroll, a secondary browsing convenience rather than the
+sole route to any item.

--- a/docs/team/worklog/2026-08-30-04-ux-ui.md
+++ b/docs/team/worklog/2026-08-30-04-ux-ui.md
@@ -1,0 +1,12 @@
+### 2026-08-30 | ux-ui | Tackle Box prototype
+
+- Built a phone-first Tackle Box page for naming and finding personal lures quickly.
+- Added favorites, search, salt/fresh filters, and an accessible Add lure dialog.
+- Kept all sample and new data in the open browser session and said so clearly; no tackle
+  record, schema, or syncing behavior was changed.
+- Added a Settings entry and focused filtering tests.
+- Files: `src/app/(app)/tackle/page.tsx`, `src/features/tackle/**`,
+  `src/app/(app)/settings/page.tsx`, `docs/design/08-tackle-box.md`.
+- Next: connect this interface to the offline store/query lane, then make favorites available
+  from the sticky rig editor. Checked in 320px Chrome touch emulation with no page overflow
+  or undersized visible targets; not on a real phone or VoiceOver yet.

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 
 import { BackendDiagnostics } from "@/features/settings/components/backend-diagnostics";
 import { UnitsToggle } from "@/features/settings/components/units-toggle";
@@ -13,6 +14,19 @@ export default function SettingsPage() {
         <p className="mt-3 text-body text-text-muted">
           Account and the platform selector (D26) land with the rest of the settings feature.
         </p>
+      </section>
+
+      <section className="rounded-lg border border-hairline bg-surface p-4">
+        <h2 className="text-h3">Tackle</h2>
+        <p className="mt-2 text-body text-text-muted">
+          Name the lures you reach for most, then keep favorites ready for your next rig.
+        </p>
+        <Link
+          href="/tackle"
+          className="mt-4 inline-flex min-h-touch-floor items-center justify-center rounded-md border border-border-interactive px-4 text-label text-text-link transition-colors hover:bg-surface-raised focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring active:scale-95 motion-reduce:transition-none"
+        >
+          Open Tackle Box
+        </Link>
       </section>
 
       <section className="rounded-lg border border-hairline bg-surface p-4">

--- a/src/app/(app)/tackle/page.tsx
+++ b/src/app/(app)/tackle/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+import { TackleBox } from "@/features/tackle/components/tackle-box";
+
+export const metadata: Metadata = {
+  title: "Tackle Box | Fish Log Book",
+  description: "A personal, session-only lure library for the Fish Log Book prototype.",
+};
+
+export default function TacklePage() {
+  return <TackleBox />;
+}

--- a/src/features/tackle/components/tackle-box.tsx
+++ b/src/features/tackle/components/tackle-box.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { TACKLE_FIXTURE } from "../tackle-fixture";
+import { FILTER_LABELS, itemMatchesFilter, type TackleDraft, type TackleFilter, type TackleItem } from "../types";
+import { TackleEditorSheet } from "./tackle-editor-sheet";
+import { TackleItemCard } from "./tackle-item-card";
+
+const FILTERS: readonly TackleFilter[] = ["all", "salt", "fresh"];
+
+export function TackleBox() {
+  const [items, setItems] = useState<TackleItem[]>(() => [...TACKLE_FIXTURE]);
+  const [filter, setFilter] = useState<TackleFilter>("all");
+  const [query, setQuery] = useState("");
+  const [editorOpen, setEditorOpen] = useState(false);
+
+  const visibleItems = useMemo(
+    () => items.filter((item) => itemMatchesFilter(item, filter, query)),
+    [filter, items, query],
+  );
+  const favorites = items.filter((item) => item.isFavorite);
+
+  function toggleFavorite(id: string) {
+    setItems((current) =>
+      current.map((item) => (item.id === id ? { ...item, isFavorite: !item.isFavorite } : item)),
+    );
+  }
+
+  function createItem(draft: TackleDraft) {
+    setItems((current) => [
+      { ...draft, id: `session-${crypto.randomUUID()}` },
+      ...current,
+    ]);
+  }
+
+  return (
+    <section className="flex flex-col gap-8 pb-8">
+      <header className="rounded-lg border border-hairline bg-surface p-4">
+        <div className="flex flex-col items-start gap-4 sm:flex-row sm:justify-between">
+          <div className="min-w-0">
+            <p className="text-caption font-bold tracking-station text-tide-cyan">YOUR LURE LIBRARY</p>
+            <h1 className="mt-1 text-h1">Tackle Box</h1>
+          </div>
+          <button
+            type="button"
+            onClick={() => setEditorOpen(true)}
+            className="inline-flex min-h-touch-floor items-center justify-center rounded-md bg-signal-orange px-4 text-label text-ink-on-orange transition-colors hover:bg-signal-orange-pressed focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring active:scale-95 motion-reduce:transition-none"
+          >
+            Add lure
+          </button>
+        </div>
+        <p className="mt-4 text-body text-text-muted">
+          Keep the lures you reach for close. Favorites will be ready when you set a rig.
+        </p>
+        <p className="mt-3 rounded-md border border-tide-cyan bg-surface-raised px-3 py-2 text-caption text-text-link" role="status">
+          Prototype: changes stay in this session and are not synced.
+        </p>
+      </header>
+
+      {favorites.length > 0 ? (
+        <section aria-labelledby="favorite-lures-heading">
+          <div className="flex items-baseline justify-between gap-3">
+            <h2 id="favorite-lures-heading" className="text-h2">Ready to rig</h2>
+            <p className="text-caption text-text-muted">Your favorites</p>
+          </div>
+          <div className="mt-4 flex gap-3 overflow-x-auto pb-2">
+            {favorites.map((item) => (
+              <TackleItemCard key={item.id} item={item} compact onToggleFavorite={toggleFavorite} />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      <section aria-labelledby="all-lures-heading">
+        <div className="flex flex-col gap-4">
+          <div className="flex items-baseline justify-between gap-3">
+            <h2 id="all-lures-heading" className="text-h2">All lures</h2>
+            <p className="text-caption text-text-muted">{items.length} in this session</p>
+          </div>
+          <label className="flex flex-col gap-2 text-label">
+            Search your tackle
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Name, class, color, or size"
+              className="min-h-touch-floor rounded-md border border-border-interactive bg-surface px-4 text-body text-text-primary placeholder:text-text-muted focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+            />
+          </label>
+          <div className="flex flex-wrap gap-3" role="group" aria-label="Water type filter">
+            {FILTERS.map((option) => {
+              const selected = filter === option;
+              return (
+                <button
+                  key={option}
+                  type="button"
+                  aria-pressed={selected}
+                  onClick={() => setFilter(option)}
+                  className={`min-h-touch-floor rounded-full border px-5 text-label transition-colors focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring active:scale-95 motion-reduce:transition-none ${
+                    selected
+                      ? "border-signal-orange bg-signal-orange text-ink-on-orange"
+                      : "border-border-interactive bg-surface text-text-link"
+                  }`}
+                >
+                  {FILTER_LABELS[option]}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {items.length > 0 ? (
+          <div className="mt-5 flex flex-col gap-3">
+            {visibleItems.map((item) => (
+              <TackleItemCard key={item.id} item={item} onToggleFavorite={toggleFavorite} />
+            ))}
+          </div>
+        ) : (
+          <div className="mt-5 rounded-lg border border-hairline bg-surface p-6">
+            <h3 className="text-h3">Your box is ready when you are.</h3>
+            <p className="mt-2 text-body text-text-muted">
+              Name the lures you reach for most. They’ll be ready when you set a rig.
+            </p>
+            <button
+              type="button"
+              onClick={() => setEditorOpen(true)}
+              className="mt-5 inline-flex min-h-touch-floor items-center justify-center rounded-md bg-signal-orange px-4 text-label text-ink-on-orange focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring active:scale-95"
+            >
+              Add your first lure
+            </button>
+          </div>
+        )}
+
+        {items.length > 0 && visibleItems.length === 0 ? (
+          <div className="mt-5 rounded-lg border border-hairline bg-surface p-6">
+            <h3 className="text-h3">Nothing matches that view.</h3>
+            <p className="mt-2 text-body text-text-muted">
+              Try a different water filter or clear your search to see this session’s tackle.
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                setFilter("all");
+                setQuery("");
+              }}
+              className="mt-5 inline-flex min-h-touch-floor items-center justify-center rounded-md border border-border-interactive px-4 text-label text-text-link focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring active:scale-95"
+            >
+              Clear filters
+            </button>
+          </div>
+        ) : null}
+      </section>
+
+      <TackleEditorSheet open={editorOpen} onClose={() => setEditorOpen(false)} onCreate={createItem} />
+    </section>
+  );
+}

--- a/src/features/tackle/components/tackle-editor-sheet.tsx
+++ b/src/features/tackle/components/tackle-editor-sheet.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { type FormEvent, useEffect, useRef, useState } from "react";
+
+import { LURE_CLASSES, type TackleDraft, type WaterClass } from "../types";
+
+const EMPTY_DRAFT: TackleDraft = {
+  label: "",
+  lureClass: "",
+  waterClass: "both",
+  color: "",
+  sizeLabel: "",
+  isFavorite: false,
+};
+
+export function TackleEditorSheet({
+  open,
+  onClose,
+  onCreate,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onCreate: (draft: TackleDraft) => void;
+}) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const nameRef = useRef<HTMLInputElement>(null);
+  const [draft, setDraft] = useState<TackleDraft>(EMPTY_DRAFT);
+  const [submitted, setSubmitted] = useState(false);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (open && !dialog.open) {
+      dialog.showModal();
+      window.requestAnimationFrame(() => nameRef.current?.focus());
+    }
+    if (!open && dialog.open) dialog.close();
+  }, [open]);
+
+  function close() {
+    setSubmitted(false);
+    setDraft(EMPTY_DRAFT);
+    onClose();
+  }
+
+  function selectClass(lureClass: string, waterClass: WaterClass) {
+    setDraft((current) => ({ ...current, lureClass, waterClass }));
+  }
+
+  function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSubmitted(true);
+    if (!draft.label.trim() || !draft.lureClass) return;
+
+    onCreate({
+      ...draft,
+      label: draft.label.trim(),
+      color: draft.color?.trim(),
+      sizeLabel: draft.sizeLabel?.trim(),
+    });
+    close();
+  }
+
+  return (
+    <dialog
+      ref={dialogRef}
+      aria-labelledby="tackle-editor-title"
+      onCancel={(event) => {
+        event.preventDefault();
+        close();
+      }}
+      onClose={() => {
+        if (open) onClose();
+      }}
+      className="m-auto max-h-dvh w-full max-w-reading border-0 bg-transparent p-0 text-text-primary backdrop:bg-background/80"
+    >
+      <form
+        onSubmit={submit}
+        className="max-h-dvh overflow-y-auto rounded-t-xl border border-border-interactive bg-surface-raised p-4 shadow-2xl motion-reduce:transition-none"
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="text-caption font-bold tracking-station text-tide-cyan">SESSION-ONLY</p>
+            <h2 id="tackle-editor-title" className="mt-1 text-h2">Add a lure</h2>
+          </div>
+          <button
+            type="button"
+            onClick={close}
+            className="inline-flex min-h-touch-floor items-center justify-center rounded-md border border-border-interactive px-4 text-label text-text-link focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring active:scale-95"
+          >
+            Close
+          </button>
+        </div>
+
+        <p className="mt-3 text-body text-text-muted">
+          This prototype keeps changes only in this open session. Nothing syncs yet.
+        </p>
+
+        <div className="mt-6 flex flex-col gap-5">
+          <label className="flex flex-col gap-2 text-label">
+            Your lure name
+            <input
+              ref={nameRef}
+              value={draft.label}
+              onChange={(event) => setDraft((current) => ({ ...current, label: event.target.value }))}
+              aria-invalid={submitted && !draft.label.trim()}
+              aria-describedby={submitted && !draft.label.trim() ? "tackle-name-error" : undefined}
+              className="min-h-touch-floor rounded-md border border-border-interactive bg-background px-4 text-body text-text-primary focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+            />
+            {submitted && !draft.label.trim() ? (
+              <span id="tackle-name-error" className="text-caption text-error-red">
+                Give this lure a name.
+              </span>
+            ) : null}
+          </label>
+
+          <fieldset className="flex flex-col gap-3">
+            <legend className="text-label">Lure class</legend>
+            <div className="flex flex-wrap gap-3" role="group" aria-label="Lure class">
+              {LURE_CLASSES.slice(0, 7).map((option) => {
+                const selected = draft.lureClass === option.label;
+                return (
+                  <button
+                    key={option.label}
+                    type="button"
+                    aria-pressed={selected}
+                    onClick={() => selectClass(option.label, option.waterClass)}
+                    className={`min-h-touch-floor rounded-full border px-4 text-label focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring active:scale-95 ${
+                      selected
+                        ? "border-signal-orange bg-signal-orange text-ink-on-orange"
+                        : "border-border-interactive text-text-link"
+                    }`}
+                  >
+                    {option.label}
+                  </button>
+                );
+              })}
+            </div>
+            <label className="flex flex-col gap-2 text-label">
+              Or choose another class
+              <select
+                value={draft.lureClass}
+                onChange={(event) => {
+                  const option = LURE_CLASSES.find((candidate) => candidate.label === event.target.value);
+                  selectClass(option?.label ?? "", option?.waterClass ?? "both");
+                }}
+                aria-invalid={submitted && !draft.lureClass}
+                aria-describedby={submitted && !draft.lureClass ? "tackle-class-error" : undefined}
+                className="min-h-touch-floor rounded-md border border-border-interactive bg-background px-4 text-body text-text-primary focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+              >
+                <option value="">Choose a lure class</option>
+                {LURE_CLASSES.map((option) => (
+                  <option key={option.label} value={option.label}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            {submitted && !draft.lureClass ? (
+              <p id="tackle-class-error" className="text-caption text-error-red">
+                Choose the closest lure class.
+              </p>
+            ) : null}
+          </fieldset>
+
+          <div className="grid gap-5 sm:grid-cols-2">
+            <label className="flex flex-col gap-2 text-label">
+              Color <span className="font-normal text-text-muted">(optional)</span>
+              <input
+                value={draft.color}
+                onChange={(event) => setDraft((current) => ({ ...current, color: event.target.value }))}
+                className="min-h-touch-floor rounded-md border border-border-interactive bg-background px-4 text-body text-text-primary focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+              />
+            </label>
+            <label className="flex flex-col gap-2 text-label">
+              Size <span className="font-normal text-text-muted">(optional)</span>
+              <input
+                value={draft.sizeLabel}
+                onChange={(event) => setDraft((current) => ({ ...current, sizeLabel: event.target.value }))}
+                className="min-h-touch-floor rounded-md border border-border-interactive bg-background px-4 text-body text-text-primary focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+              />
+            </label>
+          </div>
+
+          <button
+            type="button"
+            aria-pressed={draft.isFavorite}
+            onClick={() => setDraft((current) => ({ ...current, isFavorite: !current.isFavorite }))}
+            className={`min-h-touch-floor rounded-md border px-4 text-label focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring active:scale-95 ${
+              draft.isFavorite
+                ? "border-signal-orange bg-signal-orange text-ink-on-orange"
+                : "border-border-interactive text-text-link"
+            }`}
+          >
+            {draft.isFavorite ? "Favorite for quick rigging" : "Save as a favorite"}
+          </button>
+        </div>
+
+        <button
+          type="submit"
+          className="mt-8 flex min-h-touch-primary-standard w-full items-center justify-center rounded-md bg-signal-orange px-6 text-label text-ink-on-orange transition-colors hover:bg-signal-orange-pressed focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring active:scale-95 motion-reduce:transition-none"
+        >
+          Add lure to this session
+        </button>
+      </form>
+    </dialog>
+  );
+}

--- a/src/features/tackle/components/tackle-item-card.tsx
+++ b/src/features/tackle/components/tackle-item-card.tsx
@@ -1,0 +1,39 @@
+import type { TackleItem } from "../types";
+
+export function TackleItemCard({
+  item,
+  compact = false,
+  onToggleFavorite,
+}: {
+  item: TackleItem;
+  compact?: boolean;
+  onToggleFavorite: (id: string) => void;
+}) {
+  const metadata = [item.color, item.sizeLabel].filter(Boolean).join(" · ");
+
+  return (
+    <article
+      className={`flex border border-hairline bg-surface ${
+        compact ? "min-w-64 flex-col gap-3 rounded-lg p-4" : "items-start gap-3 rounded-lg p-4"
+      }`}
+    >
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-h3">{item.label}</p>
+        <p className="mt-1 text-caption text-text-link">{item.lureClass}</p>
+        {metadata ? <p className="mt-2 text-caption text-text-muted">{metadata}</p> : null}
+      </div>
+      <button
+        type="button"
+        aria-pressed={item.isFavorite}
+        onClick={() => onToggleFavorite(item.id)}
+        className={`inline-flex min-h-touch-floor shrink-0 items-center justify-center rounded-full border px-4 text-label transition-colors focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring active:scale-95 motion-reduce:transition-none ${
+          item.isFavorite
+            ? "border-signal-orange bg-signal-orange text-ink-on-orange"
+            : "border-border-interactive bg-surface-raised text-text-link"
+        }`}
+      >
+        {item.isFavorite ? "Favorite" : "Save favorite"}
+      </button>
+    </article>
+  );
+}

--- a/src/features/tackle/tackle-filter.test.ts
+++ b/src/features/tackle/tackle-filter.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { TACKLE_FIXTURE } from "./tackle-fixture";
+import { itemMatchesFilter } from "./types";
+
+describe("itemMatchesFilter", () => {
+  it("keeps all-water items in a saltwater view", () => {
+    const names = TACKLE_FIXTURE.filter((item) => itemMatchesFilter(item, "salt", "")).map(
+      (item) => item.label,
+    );
+
+    expect(names).toContain("White paddle tail");
+    expect(names).not.toContain("Willow spinnerbait");
+  });
+
+  it("finds an optional attribute without relaxing the water filter", () => {
+    expect(itemMatchesFilter(TACKLE_FIXTURE[0], "salt", "silver")).toBe(true);
+    expect(itemMatchesFilter(TACKLE_FIXTURE[4], "salt", "gold")).toBe(false);
+  });
+});

--- a/src/features/tackle/tackle-fixture.ts
+++ b/src/features/tackle/tackle-fixture.ts
@@ -1,0 +1,53 @@
+import type { TackleItem } from "./types";
+
+/**
+ * Deliberately local sample data for the web prototype. This is not a user's tackle,
+ * is not written to storage, and is replaced by the offline query layer when that lane lands.
+ */
+export const TACKLE_FIXTURE: readonly TackleItem[] = [
+  {
+    id: "fixture-sabiki",
+    label: "Blue flash sabiki",
+    lureClass: "Sabiki",
+    waterClass: "salt",
+    color: "Blue / silver",
+    sizeLabel: "Size 6",
+    isFavorite: true,
+  },
+  {
+    id: "fixture-swimbait",
+    label: "White paddle tail",
+    lureClass: "Swimbait (soft plastic)",
+    waterClass: "both",
+    color: "Pearl white",
+    sizeLabel: "4 in",
+    isFavorite: true,
+  },
+  {
+    id: "fixture-bucktail",
+    label: "Chartreuse bucktail",
+    lureClass: "Bucktail jig",
+    waterClass: "both",
+    color: "Chartreuse",
+    sizeLabel: "1 oz",
+    isFavorite: false,
+  },
+  {
+    id: "fixture-iron",
+    label: "Mint surface iron",
+    lureClass: "Surface iron",
+    waterClass: "salt",
+    color: "Mint / chrome",
+    sizeLabel: "7 in",
+    isFavorite: false,
+  },
+  {
+    id: "fixture-spinnerbait",
+    label: "Willow spinnerbait",
+    lureClass: "Spinnerbait",
+    waterClass: "fresh",
+    color: "White / gold",
+    sizeLabel: "3/8 oz",
+    isFavorite: false,
+  },
+];

--- a/src/features/tackle/types.ts
+++ b/src/features/tackle/types.ts
@@ -1,0 +1,53 @@
+export type WaterClass = "salt" | "fresh" | "both";
+
+export type TackleFilter = "all" | "salt" | "fresh";
+
+export type TackleItem = {
+  id: string;
+  label: string;
+  lureClass: string;
+  waterClass: WaterClass;
+  color?: string;
+  sizeLabel?: string;
+  isFavorite: boolean;
+};
+
+export type TackleDraft = Omit<TackleItem, "id">;
+
+export const FILTER_LABELS: Record<TackleFilter, string> = {
+  all: "All",
+  salt: "Salt",
+  fresh: "Fresh",
+};
+
+export const LURE_CLASSES = [
+  { label: "Swimbait (soft plastic)", waterClass: "both" },
+  { label: "Plastic grub", waterClass: "both" },
+  { label: "Plastic worm", waterClass: "fresh" },
+  { label: "Jerkbait (hard)", waterClass: "both" },
+  { label: "Crankbait", waterClass: "both" },
+  { label: "Topwater walker", waterClass: "both" },
+  { label: "Popper", waterClass: "both" },
+  { label: "Surface iron", waterClass: "salt" },
+  { label: "Yo-yo iron", waterClass: "salt" },
+  { label: "Lead-head jig", waterClass: "both" },
+  { label: "Bucktail jig", waterClass: "both" },
+  { label: "Spoon", waterClass: "both" },
+  { label: "Sabiki", waterClass: "salt" },
+  { label: "Fly", waterClass: "both" },
+  { label: "Trolled plug", waterClass: "salt" },
+  { label: "Spinnerbait", waterClass: "fresh" },
+  { label: "Carolina rig", waterClass: "fresh" },
+  { label: "Dropper loop rig", waterClass: "salt" },
+] as const satisfies ReadonlyArray<{ label: string; waterClass: WaterClass }>;
+
+export function itemMatchesFilter(item: TackleItem, filter: TackleFilter, query: string): boolean {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  const matchesWater = filter === "all" || item.waterClass === "both" || item.waterClass === filter;
+  const searchText = [item.label, item.lureClass, item.color, item.sizeLabel]
+    .filter(Boolean)
+    .join(" ")
+    .toLocaleLowerCase();
+
+  return matchesWater && searchText.includes(normalizedQuery);
+}


### PR DESCRIPTION
## Summary

- adds a phone-first Tackle Box at `/tackle` with an entry from Settings
- adds Favorites, labeled search, All/Salt/Fresh filters, and polished lure cards
- adds an accessible Add Lure dialog with validation, the full lure-class vocabulary, optional color/size, and favorite state
- clearly identifies fixture-backed additions as session-only rather than implying cloud persistence
- documents the interaction model, accessibility decisions, and future persistence boundary

## Verification

- `npm run verify` — passed (14 test files, 111 tests)
- `npm run build -- --webpack` — passed
- exact 320px Chrome QA — no page overflow or visible target below 48px
- add-lure dialog focus and mobile width checked with no browser errors

## Scope boundary

This PR does not change the bottom navigation, Supabase schema, offline sync, rigs, or catches. Permanent local/cloud persistence remains a separate data-layer follow-up.

The moon/calendar and distinct sunrise/sunset tide-chart refinements from the same work session are already merged into `main` through commit `51e175e`; this branch starts from that updated base.
