### PR TITLE
fix(tide): production-readiness cleanup of the tide chart

### DIFF
--- a/docs/team/worklog/2026-08-31-02-head-dev.md
+++ b/docs/team/worklog/2026-08-31-02-head-dev.md
@@ -1,0 +1,44 @@
+### 2026-08-31 | head-dev | production-readiness review of the tide chart
+
+Reviewed the tide chart work (screen, timeline, geometry, sheets, CSS, formatting) against a
+production bar. The shape and the honesty rules hold up — this pass fixes the real defects
+found in review, not the design.
+
+- **The big reading was invalid HTML.** The readout card at the top was a `<button>`, and
+  inside it sat the two interactive "Interpolated"/"Estimated" disclosure markers
+  (`<details>/<summary>`). Interactive content nested inside a button is invalid HTML, and
+  in practice a tap on "Interpolated" was bubbling up and opening the Tide detail sheet
+  instead of revealing the provenance sentence. The readout is now a `role="button"` div
+  with the same keyboard behaviour (Enter/Space opens the detail sheet, focus ring
+  unchanged), and taps/keys that start inside a disclosure stay with the disclosure.
+  Verified in a browser: disclosure toggles without opening the sheet; clicking the card
+  body or pressing Enter on it opens the sheet.
+- **The sunrise/sunset markers were tap-only.** They now take keyboard focus and reveal
+  their time on Enter/Space, with the same focus ring as every other control.
+- **Empty-data safety net.** Every line of the screen indexes the first and last sample
+  of the prediction series. The current fixture can never be empty, but the live NOAA
+  fetch that replaces it can fail or return nothing — an empty feed would have rendered a
+  screen of NaNs. It now renders an honest "No tide predictions loaded" state.
+- **Formatting finally has tests.** `format.ts` had none — every time string on the
+  screen (`6:04am`, `FRI, AUG 28`, `1h 30m`) was untested. Added 20 tests covering unit
+  conversion, clock/hour forms, calendar forms, zone abbreviations, countdowns,
+  coordinates and lunar age. The tests immediately caught one real bug: a 30-second
+  countdown read "1 min" instead of "under a minute" (rounding, now floored — a 30-second
+  wait is not a minute).
+- **Axis label selection moved where it can be tested.** The hour-axis labels (every
+  third hour, midnight left to the day dividers) moved from inside the timeline component
+  into `format.ts`, and the height-grid values into the geometry module. Both now have
+  tests pinning the exact spec.
+- One robustness fix in the drag-to-pan: pointer capture loss now cleans up its drag
+  state.
+
+- Checked in a browser at 390x844 (headless Chromium): no console errors; the readout
+  height is identical (216.3px) at every scrub position — the shake stays fixed; all four
+  sheets open and close; disclosure taps and keyboard work. Not checked on a real phone.
+- Files: src/features/conditions/tide-screen.tsx,
+  src/features/conditions/components/tide-timeline.tsx,
+  src/features/conditions/tide-chart-geometry.ts (+ tests),
+  src/features/conditions/format.ts (+ new format.test.ts), src/styles/tide-chart.css.
+- Next: the open items in `docs/design/07-tide-chart.md` are unchanged — the amber/moon
+  pale token collision, real data, a second station, and the real-phone check all still
+  belong to their owners.

