### PR TITLE
feat(tackle): category pages — categories navigate, ready-to-rig rail removed

### DIFF
--- a/docs/design/08-tackle-box.md
+++ b/docs/design/08-tackle-box.md
@@ -55,6 +55,26 @@ the session-only boundary:
 The old All/Salt/Fresh water filter was removed: `waterClass` described lure *classes*,
 not an inventory of every gear type, and categories + search carry the load now.
 
+## Third slice (category pages, 2026-08-31)
+
+Two owner-review changes:
+
+- **The "Ready to rig" rail is gone.** Favoriting stays (it drives the Favorites
+  view), but the duplicated strip above the list was determined to be noise.
+- **Categories navigate instead of filtering.** Each browse card is a real link to
+  `/tackle/<category>` — one prerendered page per registry entry (`generateStaticParams`,
+  `dynamicParams = false`, unknown categories 404). The category page mirrors the main
+  header anatomy (back link, icon + title, + Add gear, scoped counts) and hosts the
+  same inventory list scoped to the category; Add gear there pre-picks the category.
+
+State moved from component state to a tiny module-level session store
+(`session-store.ts`, `useSyncExternalStore`), so client-side navigation between the
+box and category pages keeps the session's edits — while a full refresh still resets
+to the fixture, exactly as the on-screen notice says. The inventory list (search,
+views, sort, cards, paging, empty states) is now one shared component used by both
+routes, and every chip/pill/primary class string lives in `ui-classes.ts` so the
+treatment cannot drift between pages.
+
 ## Consistency pass (2026-08-31)
 
 Applied the owner's alignment & visual-consistency standard to everything above:

--- a/docs/team/worklog/2026-08-31-03-ux-ui.md
+++ b/docs/team/worklog/2026-08-31-03-ux-ui.md
@@ -35,9 +35,18 @@
   a cyan box to a calm caption, one shared chip spec everywhere, fixed-width star
   Favorite pills, and Ready-to-rig rail cards made equal height on a raised surface so
   they read as a quick strip instead of a duplicate list.
-- Checked: verify suite green (tokens, tripwires, lint, types, 136 tests — 16 new for
-  tackle logic and icon coverage), production build passes, page exercised in headless
-  Chromium at phone size (see PR body). Not checked on a real phone yet.
+- Owner round 3: removed the "Ready to rig" rail from the main page, and category
+  cards now open a dedicated page per category (/tackle/hooks, /tackle/line, …) with
+  a back link, its own counts, and Add gear that pre-picks the category. Inventory
+  state moved to a small shared session store so edits survive moving between pages
+  (still resets on refresh, as the notice says). Also fixed "1 items" grammar nits.
+- This work is on its own branch/PR stacked on the category-driven inventory PR;
+  merge that one first.
+- Checked: verify suite green (tokens, tripwires, lint, types, 136 tests), production
+  build passes, 46 automated browser checks pass at phone size (add/edit/duplicate/
+  delete, search, sort, category navigation, session persistence across pages, 404
+  for unknown category, 320px wrap) plus a 14-check keyboard-only pass. Not checked
+  on a real phone yet.
 - Still session-only on purpose: nothing saves after a refresh until the offline
   store lane lands. Photos and tags are still future work per the spec.
 - Note for the next agent: this branch was cut from main before the tide-chart

--- a/src/app/(app)/tackle/[category]/page.tsx
+++ b/src/app/(app)/tackle/[category]/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { TackleCategoryView } from "@/features/tackle/components/tackle-category-view";
+import { TACKLE_CATEGORIES } from "@/features/tackle/types";
+
+// The registry is the whole URL space: one prerendered page per category, and any
+// other segment 404s (dynamicParams = false).
+export function generateStaticParams() {
+  return TACKLE_CATEGORIES.map((category) => ({ category: category.id }));
+}
+
+export const dynamicParams = false;
+
+type Params = Promise<{ category: string }>;
+
+export async function generateMetadata({ params }: { params: Params }): Promise<Metadata> {
+  const { category } = await params;
+  const spec = TACKLE_CATEGORIES.find((candidate) => candidate.id === category);
+  return {
+    title: `${spec?.label ?? "Category"} | Fish Log Book`,
+    description: "A personal, session-only tackle inventory for the Fish Log Book prototype.",
+  };
+}
+
+export default async function TackleCategoryPage({ params }: { params: Params }) {
+  const { category } = await params;
+  const spec = TACKLE_CATEGORIES.find((candidate) => candidate.id === category);
+  if (!spec) notFound();
+  return <TackleCategoryView category={spec.id} />;
+}

--- a/src/features/tackle/components/choice-field.tsx
+++ b/src/features/tackle/components/choice-field.tsx
@@ -3,11 +3,7 @@
 import { useId, useState } from "react";
 
 import { suggestedOptions, type AttributeField } from "../types";
-
-const CHIP_CLASS =
-  "min-h-touch-floor rounded-full border px-4 text-label transition-colors focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring active:scale-95 motion-reduce:transition-none";
-const CHIP_ON = "border-signal-orange bg-signal-orange text-ink-on-orange";
-const CHIP_OFF = "border-border-interactive text-text-link";
+import { CHIP_CLASS, CHIP_OFF, CHIP_ON } from "../ui-classes";
 
 /**
  * The single repeated field pattern for the Add Gear sheet: a row of common

--- a/src/features/tackle/components/tackle-box.tsx
+++ b/src/features/tackle/components/tackle-box.tsx
@@ -1,173 +1,21 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import Link from "next/link";
 
-import { TACKLE_FIXTURE } from "../tackle-fixture";
-import {
-  categoryFor,
-  countByCategory,
-  countLow,
-  itemMatchesSearch,
-  itemMatchesView,
-  rememberValue,
-  SORT_LABELS,
-  sortItems,
-  TACKLE_CATEGORIES,
-  VIEW_FILTER_LABELS,
-  type CategoryId,
-  type RecentsMap,
-  type SortOrder,
-  type TackleDraft,
-  type TackleItem,
-  type ViewFilter,
-} from "../types";
+import { deleteTackleItem, saveTackleItem, useTackleSession } from "../session-store";
+import { countByCategory, countLow, TACKLE_CATEGORIES } from "../types";
+import { FOCUS_RING, PRIMARY_BUTTON } from "../ui-classes";
+import { useTackleEditor } from "../use-tackle-editor";
 import { CategoryIcon } from "./category-icon";
-import { TackleEditorSheet, type EditorRequest } from "./tackle-editor-sheet";
-import { TackleItemCard } from "./tackle-item-card";
-
-const VIEW_FILTERS: readonly ViewFilter[] = ["all", "favorites", "low"];
-
-/** Rendered in pages so a 5,000-item box never mounts 5,000 cards; anglers at
- *  scale find with search/filters rather than scrolling the full list. */
-const LIST_PAGE = 100;
-/** The horizontal rail stays a quick rig list, not a second inventory. */
-const RAIL_MAX = 12;
-const SORT_ORDERS: readonly SortOrder[] = ["recent", "name", "category", "quantity"];
-
-const FOCUS_RING =
-  "focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring";
-const CHIP_CLASS = `min-h-touch-floor rounded-full border px-4 text-label transition-colors ${FOCUS_RING} active:scale-95 motion-reduce:transition-none`;
-const CHIP_ON = "border-signal-orange bg-signal-orange text-ink-on-orange";
-const CHIP_OFF = "border-border-interactive bg-surface text-text-link";
-const PRIMARY_BUTTON = `inline-flex min-h-touch-floor items-center justify-center rounded-md bg-signal-orange px-4 text-label text-ink-on-orange transition-colors hover:bg-signal-orange-pressed ${FOCUS_RING} active:scale-95 motion-reduce:transition-none`;
+import { TackleEditorSheet } from "./tackle-editor-sheet";
+import { TackleInventoryList } from "./tackle-inventory-list";
 
 export function TackleBox() {
-  const [items, setItems] = useState<TackleItem[]>(() => [...TACKLE_FIXTURE]);
-  const [view, setView] = useState<ViewFilter>("all");
-  const [categoryFilter, setCategoryFilter] = useState<CategoryId | "all">("all");
-  const [query, setQuery] = useState("");
-  const [sort, setSort] = useState<SortOrder>("recent");
-  const [shownCount, setShownCount] = useState(LIST_PAGE);
-  const [recents, setRecents] = useState<RecentsMap>({});
-  const [lastDraft, setLastDraft] = useState<TackleDraft | null>(null);
-  const [editor, setEditor] = useState<EditorRequest | null>(null);
+  const { items, recents } = useTackleSession();
+  const editor = useTackleEditor();
 
-  const visibleItems = useMemo(
-    () =>
-      sortItems(
-        items.filter(
-          (item) =>
-            (categoryFilter === "all" || item.category === categoryFilter) &&
-            itemMatchesView(item, view) &&
-            itemMatchesSearch(item, query),
-        ),
-        sort,
-      ),
-    [categoryFilter, items, query, sort, view],
-  );
-  const shownItems = visibleItems.slice(0, shownCount);
-  const favorites = items.filter((item) => item.isFavorite);
-  const railItems = favorites.slice(0, RAIL_MAX);
-
-  function applyQuery(next: string) {
-    setQuery(next);
-    setShownCount(LIST_PAGE);
-  }
-
-  function applyView(next: ViewFilter) {
-    setView(next);
-    setShownCount(LIST_PAGE);
-  }
-
-  function applyCategoryFilter(next: CategoryId | "all") {
-    setCategoryFilter(next);
-    setShownCount(LIST_PAGE);
-  }
-
-  function applySort(next: SortOrder) {
-    setSort(next);
-    setShownCount(LIST_PAGE);
-  }
   const categoryCounts = countByCategory(items);
   const lowCount = countLow(items);
-  const categoriesInUse = TACKLE_CATEGORIES.filter(
-    (category) => (categoryCounts[category.id]?.total ?? 0) > 0 || categoryFilter === category.id,
-  );
-
-  function openAddSheet() {
-    setEditor(
-      lastDraft
-        ? {
-            kind: "add",
-            key: crypto.randomUUID(),
-            prefill: { ...lastDraft, label: "" },
-            note: "Pre-filled from your last add — change what’s different and save.",
-          }
-        : { kind: "add", key: crypto.randomUUID(), prefill: null, note: null },
-    );
-  }
-
-  function openEditSheet(id: string) {
-    const item = items.find((candidate) => candidate.id === id);
-    if (item) setEditor({ kind: "edit", key: crypto.randomUUID(), item });
-  }
-
-  function openDuplicateSheet(source: TackleItem) {
-    setEditor({
-      kind: "add",
-      key: crypto.randomUUID(),
-      prefill: {
-        category: source.category,
-        label: source.label,
-        quantity: source.quantity,
-        lowStockAt: source.lowStockAt,
-        attributes: { ...source.attributes },
-        notes: source.notes,
-        isFavorite: source.isFavorite,
-      },
-      note: `Duplicating “${source.label}” — change what’s different, then save.`,
-    });
-  }
-
-  function saveItem(draft: TackleDraft, id?: string) {
-    setItems((current) =>
-      id
-        ? current.map((item) => (item.id === id ? { ...draft, id, addedAt: item.addedAt } : item))
-        : [{ ...draft, id: `session-${crypto.randomUUID()}`, addedAt: Date.now() }, ...current],
-    );
-    setRecents((current) => {
-      let next = current;
-      for (const [fieldKey, value] of Object.entries(draft.attributes)) {
-        next = rememberValue(next, `${draft.category}:${fieldKey}`, value);
-      }
-      return next;
-    });
-    setLastDraft(draft);
-  }
-
-  function deleteItem(id: string) {
-    setItems((current) => current.filter((item) => item.id !== id));
-  }
-
-  function toggleFavorite(id: string) {
-    setItems((current) =>
-      current.map((item) => (item.id === id ? { ...item, isFavorite: !item.isFavorite } : item)),
-    );
-  }
-
-  function adjustQuantity(id: string, next: number) {
-    setItems((current) =>
-      current.map((item) => (item.id === id ? { ...item, quantity: next } : item)),
-    );
-  }
-
-  function clearListControls() {
-    setQuery("");
-    setView("all");
-    setCategoryFilter("all");
-    setSort("recent");
-    setShownCount(LIST_PAGE);
-  }
 
   return (
     <section className="flex flex-col gap-8 pb-8">
@@ -177,7 +25,7 @@ export function TackleBox() {
             <p className="text-caption font-bold tracking-station text-tide-cyan">YOUR GEAR INVENTORY</p>
             <h1 className="mt-1 text-h1">Tackle Box</h1>
           </div>
-          <button type="button" onClick={openAddSheet} className={PRIMARY_BUTTON}>
+          <button type="button" onClick={() => editor.openAdd()} className={PRIMARY_BUTTON}>
             + Add gear
           </button>
         </div>
@@ -186,7 +34,7 @@ export function TackleBox() {
         </p>
         <div className="mt-4 flex flex-wrap items-center gap-x-6 gap-y-2 text-caption text-text-muted">
           <span>
-            <strong className="text-text-primary">{items.length}</strong> items
+            <strong className="text-text-primary">{items.length}</strong> {items.length === 1 ? "item" : "items"}
           </span>
           <span>
             <strong className={lowCount > 0 ? "text-amber-flag" : "text-text-primary"}>{lowCount}</strong>{" "}
@@ -198,193 +46,58 @@ export function TackleBox() {
         </p>
       </header>
 
-      {favorites.length > 0 ? (
-        <section aria-labelledby="favorite-gear-heading">
-          <div className="flex items-baseline justify-between gap-3">
-            <h2 id="favorite-gear-heading" className="text-h2">Ready to rig</h2>
-            {favorites.length > RAIL_MAX ? (
-              <p className="text-caption text-text-muted">{favorites.length} total — see the Favorites view</p>
-            ) : null}
-          </div>
-          <div className="mt-4 flex items-stretch gap-3 overflow-x-auto pb-2">
-            {railItems.map((item) => (
-              <TackleItemCard
-                key={item.id}
-                item={item}
-                compact
-                onOpen={openEditSheet}
-                onToggleFavorite={toggleFavorite}
-                onAdjustQuantity={adjustQuantity}
-              />
-            ))}
-          </div>
-        </section>
-      ) : null}
-
-      {items.length > 0 ? (
-        <section aria-labelledby="categories-heading">
-          <h2 id="categories-heading" className="text-h2">Browse by category</h2>
-          <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3">
-            {categoriesInUse.map((category) => {
-              const counts = categoryCounts[category.id] ?? { total: 0, low: 0 };
-              const active = categoryFilter === category.id;
-              return (
-                <button
-                  key={category.id}
-                  type="button"
-                  aria-pressed={active}
-                  onClick={() => applyCategoryFilter(active ? "all" : category.id)}
-                  className={`flex min-h-touch-floor flex-col items-start gap-2 rounded-lg border p-4 text-left transition-colors ${FOCUS_RING} active:scale-95 motion-reduce:transition-none ${
-                    active ? "border-signal-orange bg-surface-raised" : "border-hairline bg-surface"
-                  }`}
-                >
-                  <CategoryIcon
-                    id={category.id}
-                    className={`h-6 w-6 ${active ? "text-signal-orange" : "text-text-muted"}`}
-                  />
-                  <span className="text-label text-text-primary">{category.label}</span>
-                  <span className="mt-auto text-caption text-text-muted">
-                    {counts.total} {counts.total === 1 ? "item" : "items"}
-                    {counts.low > 0 ? (
-                      <span className="text-amber-flag"> · {counts.low} low</span>
-                    ) : null}
-                  </span>
-                </button>
-              );
-            })}
-          </div>
-        </section>
-      ) : null}
+      <section aria-labelledby="categories-heading">
+        <h2 id="categories-heading" className="text-h2">Browse by category</h2>
+        <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3">
+          {TACKLE_CATEGORIES.map((category) => {
+            const counts = categoryCounts[category.id] ?? { total: 0, low: 0 };
+            return (
+              <Link
+                key={category.id}
+                href={`/tackle/${category.id}`}
+                className={`flex min-h-touch-floor flex-col items-start gap-2 rounded-lg border border-hairline bg-surface p-4 text-left transition-colors hover:bg-surface-raised ${FOCUS_RING} active:scale-95 motion-reduce:transition-none`}
+              >
+                <span className="flex w-full items-center justify-between gap-2">
+                  <CategoryIcon id={category.id} className="h-6 w-6 text-text-muted" />
+                  <svg
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                    className="h-5 w-5 shrink-0 text-text-muted"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="m9 6 6 6-6 6" />
+                  </svg>
+                </span>
+                <span className="text-label text-text-primary">{category.label}</span>
+                <span className="mt-auto text-caption text-text-muted">
+                  {counts.total} {counts.total === 1 ? "item" : "items"}
+                  {counts.low > 0 ? <span className="text-amber-flag"> · {counts.low} low</span> : null}
+                </span>
+              </Link>
+            );
+          })}
+        </div>
+      </section>
 
       <section aria-labelledby="all-gear-heading">
-        <div className="flex flex-col gap-4">
-          <div className="flex items-baseline justify-between gap-3">
-            <h2 id="all-gear-heading" className="text-h2">All gear</h2>
-            <p className="text-caption text-text-muted">{items.length} in this session</p>
-          </div>
-
-          <label className="flex flex-col gap-2 text-label">
-            Search your tackle
-            <input
-              value={query}
-              onChange={(event) => applyQuery(event.target.value)}
-              placeholder="Name, brand, size, color…"
-              className={`min-h-touch-floor rounded-md border border-border-interactive bg-surface px-4 text-body text-text-primary placeholder:text-text-muted ${FOCUS_RING}`}
-            />
-          </label>
-
-          <div className="flex flex-wrap gap-3" role="group" aria-label="Inventory view">
-            {VIEW_FILTERS.map((option) => {
-              const selected = view === option;
-              const label =
-                option === "low" && lowCount > 0
-                  ? `${VIEW_FILTER_LABELS[option]} (${lowCount})`
-                  : VIEW_FILTER_LABELS[option];
-              return (
-                <button
-                  key={option}
-                  type="button"
-                  aria-pressed={selected}
-                  onClick={() => applyView(option)}
-                  className={`${CHIP_CLASS} ${selected ? CHIP_ON : CHIP_OFF}`}
-                >
-                  {label}
-                </button>
-              );
-            })}
-          </div>
-
-          <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
-            <label className="flex items-center gap-3 text-label">
-              Sort
-              <select
-                value={sort}
-                onChange={(event) => applySort(event.target.value as SortOrder)}
-                className={`min-h-touch-floor rounded-md border border-border-interactive bg-surface px-4 text-body text-text-primary ${FOCUS_RING}`}
-              >
-                {SORT_ORDERS.map((order) => (
-                  <option key={order} value={order}>
-                    {SORT_LABELS[order]}
-                  </option>
-                ))}
-              </select>
-            </label>
-            {categoryFilter !== "all" ? (
-              <button
-                type="button"
-                onClick={() => applyCategoryFilter("all")}
-                aria-label={`Clear the ${categoryFor(categoryFilter).label} category filter`}
-                className={`${CHIP_CLASS} ${CHIP_ON}`}
-              >
-                {categoryFor(categoryFilter).label} ✕
-              </button>
-            ) : null}
-          </div>
+        <div className="mb-4 flex items-baseline justify-between gap-3">
+          <h2 id="all-gear-heading" className="text-h2">All gear</h2>
+          <p className="text-caption text-text-muted">{items.length} in this session</p>
         </div>
-
-        {items.length === 0 ? (
-          <div className="mt-5 rounded-lg border border-hairline bg-surface p-6">
-            <h3 className="text-h3">Your tackle box is empty.</h3>
-            <p className="mt-2 text-body text-text-muted">
-              Add the gear you actually carry — hooks, line, lures, all of it — so counts stay honest
-              and restocking is obvious.
-            </p>
-            <button type="button" onClick={openAddSheet} className={`mt-5 ${PRIMARY_BUTTON}`}>
-              Add your first item
-            </button>
-          </div>
-        ) : visibleItems.length === 0 ? (
-          <div className="mt-5 rounded-lg border border-hairline bg-surface p-6">
-            <h3 className="text-h3">Nothing matches that view.</h3>
-            <p className="mt-2 text-body text-text-muted">
-              Try a different view, another category, or clear your search.
-            </p>
-            <button
-              type="button"
-              onClick={clearListControls}
-              className={`mt-5 inline-flex min-h-touch-floor items-center justify-center rounded-md border border-border-interactive px-4 text-label text-text-link ${FOCUS_RING} active:scale-95`}
-            >
-              Clear search and filters
-            </button>
-          </div>
-        ) : (
-          <>
-            <div className="mt-5 flex flex-col gap-3">
-              {shownItems.map((item) => (
-                <TackleItemCard
-                  key={item.id}
-                  item={item}
-                  onOpen={openEditSheet}
-                  onToggleFavorite={toggleFavorite}
-                  onAdjustQuantity={adjustQuantity}
-                />
-              ))}
-            </div>
-            <p className="mt-4 text-caption text-text-muted">
-              {visibleItems.length === items.length
-                ? `${items.length} items`
-                : `Showing ${shownItems.length} of ${visibleItems.length} matching · ${items.length} total`}
-            </p>
-            {shownItems.length < visibleItems.length ? (
-              <button
-                type="button"
-                onClick={() => setShownCount((count) => count + LIST_PAGE)}
-                className={`mt-3 inline-flex min-h-touch-floor w-full items-center justify-center rounded-md border border-border-interactive px-4 text-label text-text-link ${FOCUS_RING} active:scale-95`}
-              >
-                Show more ({visibleItems.length - shownItems.length} left)
-              </button>
-            ) : null}
-          </>
-        )}
+        <TackleInventoryList headingId="all-gear-heading" onAdd={() => editor.openAdd()} onEdit={editor.openEdit} />
       </section>
 
       <TackleEditorSheet
-        request={editor}
+        request={editor.editor}
         recents={recents}
-        onClose={() => setEditor(null)}
-        onSave={saveItem}
-        onDuplicate={openDuplicateSheet}
-        onDelete={deleteItem}
+        onClose={editor.closeEditor}
+        onSave={saveTackleItem}
+        onDuplicate={editor.openDuplicate}
+        onDelete={deleteTackleItem}
       />
     </section>
   );

--- a/src/features/tackle/components/tackle-category-view.tsx
+++ b/src/features/tackle/components/tackle-category-view.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import Link from "next/link";
+
+import { deleteTackleItem, saveTackleItem, useTackleSession } from "../session-store";
+import { categoryFor, countByCategory, countLow, type CategoryId } from "../types";
+import { FOCUS_RING, PRIMARY_BUTTON } from "../ui-classes";
+import { useTackleEditor } from "../use-tackle-editor";
+import { CategoryIcon } from "./category-icon";
+import { TackleEditorSheet } from "./tackle-editor-sheet";
+import { TackleInventoryList } from "./tackle-inventory-list";
+
+/**
+ * One category's inventory. Same header anatomy as the main Tackle Box so the
+ * transition reads as a drill-in, not a different app; the back link lands on /tackle.
+ */
+export function TackleCategoryView({ category }: { category: CategoryId }) {
+  const { items, recents } = useTackleSession();
+  const editor = useTackleEditor();
+
+  const spec = categoryFor(category);
+  const scoped = items.filter((item) => item.category === category);
+  const lowCount = countByCategory(scoped)[category]?.low ?? countLow(scoped);
+
+  return (
+    <section className="flex flex-col gap-8 pb-8">
+      <header className="rounded-lg border border-hairline bg-surface p-4">
+        <Link
+          href="/tackle"
+          className={`inline-flex min-h-touch-floor items-center gap-2 rounded-md text-label text-text-link ${FOCUS_RING}`}
+        >
+          <svg
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            className="h-5 w-5 shrink-0"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="m15 6-6 6 6 6" />
+          </svg>
+          Tackle Box
+        </Link>
+        <div className="mt-2 flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex min-w-0 items-center gap-3">
+            <CategoryIcon id={category} className="h-8 w-8 shrink-0 text-text-muted" />
+            <h1 id="category-heading" className="text-h1">{spec.label}</h1>
+          </div>
+          <button type="button" onClick={() => editor.openAdd(category)} className={PRIMARY_BUTTON}>
+            + Add gear
+          </button>
+        </div>
+        <div className="mt-4 flex flex-wrap items-center gap-x-6 gap-y-2 text-caption text-text-muted">
+          <span>
+            <strong className="text-text-primary">{scoped.length}</strong> {scoped.length === 1 ? "item" : "items"}
+          </span>
+          <span>
+            <strong className={lowCount > 0 ? "text-amber-flag" : "text-text-primary"}>{lowCount}</strong>{" "}
+            running low
+          </span>
+        </div>
+        <p className="mt-4 border-t border-hairline pt-3 text-caption text-text-muted" role="status">
+          Prototype: changes stay in this session and are not synced.
+        </p>
+      </header>
+
+      <TackleInventoryList
+        scopeCategory={category}
+        headingId="category-heading"
+        onAdd={() => editor.openAdd(category)}
+        onEdit={editor.openEdit}
+      />
+
+      <TackleEditorSheet
+        request={editor.editor}
+        recents={recents}
+        onClose={editor.closeEditor}
+        onSave={saveTackleItem}
+        onDuplicate={editor.openDuplicate}
+        onDelete={deleteTackleItem}
+      />
+    </section>
+  );
+}

--- a/src/features/tackle/components/tackle-editor-sheet.tsx
+++ b/src/features/tackle/components/tackle-editor-sheet.tsx
@@ -58,12 +58,12 @@ function draftFrom(request: Exclude<EditorRequest, null>): DraftState {
   return EMPTY_DRAFT;
 }
 
-const FOCUS_RING =
-  "focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring";
+import { CHIP_CLASS as SHARED_CHIP_CLASS, CHIP_OFF as SHARED_CHIP_OFF, CHIP_ON as SHARED_CHIP_ON, FOCUS_RING } from "../ui-classes";
+
 const INPUT_CLASS = `min-h-touch-floor rounded-md border border-border-interactive bg-background px-4 text-body text-text-primary placeholder:text-text-muted ${FOCUS_RING}`;
-const CHIP_CLASS = `min-h-touch-floor rounded-full border px-4 text-label transition-colors ${FOCUS_RING} active:scale-95 motion-reduce:transition-none`;
-const CHIP_ON = "border-signal-orange bg-signal-orange text-ink-on-orange";
-const CHIP_OFF = "border-border-interactive text-text-link";
+const CHIP_CLASS = SHARED_CHIP_CLASS;
+const CHIP_ON = SHARED_CHIP_ON;
+const CHIP_OFF = SHARED_CHIP_OFF;
 
 export function TackleEditorSheet({
   request,

--- a/src/features/tackle/components/tackle-inventory-list.tsx
+++ b/src/features/tackle/components/tackle-inventory-list.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { adjustTackleQuantity, toggleTackleFavorite, useTackleSession } from "../session-store";
+import {
+  categoryFor,
+  countLow,
+  itemMatchesSearch,
+  itemMatchesView,
+  SORT_LABELS,
+  sortItems,
+  VIEW_FILTER_LABELS,
+  type CategoryId,
+  type SortOrder,
+  type ViewFilter,
+} from "../types";
+import { CHIP_CLASS, CHIP_OFF_ON_SURFACE, CHIP_ON, FOCUS_RING, PRIMARY_BUTTON } from "../ui-classes";
+import { TackleItemCard } from "./tackle-item-card";
+
+const VIEW_FILTERS: readonly ViewFilter[] = ["all", "favorites", "low"];
+const SORT_ORDERS: readonly SortOrder[] = ["recent", "name", "category", "quantity"];
+
+/** Rendered in pages so a multi-thousand-item box never mounts thousands of cards;
+ *  at scale anglers find with search/filters rather than scrolling the full list. */
+const LIST_PAGE = 100;
+
+/**
+ * The inventory browser shared by the main Tackle Box (`scopeCategory` null) and
+ * each category page: one search field, one chip row, one sort order, the same
+ * cards, paging, and empty states — identical behavior everywhere it appears.
+ */
+export function TackleInventoryList({
+  scopeCategory = null,
+  headingId,
+  onAdd,
+  onEdit,
+}: {
+  scopeCategory?: CategoryId | null;
+  headingId: string;
+  onAdd: () => void;
+  onEdit: (id: string) => void;
+}) {
+  const { items } = useTackleSession();
+  const [view, setView] = useState<ViewFilter>("all");
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<SortOrder>("recent");
+  const [shownCount, setShownCount] = useState(LIST_PAGE);
+
+  const resetWindow = () => setShownCount(LIST_PAGE);
+
+  const scopedItems = useMemo(
+    () => (scopeCategory ? items.filter((item) => item.category === scopeCategory) : [...items]),
+    [items, scopeCategory],
+  );
+  const visibleItems = useMemo(
+    () =>
+      sortItems(
+        scopedItems.filter((item) => itemMatchesView(item, view) && itemMatchesSearch(item, query)),
+        sort,
+      ),
+    [query, scopedItems, sort, view],
+  );
+  const shownItems = visibleItems.slice(0, shownCount);
+  const lowCount = countLow(scopedItems);
+
+  const scopeLabel = scopeCategory ? categoryFor(scopeCategory).label : null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <label className="flex flex-col gap-2 text-label">
+        {scopeLabel ? `Search ${scopeLabel.toLowerCase()}` : "Search your tackle"}
+        <input
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            resetWindow();
+          }}
+          placeholder="Name, brand, size, color…"
+          className={`min-h-touch-floor rounded-md border border-border-interactive bg-surface px-4 text-body text-text-primary placeholder:text-text-muted ${FOCUS_RING}`}
+        />
+      </label>
+
+      <div className="flex flex-wrap gap-3" role="group" aria-label="Inventory view">
+        {VIEW_FILTERS.map((option) => {
+          const selected = view === option;
+          const label =
+            option === "low" && lowCount > 0
+              ? `${VIEW_FILTER_LABELS[option]} (${lowCount})`
+              : VIEW_FILTER_LABELS[option];
+          return (
+            <button
+              key={option}
+              type="button"
+              aria-pressed={selected}
+              onClick={() => {
+                setView(option);
+                resetWindow();
+              }}
+              className={`${CHIP_CLASS} ${selected ? CHIP_ON : CHIP_OFF_ON_SURFACE}`}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      <label className="flex items-center gap-3 text-label">
+        Sort
+        <select
+          value={sort}
+          onChange={(event) => {
+            setSort(event.target.value as SortOrder);
+            resetWindow();
+          }}
+          className={`min-h-touch-floor rounded-md border border-border-interactive bg-surface px-4 text-body text-text-primary ${FOCUS_RING}`}
+        >
+          {SORT_ORDERS.map((order) => (
+            <option key={order} value={order}>
+              {SORT_LABELS[order]}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <section aria-labelledby={headingId} className="flex flex-col gap-3">
+        {scopedItems.length === 0 ? (
+          <div className="rounded-lg border border-hairline bg-surface p-6">
+            <h3 className="text-h3">
+              {scopeLabel ? `No ${scopeLabel.toLowerCase()} yet.` : "Your tackle box is empty."}
+            </h3>
+            <p className="mt-2 text-body text-text-muted">
+              {scopeLabel
+                ? `Add your first one — it takes a few seconds, and it will show up here and in your whole box.`
+                : `Add the gear you actually carry — hooks, line, lures, all of it — so counts stay honest and restocking is obvious.`}
+            </p>
+            <button type="button" onClick={onAdd} className={`mt-5 ${PRIMARY_BUTTON}`}>
+              Add your first item
+            </button>
+          </div>
+        ) : visibleItems.length === 0 ? (
+          <div className="rounded-lg border border-hairline bg-surface p-6">
+            <h3 className="text-h3">Nothing matches that view.</h3>
+            <p className="mt-2 text-body text-text-muted">
+              Try a different view or clear your search.
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                setQuery("");
+                setView("all");
+                setSort("recent");
+                resetWindow();
+              }}
+              className={`mt-5 inline-flex min-h-touch-floor items-center justify-center rounded-md border border-border-interactive px-4 text-label text-text-link ${FOCUS_RING} active:scale-95`}
+            >
+              Clear search and filters
+            </button>
+          </div>
+        ) : (
+          <>
+            <div className="flex flex-col gap-3">
+              {shownItems.map((item) => (
+                <TackleItemCard
+                  key={item.id}
+                  item={item}
+                  onOpen={onEdit}
+                  onToggleFavorite={toggleTackleFavorite}
+                  onAdjustQuantity={adjustTackleQuantity}
+                />
+              ))}
+            </div>
+            <p className="text-caption text-text-muted">
+              {visibleItems.length === scopedItems.length
+                ? `${scopedItems.length} ${scopedItems.length === 1 ? "item" : "items"}`
+                : `Showing ${shownItems.length} of ${visibleItems.length} matching · ${scopedItems.length} total`}
+            </p>
+            {shownItems.length < visibleItems.length ? (
+              <button
+                type="button"
+                onClick={() => setShownCount((count) => count + LIST_PAGE)}
+                className={`inline-flex min-h-touch-floor w-full items-center justify-center rounded-md border border-border-interactive px-4 text-label text-text-link ${FOCUS_RING} active:scale-95`}
+              >
+                Show more ({visibleItems.length - shownItems.length} left)
+              </button>
+            ) : null}
+          </>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/features/tackle/components/tackle-item-card.tsx
+++ b/src/features/tackle/components/tackle-item-card.tsx
@@ -1,8 +1,6 @@
 import { cardSummary, categoryFor, isLowStock, isOutOfStock, type TackleItem } from "../types";
+import { FOCUS_RING } from "../ui-classes";
 import { QuantityStepper } from "./quantity-stepper";
-
-const FOCUS_RING =
-  "focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring";
 
 function FavoritePill({ isFavorite, onToggle, fullWidth = false }: { isFavorite: boolean; onToggle: () => void; fullWidth?: boolean }) {
   return (

--- a/src/features/tackle/session-store.ts
+++ b/src/features/tackle/session-store.ts
@@ -1,0 +1,98 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+import { TACKLE_FIXTURE } from "./tackle-fixture";
+import {
+  clampQuantity,
+  rememberValue,
+  type RecentsMap,
+  type TackleDraft,
+  type TackleItem,
+} from "./types";
+
+/**
+ * The tackle inventory is a session-only prototype (docs/design/08-tackle-box.md):
+ * one module-level store shared by the Tackle Box page and every category page, so
+ * edits made on /tackle/hooks are still there when you go back to /tackle — and
+ * everything still honestly resets on refresh. When the offline store lane lands,
+ * this module is the single swap point.
+ */
+
+export type TackleSession = {
+  items: readonly TackleItem[];
+  recents: RecentsMap;
+  lastDraft: TackleDraft | null;
+};
+
+const initialSession: TackleSession = {
+  items: [...TACKLE_FIXTURE],
+  recents: {},
+  lastDraft: null,
+};
+
+let session: TackleSession = initialSession;
+const listeners = new Set<() => void>();
+
+function setSession(next: TackleSession) {
+  session = next;
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): TackleSession {
+  return session;
+}
+
+/** During SSR/hydration both branches must render the untouched initial session. */
+function getServerSnapshot(): TackleSession {
+  return initialSession;
+}
+
+export function useTackleSession(): TackleSession {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+// --- Mutations -------------------------------------------------------------------------------
+
+export function saveTackleItem(draft: TackleDraft, id?: string): void {
+  setSession({
+    ...session,
+    items: id
+      ? session.items.map((item) => (item.id === id ? { ...draft, id, addedAt: item.addedAt } : item))
+      : [{ ...draft, id: `session-${crypto.randomUUID()}`, addedAt: Date.now() }, ...session.items],
+    recents: Object.entries(draft.attributes).reduce(
+      (recents, [fieldKey, value]) => rememberValue(recents, `${draft.category}:${fieldKey}`, value),
+      session.recents,
+    ),
+    lastDraft: draft,
+  });
+}
+
+export function deleteTackleItem(id: string): void {
+  setSession({ ...session, items: session.items.filter((item) => item.id !== id) });
+}
+
+export function toggleTackleFavorite(id: string): void {
+  setSession({
+    ...session,
+    items: session.items.map((item) =>
+      item.id === id ? { ...item, isFavorite: !item.isFavorite } : item,
+    ),
+  });
+}
+
+export function adjustTackleQuantity(id: string, next: number): void {
+  setSession({
+    ...session,
+    items: session.items.map((item) =>
+      item.id === id ? { ...item, quantity: clampQuantity(next) } : item,
+    ),
+  });
+}

--- a/src/features/tackle/ui-classes.ts
+++ b/src/features/tackle/ui-classes.ts
@@ -1,0 +1,15 @@
+/**
+ * One shared visual spec for the tackle feature's repeated controls — chips, focus
+ * rings, and the primary action. Component files import these instead of restating
+ * class strings, so the treatment cannot drift between pages.
+ */
+
+export const FOCUS_RING =
+  "focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring";
+
+export const CHIP_CLASS = `min-h-touch-floor rounded-full border px-4 text-label transition-colors ${FOCUS_RING} active:scale-95 motion-reduce:transition-none`;
+export const CHIP_ON = "border-signal-orange bg-signal-orange text-ink-on-orange";
+export const CHIP_OFF = "border-border-interactive text-text-link";
+export const CHIP_OFF_ON_SURFACE = "border-border-interactive bg-surface text-text-link";
+
+export const PRIMARY_BUTTON = `inline-flex min-h-touch-floor items-center justify-center rounded-md bg-signal-orange px-4 text-label text-ink-on-orange transition-colors hover:bg-signal-orange-pressed ${FOCUS_RING} active:scale-95 motion-reduce:transition-none`;

--- a/src/features/tackle/use-tackle-editor.ts
+++ b/src/features/tackle/use-tackle-editor.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+
+import type { EditorRequest } from "./components/tackle-editor-sheet";
+import { useTackleSession } from "./session-store";
+import type { CategoryId, TackleItem } from "./types";
+
+/**
+ * The add/edit/duplicate choreography behind the editor sheet, shared by the main
+ * Tackle Box page and every category page so every entry point behaves identically.
+ */
+export function useTackleEditor() {
+  const { items, recents, lastDraft } = useTackleSession();
+  const [editor, setEditor] = useState<EditorRequest | null>(null);
+
+  function openAdd(presetCategory?: CategoryId) {
+    const reuseLast = lastDraft && (!presetCategory || presetCategory === lastDraft.category);
+    if (reuseLast && lastDraft) {
+      setEditor({
+        kind: "add",
+        key: crypto.randomUUID(),
+        prefill: { ...lastDraft, label: "" },
+        note: "Pre-filled from your last add — change what’s different and save.",
+      });
+      return;
+    }
+    setEditor({
+      kind: "add",
+      key: crypto.randomUUID(),
+      prefill: presetCategory
+        ? { category: presetCategory, label: "", quantity: 1, lowStockAt: null, attributes: {}, isFavorite: false }
+        : null,
+      note: null,
+    });
+  }
+
+  function openEdit(id: string) {
+    const item = items.find((candidate) => candidate.id === id);
+    if (item) setEditor({ kind: "edit", key: crypto.randomUUID(), item });
+  }
+
+  function openDuplicate(source: TackleItem) {
+    setEditor({
+      kind: "add",
+      key: crypto.randomUUID(),
+      prefill: {
+        category: source.category,
+        label: source.label,
+        quantity: source.quantity,
+        lowStockAt: source.lowStockAt,
+        attributes: { ...source.attributes },
+        notes: source.notes,
+        isFavorite: source.isFavorite,
+      },
+      note: `Duplicating “${source.label}” — change what’s different, then save.`,
+    });
+  }
+
+  return {
+    editor,
+    recents,
+    openAdd,
+    openEdit,
+    openDuplicate,
+    closeEditor: () => setEditor(null),
+  };
+}


### PR DESCRIPTION
> **Stacked on #11** — this builds on the category-driven Tackle Box. Merge #11 first; GitHub will retarget this PR to `main` automatically.

## What changed

Two owner-review changes:

- **Removed the "Ready to rig" rail** from the main Tackle Box page. Favoriting stays (it drives the Favorites view), but the duplicated strip above the list was noise.
- **Categories are now real destinations.** Tapping a card in "Browse by category" navigates to its own page — `/tackle/hooks`, `/tackle/line`, … one page per registered category.

The category page mirrors the main header anatomy so it reads as a drill-in: back link to the Tackle Box, icon + category name, its own counts ("4 items · 1 running low"), and **+ Add gear that pre-picks that category**. The inventory tools are the same component as the main page — scoped search, All/Favorites/Low stock chips, sort, paging, identical cards.

## How it's built

- Session state moved from page component state to a tiny module-level store (`session-store.ts`, `useSyncExternalStore`) shared by both routes, so an edit on `/tackle/hooks` is still there when you go back to `/tackle` — while a full refresh still resets to the fixture, exactly like the on-screen notice says. This module is the single swap point when the offline-store lane lands.
- Route: `src/app/(app)/tackle/[category]/page.tsx` with `generateStaticParams` over the category registry + `dynamicParams = false` → **all 13 category pages prerendered statically**, unknown categories 404. Next 16 conventions were read from `node_modules/next/dist/docs` before writing it.
- `use-tackle-editor.ts` centralizes the add/edit/duplicate choreography; `tackle-inventory-list.tsx` is the one shared list; `ui-classes.ts` holds the single chip/pill/primary class spec so pages can't drift apart.
- Grammar nits fixed ("1 items" → "1 item").

## How checked

- `npm run verify` green (tokens, tripwires, lint, tsc, 136 tests) + `npm run build` green — `/tackle` and all 13 `/tackle/[category]` pages static.
- Headless Chromium at 390×844: **46 scripted checks pass** — previous coverage (category-driven add, Other→recents personalization, duplicate, delete confirm, steppers, views, search, 320px/390px overflow) plus: rail absent, category click navigates client-side, scoped list/counts on the category page, add-from-category preselects the category, favorite + additions survive navigation, direct `/tackle/leaders` load resets the session honestly, `/tackle/not-a-category` 404s. **14/14 keyboard-only checks** pass (Enter on cards/links, trap in dialog, focus through delete confirm, Escape).
- Found and fixed while testing: a category chevron that overflowed its row by 1px at 320px (moved up beside the icon). Caught because the test measures sub-pixel overflow.
- **Not checked on a real phone yet.**