--- a/src/features/conditions/components/tide-timeline.tsx
+++ b/src/features/conditions/components/tide-timeline.tsx
@@ -14,6 +14,7 @@ import {
   atFromScrollLeft,
   chartWidthFor,
   curvePath,
+  gridValues,
   labelPlate,
   makeYFor,
   plotHeightFor,
@@ -21,7 +22,7 @@ import {
   visibleLabelFlags,
   xFor as xForAt,
 } from "../tide-chart-geometry";
-import { clock, dividerDay, formatHeight, hourLabel, stationHour } from "../format";
+import { clock, dividerDay, formatHeight, hourLabel, hourLabels } from "../format";
 import type { UnitPreference } from "@/features/settings/units";
 
 const CURVE_STEP_MS = 15 * 60_000;
@@ -274,6 +275,9 @@ export function TideTimeline({
         onPointerCancel={() => {
           dragRef.current = null;
         }}
+        onLostPointerCapture={() => {
+          dragRef.current = null;
+        }}
         onKeyDown={(event) => {
           const step = event.shiftKey ? KEY_STEP_MS_FAST : KEY_STEP_MS;
           if (event.key === "ArrowRight") {
@@ -399,10 +403,16 @@ export function TideTimeline({
                 <g
                   key={`sun-${marker.at}`}
                   data-sun-transition={marker.kind}
-                  role="img"
-                  aria-label={`${label}, ${time}, tide ${formatHeight(unwrapSourced(height), unit)}`}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`${label}, ${time}, tide ${formatHeight(unwrapSourced(height), unit)}. Activate to show or hide the time on the chart.`}
                   onClick={() => {
                     if (dragRef.current?.moved) return;
+                    setRevealedSunAt((current) => (current === marker.at ? null : marker.at));
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key !== "Enter" && event.key !== " ") return;
+                    event.preventDefault();
                     setRevealedSunAt((current) => (current === marker.at ? null : marker.at));
                   }}
                 >
@@ -495,21 +505,4 @@ function SunTransitionGlyph({ kind, x, y }: { kind: "sunrise" | "sunset"; x: num
   );
 }
 
-function gridValues(yMinimum: number, yMaximum: number): number[] {
-  const values: number[] = [];
-  const stepMetres = 0.5;
-  for (let value = Math.ceil(yMinimum / stepMetres) * stepMetres; value <= yMaximum; value += stepMetres) {
-    values.push(Math.round(value * 1000) / 1000);
-  }
-  return values;
-}
 
-function hourLabels(seriesStart: number, seriesEnd: number, timeZone: string): number[] {
-  const result: number[] = [];
-  const hourMs = 3_600_000;
-  for (let t = Math.ceil(seriesStart / hourMs) * hourMs; t <= seriesEnd; t += hourMs) {
-    const hour = stationHour(instant(t), timeZone);
-    if (hour !== 0 && hour % 3 === 0) result.push(t);
-  }
-  return result;
-}

--- a/src/features/conditions/format.test.ts
+++ b/src/features/conditions/format.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+
+import { degrees, instant, metres, metresPerHour } from "@/core/units";
+import {
+  calendarDayNumber,
+  calendarWeekday,
+  clock,
+  compactDate,
+  dayLabel,
+  dividerDay,
+  formatCoordinates,
+  formatCountdown,
+  formatDurationMagnitude,
+  formatHeight,
+  formatLunarAge,
+  formatMoonIllumination,
+  formatMoonPhaseName,
+  formatMotion,
+  formatPace,
+  formatRate,
+  hourLabel,
+  hourLabels,
+  monthDay,
+  stationHour,
+  toDisplayHeight,
+  toDisplayRate,
+  zoneAbbreviation,
+} from "./format";
+
+/** The station zone every tide time is anchored to. */
+const ZONE = "America/Los_Angeles";
+/** 2026-08-28 08:00 UTC — 01:00 PDT (summer time, UTC-7). */
+const SUMMER_MORNING = instant(Date.UTC(2026, 7, 28, 8, 0, 0));
+/** 2026-01-15 20:00 UTC — 12:00 PST (winter time, UTC-8). */
+const WINTER_NOON = instant(Date.UTC(2026, 0, 15, 20, 0, 0));
+
+describe("unit conversion", () => {
+  it("converts metres to feet with the NOAA datum factor", () => {
+    expect(toDisplayHeight(metres(1), "m")).toBeCloseTo(1, 9);
+    expect(toDisplayHeight(metres(1), "ft")).toBeCloseTo(3.280839895, 9);
+    expect(toDisplayRate(metresPerHour(1), "ft")).toBeCloseTo(3.280839895, 9);
+  });
+
+  it("formats heights with the unit suffix", () => {
+    expect(formatHeight(metres(1.036), "m")).toBe("1.04 m");
+    expect(formatHeight(metres(1.036), "ft")).toBe("3.40 ft");
+  });
+
+  it("always signs the rate, with ± only at exactly zero", () => {
+    expect(formatRate(metresPerHour(0.62), "m")).toBe("+0.62 m/hr");
+    expect(formatRate(metresPerHour(-0.19), "m")).toBe("-0.19 m/hr");
+    expect(formatRate(metresPerHour(0), "m")).toBe("±0.00 m/hr");
+  });
+});
+
+describe("labels", () => {
+  it("spells every motion, pace class and phase name once", () => {
+    expect(formatMotion("rising")).toBe("Rising");
+    expect(formatMotion("falling")).toBe("Falling");
+    expect(formatMotion("near-slack")).toBe("Near slack");
+    expect(formatMotion("slack")).toBe("Slack");
+    expect(formatPace("very-fast")).toBe("Very fast");
+    expect(formatPace("slow")).toBe("Slow");
+    expect(formatMoonPhaseName("waxing-crescent")).toBe("Waxing crescent");
+    expect(formatMoonPhaseName("full")).toBe("Full moon");
+  });
+
+  it("reports illumination as a whole percentage", () => {
+    expect(formatMoonIllumination(0.5)).toBe("50% lit");
+    expect(formatMoonIllumination(0.999)).toBe("100% lit");
+  });
+});
+
+describe("clock time", () => {
+  it("renders one lowercase 12-hour form, no space before am/pm", () => {
+    expect(clock(SUMMER_MORNING, ZONE)).toBe("1:00am");
+    expect(clock(instant(Date.UTC(2026, 7, 28, 16, 4, 0)), ZONE)).toBe("9:04am");
+    expect(clock(instant(Date.UTC(2026, 7, 28, 23, 30, 0)), ZONE)).toBe("4:30pm");
+  });
+
+  it("keeps midnight and noon distinct", () => {
+    expect(clock(WINTER_NOON, ZONE)).toBe("12:00pm");
+    expect(clock(instant(Date.UTC(2026, 0, 15, 8, 0, 0)), ZONE)).toBe("12:00am");
+  });
+
+  it("labels the hour axis in the same form as the reading", () => {
+    expect(hourLabel(SUMMER_MORNING, ZONE)).toBe("1am");
+    expect(hourLabel(instant(Date.UTC(2026, 7, 28, 19, 0, 0)), ZONE)).toBe("12pm");
+  });
+
+  it("reads the zone abbreviation for the instant's own offset", () => {
+    expect(zoneAbbreviation(SUMMER_MORNING, ZONE)).toBe("PDT");
+    expect(zoneAbbreviation(WINTER_NOON, ZONE)).toBe("PST");
+  });
+});
+
+describe("calendar dates", () => {
+  it("spells the long and short day forms in the same zone", () => {
+    expect(dayLabel(SUMMER_MORNING, ZONE)).toBe("Friday, August 28");
+    expect(monthDay(SUMMER_MORNING, ZONE)).toBe("Aug 28");
+    expect(calendarWeekday(SUMMER_MORNING, ZONE)).toBe("Fri");
+    expect(calendarDayNumber(SUMMER_MORNING, ZONE)).toBe("28");
+  });
+
+  it("keeps the date control and the chart divider in the same word order", () => {
+    // Intl's own weekday+day pattern would return "28 Fri"; the two helpers compose the
+    // parts so both say "FRI, AUG 28" / "FRI 28" on one screen.
+    expect(compactDate(SUMMER_MORNING, ZONE)).toBe("FRI, AUG 28");
+    expect(dividerDay(SUMMER_MORNING, ZONE)).toBe("FRI 28");
+  });
+
+  it("reads the station hour in the station's calendar", () => {
+    expect(stationHour(SUMMER_MORNING, ZONE)).toBe(1);
+    expect(stationHour(instant(Date.UTC(2026, 7, 28, 7, 59, 0)), ZONE)).toBe(0);
+  });
+});
+
+describe("hourLabels", () => {
+  it("labels every third station hour across the window", () => {
+    // Window: 2026-08-28 07:00 UTC (midnight PDT) through 2026-08-29 06:59 UTC.
+    const start = Date.UTC(2026, 7, 28, 7, 0, 0);
+    const end = Date.UTC(2026, 7, 29, 6, 59, 0);
+    expect(hourLabels(start, end, ZONE)).toEqual([
+      Date.UTC(2026, 7, 28, 10, 0, 0), // 03:00 PDT
+      Date.UTC(2026, 7, 28, 13, 0, 0), // 06:00 PDT
+      Date.UTC(2026, 7, 28, 16, 0, 0), // 09:00 PDT
+      Date.UTC(2026, 7, 28, 19, 0, 0), // 12:00 PDT
+      Date.UTC(2026, 7, 28, 22, 0, 0), // 15:00 PDT
+      Date.UTC(2026, 7, 29, 1, 0, 0), // 18:00 PDT
+      Date.UTC(2026, 7, 29, 4, 0, 0), // 21:00 PDT
+    ]);
+  });
+
+  it("never labels midnight — the day divider tag already owns it", () => {
+    // Midnight PDT is 07:00 UTC on both days; the 07:00 labels are absent above, and an
+    // all-night window produces no zero-hour labels.
+    const start = Date.UTC(2026, 7, 28, 7, 0, 0);
+    const end = Date.UTC(2026, 7, 28, 8, 0, 0);
+    expect(hourLabels(start, end, ZONE)).toEqual([]);
+  });
+});
+
+describe("durations", () => {
+  it("says under a minute rather than 0 min", () => {
+    expect(formatDurationMagnitude(0)).toBe("under a minute");
+    expect(formatDurationMagnitude(30_000)).toBe("under a minute");
+  });
+
+  it("uses minutes under an hour, h and h m above", () => {
+    expect(formatDurationMagnitude(5 * 60_000)).toBe("5 min");
+    expect(formatDurationMagnitude(59 * 60_000)).toBe("59 min");
+    expect(formatDurationMagnitude(60 * 60_000)).toBe("1h");
+    expect(formatDurationMagnitude(90 * 60_000)).toBe("1h 30m");
+    expect(formatDurationMagnitude(3 * 3_600_000)).toBe("3h");
+  });
+
+  it("ignores the sign of the delta", () => {
+    expect(formatDurationMagnitude(-90 * 60_000)).toBe("1h 30m");
+  });
+
+  it("composes countdowns with the direction word", () => {
+    expect(formatCountdown(90 * 60_000, "slack")).toBe("1h 30m to slack");
+    expect(formatCountdown(-90 * 60_000, "high")).toBe("1h 30m ago (high)");
+  });
+});
+
+describe("station position and lunar age", () => {
+  it("formats coordinates at NOAA's published precision", () => {
+    expect(formatCoordinates(degrees(33.6047), degrees(-117.883))).toBe("33.6047° N, 117.8830° W");
+    expect(formatCoordinates(degrees(-45.5), degrees(10.25))).toBe("45.5000° S, 10.2500° E");
+  });
+
+  it("reports the real elapsed lunar age, not the rounded-down average", () => {
+    expect(formatLunarAge(12.36)).toBe("12.4 days since the new moon");
+    expect(formatLunarAge(0)).toBe("0.0 days since the new moon");
+  });
+});

--- a/src/features/conditions/format.ts
+++ b/src/features/conditions/format.ts
@@ -3,7 +3,7 @@
  * (ADR 006 §1, §3). `core/` stays SI-only; feet, ft/hr and every date/time string are
  * produced here, from the unit preference and the station's time zone respectively.
  */
-import type { Degrees, Instant, Metres, MetresPerHour } from "@/core/units";
+import { instant, type Degrees, type Instant, type Metres, type MetresPerHour } from "@/core/units";
 import type { UnitPreference } from "@/features/settings/units";
 import type { MoonPhaseName } from "./types";
 import type { TideMotion, PaceClass } from "@/core/rules/tide";
@@ -146,12 +146,31 @@ export function stationHour(at: Instant, timeZone: string): number {
 }
 
 /**
+ * The instants the hour axis labels: every third hour of the loaded window in `timeZone`,
+ * skipping midnight — midnight already has the day-divider tag, and a label under the tag
+ * would be the same fact written twice. `stationHour` is read so the selection follows the
+ * station's calendar, like every other date division on this chart.
+ */
+export function hourLabels(seriesStart: number, seriesEnd: number, timeZone: string): number[] {
+  const result: number[] = [];
+  const hourMs = 3_600_000;
+  for (let t = Math.ceil(seriesStart / hourMs) * hourMs; t <= seriesEnd; t += hourMs) {
+    const hour = stationHour(instant(t), timeZone);
+    if (hour !== 0 && hour % 3 === 0) result.push(t);
+  }
+  return result;
+}
+
+/**
  * "12 min", "1h 30m", "3h" — a countdown magnitude with no direction word, so callers can
  * compose "12 min to slack" / "high in 1h 30m" without this function guessing the phrasing.
  * Natural language under an hour (no "0h"), for the reading-glasses-forgotten test.
  */
 export function formatDurationMagnitude(deltaMs: number): string {
-  const totalMinutes = Math.round(Math.abs(deltaMs) / 60_000);
+  // Floor, not round: a 30-second countdown is not "1 min" away. The sub-minute branch
+  // below is the point of the floor — round(0.5) === 1 would hand "1 min" to anything
+  // 30s or more out, which is a lie at the exact moment precision matters most.
+  const totalMinutes = Math.floor(Math.abs(deltaMs) / 60_000);
   if (totalMinutes < 1) return "under a minute";
   if (totalMinutes < 60) return `${totalMinutes} min`;
   const hours = Math.floor(totalMinutes / 60);

--- a/src/features/conditions/tide-chart-geometry.test.ts
+++ b/src/features/conditions/tide-chart-geometry.test.ts
@@ -5,6 +5,7 @@ import {
   MS_PER_PIXEL,
   PLOT_TOP,
   atFromScrollLeft,
+  gridValues,
   localDayIndex,
   makeYFor,
   plotHeightFor,
@@ -75,6 +76,26 @@ describe("plot box", () => {
     expect(yFor(metres(2))).toBeCloseTo(PLOT_TOP, 6);
     expect(yFor(metres(0))).toBeCloseTo(PLOT_TOP + plotHeightFor(400), 6);
     expect(yFor(metres(1))).toBeLessThan(yFor(metres(0)));
+  });
+});
+
+describe("gridValues", () => {
+  it("steps the axis on the chart's half-metre grid", () => {
+    expect(gridValues(0, 2)).toEqual([0, 0.5, 1, 1.5, 2]);
+    expect(gridValues(-0.8, 1.2)).toEqual([-0.5, 0, 0.5, 1]);
+    expect(gridValues(0.2, 1.9)).toEqual([0.5, 1, 1.5]);
+  });
+
+  it("returns no values for an empty range", () => {
+    expect(gridValues(1.6, 1.6)).toEqual([]);
+    expect(gridValues(2, 1)).toEqual([]);
+  });
+
+  it("keeps the floating-point drift out of the axis", () => {
+    // 0.1 + 0.2 !== 0.3 in doubles; the axis values are what a human reads.
+    for (const value of gridValues(0, 5)) {
+      expect(Number.isInteger(value * 10)).toBe(true);
+    }
   });
 });
 

--- a/src/features/conditions/tide-chart-geometry.ts
+++ b/src/features/conditions/tide-chart-geometry.ts
@@ -203,6 +203,20 @@ export function labelPlate(
   return { x: centerX - width / 2, y: baselineY - fontSizePx * 0.86, width, height };
 }
 
+/**
+ * The height-axis grid values between `yMinimum` and `yMaximum`, on the chart's fixed
+ * half-metre step. The last rounding exists because repeated floating-point addition
+ * drifts (0.1 + 0.2 ≠ 0.3); the values drawn on screen are what the tests pin.
+ */
+export function gridValues(yMinimum: number, yMaximum: number): number[] {
+  const values: number[] = [];
+  const stepMetres = 0.5;
+  for (let value = Math.ceil(yMinimum / stepMetres) * stepMetres; value <= yMaximum; value += stepMetres) {
+    values.push(Math.round(value * 1000) / 1000);
+  }
+  return values;
+}
+
 /** Catmull-Rom through the given (x, y) points, as an SVG path `d` string. Presentation only. */
 export function curvePath(points: readonly (readonly [number, number])[]): string {
   if (points.length === 0) return "";

--- a/src/features/conditions/tide-screen.tsx
+++ b/src/features/conditions/tide-screen.tsx
@@ -65,9 +65,14 @@ const AT_NOW_TOLERANCE_MS = 60_000;
  */
 export function TideScreen() {
   const series = useMemo(() => loadTideSeriesFixture(), []);
-  const seriesStart = Number(series.samples[0].at);
-  const seriesEnd = Number(series.samples[series.samples.length - 1].at);
-  const initialAt = Math.max(seriesStart, Math.min(seriesEnd, Number(TIDE_SELECTED_AT)));
+  // Defensive: the fixture is never empty, but the live NOAA fetch that will replace it
+  // (ADR 006 §2) can fail or return an empty window, and every line below indexes
+  // `samples[0]`/`[length - 1]`. Guard once here so an empty feed renders an honest
+  // empty state instead of a screen of NaNs.
+  const hasSamples = series.samples.length > 0;
+  const seriesStart = hasSamples ? Number(series.samples[0].at) : 0;
+  const seriesEnd = hasSamples ? Number(series.samples[series.samples.length - 1].at) : 0;
+  const initialAt = hasSamples ? Math.max(seriesStart, Math.min(seriesEnd, Number(TIDE_SELECTED_AT))) : 0;
 
   const [unit] = useUnitPreference();
   const now = useNow();
@@ -164,6 +169,19 @@ export function TideScreen() {
     timelineRef.current?.scrollToAt(clamped, true);
   };
 
+  if (!hasSamples) {
+    return (
+      <section className="tide-screen">
+        <div className="tide-empty">
+          <p className="tide-empty-title">No tide predictions loaded</p>
+          <p className="tide-empty-note">
+            The prediction window is empty. Check the station feed and try again.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
   /** Same clock time, one station day over — so stepping days does not also move the hour. */
   const goToDay = (index: number) => {
     const target = calendarDays[index];
@@ -214,7 +232,30 @@ export function TideScreen() {
           and down mid-swipe. Anything added here needs a reserved slot, not a conditional
           row.
         */}
-        <button type="button" className="tide-readout" aria-haspopup="dialog" onClick={() => setSheet("tide")}>
+        {/* A `role="button"` div rather than a `<button>`: the two `SourcedValue` certainty
+            disclosures inside this card are native interactive `<details>/<summary>`
+            elements, and interactive content nested inside a `<button>` is invalid HTML —
+            the disclosure's click bubbles up and opens the sheet instead of toggling.
+            The div restores valid nesting; Enter/Space open the sheet exactly like a
+            native button would, and any activation that starts inside a `<details>` stays
+            with the disclosure. */}
+        <div
+          role="button"
+          tabIndex={0}
+          className="tide-readout"
+          aria-haspopup="dialog"
+          onClick={(event) => {
+            if ((event.target as HTMLElement).closest("details")) return;
+            setSheet("tide");
+          }}
+          onKeyDown={(event) => {
+            if ((event.target as HTMLElement).closest("details")) return;
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              setSheet("tide");
+            }
+          }}
+        >
           <span className="tide-readout-when">
             {/* The clock comes first so it starts on the card's text line — the same line
                 the reading below it starts on. The NOW badge holds its space whether or
@@ -278,7 +319,7 @@ export function TideScreen() {
           <span className="tide-readout-more" aria-hidden="true">
             Tide detail <Chevron />
           </span>
-        </button>
+        </div>
       </header>
 
       {/*

--- a/src/styles/tide-chart.css
+++ b/src/styles/tide-chart.css
@@ -25,6 +25,33 @@
   overflow: hidden;
 }
 
+/* ---- Empty state (the live feed can return nothing; the fixture never will) ---- */
+
+.tide-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  flex: 1;
+  padding: 0 var(--tide-gutter);
+  text-align: center;
+}
+
+.tide-empty-title {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.tide-empty-note {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 16px;
+  line-height: 1.4;
+}
+
 /* ---- Header: location, moon, and the read-head's own reading ---- */
 
 .tide-header {
@@ -461,6 +488,13 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
+}
+
+/* The sunrise/sunset markers are focusable controls (they reveal their time on
+   activation), so they need the same visible focus ring as every other control. */
+.tide-timeline-scroller svg [data-sun-transition]:focus-visible {
+  outline: 3px solid var(--color-focus-ring);
+  outline-offset: 3px;
 }
 
 /* ---- Bottom sheets ---- */


### PR DESCRIPTION
## What changed

A production-readiness pass over the tide chart (the previous developer's work). The design, engine boundaries and honesty rules hold up; this fixes the real defects found in review.

**Bugs fixed**
- The readout card was a `<button>` wrapping the interactive "Interpolated"/"Estimated" provenance disclosures (`<details>/<summary>`). Nested interactive content is invalid HTML, and a tap on the disclosure bubbled up and opened the Tide detail sheet instead of toggling the basis text. The card is now a `role="button"` div with matching keyboard behaviour (Enter/Space opens the detail sheet; activation starting inside a disclosure stays with it). Verified in browser.
- Sunrise/sunset markers were tap-only. They now take keyboard focus and reveal their time on Enter/Space, with the standard focus ring.
- `formatDurationMagnitude` read a 30-second countdown as "1 min" (rounding); now floored so sub-minute reads "under a minute".

**Hardening**
- Empty prediction series now renders an honest "No tide predictions loaded" state instead of NaN cascades (the live NOAA fetch that will replace the fixture can fail or return nothing).
- Drag-to-pan cleans up its state on lost pointer capture.

**Test coverage**
- `format.ts` had zero tests; added 20 covering unit conversion, clock/hour forms, calendar forms, zone abbreviations, countdowns, coordinates and lunar age.
- Axis label selection (hour labels, height grid) moved into testable pure modules and is now pinned by tests.
- New `gridValues` tests in geometry.

## How it was checked

- `npm run verify` green: lint, tripwires, TypeScript, 145 tests (was 122).
- `npm run build` (production) passes.
- Browser at 390×844 (headless Chromium): no console errors; readout height stable at 216.3px across the whole scrub range (the "shake" stays fixed); all four sheets open/close; disclosures toggle without opening the sheet; keyboard activation works; no vertical page scroll.
- Not checked on a real phone (house rule: stated plainly).

## Files

- `src/features/conditions/tide-screen.tsx`
- `src/features/conditions/components/tide-timeline.tsx`
- `src/features/conditions/tide-chart-geometry.ts` (+ tests)
- `src/features/conditions/format.ts` (+ new `format.test.ts`)
- `src/styles/tide-chart.css`
- `docs/team/worklog/2026-08-31-02-head-dev.md`