### PR TITLE
feat(log): Fish Log MVP — local-first catch logging, D22 quick mark wired

### DIFF
--- a/docs/design/09-fish-log.md
+++ b/docs/design/09-fish-log.md
@@ -1,0 +1,222 @@
+# 09 — Fish Log
+
+**Status:** Built as a local-first web prototype · **First slice:** 2026-09-01
+(product spec: the Fish Log specification supplied by the founder, 2026-09-01)
+
+## Job
+
+An angler holding a fish, on a moving boat, in the sun, with wet hands and no signal,
+records what they caught in under ten seconds. Underneath, the app builds a structured
+history that will later answer "what actually works for me."
+
+Those two sentences pull in opposite directions, and every decision below is about
+which one wins where. The short version: **the angler's time wins at the glass, and
+data integrity wins in the store.** Nothing is asked for that can be captured or
+inferred, and nothing is invented that was not observed.
+
+## The headline finding: this was not a schema project
+
+The spec (§38, §47, §48) asks for an architecture review before building tables, and
+lists conceptual entities: `catches`, `species`, `gear_items`, `catch_gear`,
+`catch_environment`, `trips`, `locations`.
+
+**Almost all of it already exists**, in `supabase/migrations/20260828120000_v1_core_schema.sql`,
+and it is better specified than the sketch in §39 — it already has the D22 mark
+lifecycle, the D21a sticky rig, timezone-safe local-date bucketing, soft deletes, sync
+columns and RLS. So this slice is a UI and local-store feature built on the existing
+ontology, and exactly **one** additive migration was written.
+
+| Spec asks for | What it maps to | New? |
+|---|---|---|
+| `catches` | `public.catch` | existing |
+| `species` | `public.species` (text ids, aliases, roll-ups) | existing |
+| `trips` | `public.trip` | existing |
+| `catch_environment` | `public.condition_snapshot` | existing |
+| `locations` | `public.spot` (+ `geo_cell_*` grids) | existing |
+| `gear_items` | `public.tackle_item` | existing |
+| `catch_gear` | `public.catch_gear` | **added** |
+| `tags` / `catch_tags` | `catch.tags` (array, local) | see *Deviations* |
+
+### The one migration
+
+`supabase/migrations/20260901120000_v1_catch_gear.sql` — additive only. Nothing existing
+is altered or dropped.
+
+`catch` already had `tackle_item_id`, which is one lure. Spec §14 is explicit that the
+system must not be built around a single `gear_id`: a catch involves a rod, a reel, a
+main line, a leader and a jig, and "which leader was on when the big ones bit" is a
+question the log exists to answer. `catch.tackle_item_id` is **kept and still written** —
+it is what D21a's rig inheritance and the existing analytics views read — and the new
+table carries the full rig beside it.
+
+Each gear row stores `tackle_item_id` *and* a `label`/`detail` snapshot, which is spec
+§15's requirement: the FK is `ON DELETE SET NULL`, so when the angler deletes that jig
+from their Tackle Box six months later, the catch still says what was actually tied on.
+The id answers "how has this jig performed"; the snapshot keeps the history true after
+the id is gone. This is verified against a real PostgreSQL 16, not asserted.
+
+## Answers to the spec's §48 review questions
+
+1. **Trips optional, implicit, or auto-created?** *Implicit.* `catch.trip_id` is NOT NULL
+   because a catch with no trip has no effort denominator (§12), and §11 forbids making
+   the angler create one. Both hold: the first catch of a session silently opens a trip
+   and later catches join it. The angler is never asked, and never sees the word.
+2. **Trip → Catch relationship?** One trip, many catches; the existing FK. A trip is
+   "open" until explicitly ended. An abandoned trip is a real thing that happened and is
+   not tidied away.
+3. **Species normalization?** Already normalized: `public.species`, stable text ids, with
+   group roll-ups. Mirrored into `src/core/ontology/species.ts` so the one required field
+   on a catch works with no signal. `species_other` is a separate column for the genuine
+   unknown, so free text can never be mistaken for an id.
+4. **Catch ↔ Tackle Box?** `catch_gear`, above.
+5. **Historical accuracy when gear changes?** Id plus snapshot, `ON DELETE SET NULL`.
+6. **Locations embedded, relational, or hybrid?** Hybrid, as built: `spot_id` for the
+   named place, plus `lat`/`lng` and derived `geo_cell_1km`/`geo_cell_10km` on the catch.
+7. **What to snapshot?** `condition_snapshot`, one row per catch.
+8. **Raw vs derived?** Raw. `moon_phase_angle_deg` and `moon_illumination_fraction` are
+   stored; no bite score, no "good moon", nothing derived that a better algorithm would
+   later want to recompute (§18).
+9. **Provider provenance?** `provenance` jsonb + `enrichment_status` + `snapshot_basis`,
+   all already in the schema. A snapshot written here is `partial`, never `complete` —
+   see *Conditions* below.
+10. **Editing an old catch's timestamp?** Not yet implemented; see *Not built*.
+11. **Offline persistence?** IndexedDB, per ADR 004 §1. Details below.
+12. **Offline id generation?** UUIDv7 minted on device (`src/core/sync/uuid.ts`), with
+    vectors. Time-ordered, so it doubles as the idempotency key and sorts by creation.
+13. **Sync conflict resolution?** ADR 004 §4, unchanged. The envelope and its state
+    machine are implemented in `src/core/sync/outbox.ts`; the flusher is not (below).
+14. **Indexes now?** `catch_gear` gets catch, tackle and sync-cursor indexes. The local
+    store indexes `catch` by trip and by local date.
+15. **Protecting exact locations?** Coordinates are never rendered — the detail screen
+    says "Saved privately with this catch" and nothing more. RLS on every table is
+    verified to block cross-angler reads, inserts and deletes, and `anon` has no access
+    at all. Privacy is enforced at the data layer, not by hiding it visually (§37).
+16. **10,000+ catches?** Measured, not assumed: see *Numbers*.
+17. **Existing structures that should replace the proposal?** Yes — nearly all of it.
+    See the table above.
+
+## What was built
+
+- **`/log`** — the Fish Log home. `+ Log catch`, recent catches grouped by local day,
+  search, and three views (All / Favorites / Needs details). Deliberately not a
+  dashboard: analytics belong to their own feature (§8, §33).
+- **Quick Log** — one thing above the fold, species, and Save live from the first tap.
+  Everything else is behind **Add details**. Save never blocks.
+- **Species picker** — recent first, then a curated common set, then all species behind
+  one tap, then search, then "Something else" free text. Recent-first is the design:
+  during a hot bite the fish you just caught is the fish you are about to catch again.
+- **Repeat and Duplicate** (§6, §7) — "Save & log another" reopens the sheet with the
+  same setup and a new timestamp; Duplicate does the same from any past catch. Both
+  carry *how you were fishing* and deliberately not *this fish*: weight, length and
+  notes never copy forward, because copying them manufactures data.
+- **Catch detail** — sections that render only when they hold something, plus Edit-by-
+  duplicate, Favorite, and a two-step Delete.
+- **The quick mark (D22)** — the shell button that has said "wired when logging lands"
+  since the shell round is now wired. It writes an `unresolved` row: no species, no
+  outcome, excluded from every rate until a human says what happened.
+- **Photos** — stored as blobs on the device, in their own object store so a list query
+  never drags megabytes along. EXIF is deliberately not read for time or place (§25).
+
+## Local-first, and what "saved" means
+
+Per ADR 004: every read comes from IndexedDB and the network fills it in later. A row
+and its outbox mutation are written in **one transaction** — if the tab dies between
+them, either both landed or neither did. A catch that existed locally with nothing
+queued would never sync and nobody would know; that is the quiet data-loss bug this
+shape prevents.
+
+The vocabulary at the glass is ADR 004 §6's: "Saved to this device", then "N waiting to
+back up". Offline is a normal state, never an error, and the word "failed" does not
+appear while retries remain.
+
+### The bug worth naming
+
+The first build warmed the GPS when the sheet opened and **awaited the fix at save
+time**. On a phone without a recent fix that is the full timeout — four seconds of
+nothing, against a five-to-ten-second target for the whole catch, and a direct breach of
+§21. It was caught by measuring the save, not by reading the code.
+
+The fix is the rule now written into `startPositionRequest`: the position is *read*,
+never awaited. Whatever has arrived is used; a fix that lands afterwards is patched on
+silently. The same rule already governed the quick mark, and now both share it.
+
+## Conditions (§16–§19)
+
+`PLAN.md` §1 cuts live enrichment from the web prototype: tide and weather are fetched
+server-side later and every web write lands `pending`. That cut is honoured.
+
+Sun and moon are the exception, and the reason is D25: they are **computed on device**
+from the instant and the coordinates — no API, no key, no network, as available on a
+boat as on wifi. Leaving them null to ask a server later would be worse data for no gain.
+
+So a snapshot is written `partial`, never `complete`: the astronomical fields are real
+observations and the marine ones are genuinely still owed. Saying `complete` would be a
+lie a future correlation would act on.
+
+Tide state is not guessed at all. §19 forbids calling anything slack that was not
+measured, and with no series fetched there is nothing honest to call.
+
+## Numbers
+
+Measured in headless Chromium at 390×844, production build.
+
+| | |
+|---|---|
+| Basic catch — open sheet → saved and on screen | **225 ms** |
+| Repeat catch — seeded species → saved | **47 ms** |
+| Quick mark — tap → acknowledged | **46 ms** |
+| Catch saved with the network **fully off** | **83 ms** |
+| 10,000 catches — log opens | **655 ms**, 433 DOM nodes |
+| 10,000 catches — search keystroke → repaint | **97 ms** |
+| 10,000 catches — logging one more | **719 ms** |
+
+The 5–10 second target in §2 is a *human* budget; the app's share of it is about a fifth
+of a second. The list pages at 50, so the DOM stays small however long the history gets.
+
+## Checks
+
+- `npm run verify` green — tokens, tripwires, lint, tsc, **265 tests**. `npm run build`
+  green, `/log` static.
+- **32 functional browser checks** at 390×844, zero console errors: the full log/repeat/
+  duplicate/delete/favorite/search path, the mark landing in the needs-details queue, no
+  horizontal overflow at 390 px and 320 px, every visible control clearing a 44 px touch
+  floor.
+- **19 harder checks**: a catch saved with the network completely off and still present
+  after reload; 10,000-catch scale; and a keyboard-only sweep including focus moving to
+  "Keep it" when the delete confirm opens rather than falling to `<body>`.
+- **The migration was run against a real PostgreSQL 16**, not eyeballed: all six
+  migrations apply in order; deleting a tackle item leaves the catch's gear label intact
+  with the link nulled (§15); blank labels and unknown roles are refused; two jigs on one
+  catch are allowed; RLS blocks cross-angler read, insert and delete; `anon` has nothing.
+- **Not tested on a real phone.** Same open item as the tide chart and the Tackle Box.
+
+## Deviations from the spec, stated plainly
+
+1. **No `tags`/`catch_tags` tables.** Tags are a `text[]` on the catch locally. §27 says
+   tags should stay flexible and there is no tag UI yet; a join table with no writer is
+   speculative schema. It graduates by ADR when something actually filters on it.
+2. **`catch.tackle_item_id` was kept** rather than replaced by `catch_gear`. Removing it
+   would break D21a rig inheritance and the shipped analytics views for no gain.
+3. **Enrichment is `partial`, not `pending`**, when a position fix exists — because the
+   on-device astro fields are genuinely observed. This is a deliberate refinement of
+   PLAN §1's "everything lands pending", explained above.
+4. **The prototype writes as one hard-coded local angler.** There is no auth session
+   wired to the log yet, so `LOCAL_ANGLER_ID` stands in. The RLS that makes this safe on
+   the server is in place and verified; the client simply has no session to read yet.
+
+## Not built (and deliberately so)
+
+- **The outbox flusher.** The envelope, the retry schedule, the conflict rules and the
+  "what the glass may say" states are implemented and tested; the code that actually
+  PUSHes to PostgREST and pulls with the `updated_at` cursor is not. It cannot be
+  written honestly without a live backend to test against, and a sync layer that has
+  never round-tripped is worse than none, because it looks finished. Writes queue
+  durably in the meantime and nothing is lost.
+- **Editing a catch's timestamp** (§22's "if catch time changes, the environmental data
+  must not silently remain attached as if it were correct"). Edit-by-duplicate covers
+  correcting a record today. Time editing needs the snapshot to be invalidated and
+  re-derived with it, which is the enrichment lane's job.
+- **Trip UI.** Trips are created and joined implicitly and correctly; there is no screen
+  for starting, ending, naming or reviewing one yet. `/trip/[id]` is still a stub.
+- **Spot picking, batch quantity beyond a stepper, and the calendar's catch counts.**
+- Everything in §45, which is explicitly out.

--- a/docs/team/worklog/2026-09-01-01-head-dev.md
+++ b/docs/team/worklog/2026-09-01-01-head-dev.md
@@ -1,0 +1,45 @@
+### 2026-09-01 | head-dev | Fish Log MVP — local-first catch logging
+
+Built the Fish Log against the founder's specification of 2026-09-01. Full write-up in
+`docs/design/09-fish-log.md`; this is what happened and what is worth knowing.
+
+- **It was not a schema project.** The spec (§38/§47/§48) asks for a data model review
+  before building tables, and lists seven entities. Six already exist in the V1 core
+  schema and are better specified than the sketch — mark lifecycle (D22), sticky rig
+  (D21a), local-date bucketing, soft deletes, sync columns, RLS. So this is a UI and
+  local-store slice on the existing ontology, with **one** additive migration:
+  `catch_gear`, because §14 is explicit that a catch must not be modelled around a
+  single `gear_id` and `catch.tackle_item_id` is one lure. That column stays and is
+  still written — D21a inheritance and the analytics views read it.
+- **§15 is enforced by the FK, not by hope.** Gear rows carry `tackle_item_id` *and* a
+  `label`/`detail` snapshot, with `ON DELETE SET NULL`. Deleting a tackle item six
+  months later leaves the catch's record of what was tied on intact. Verified against a
+  real PostgreSQL 16 — all six migrations applied in order, plus behaviour and RLS tests
+  (cross-angler read/insert/delete blocked, `anon` has nothing).
+- **The bug worth reading about.** The first build warmed the GPS on sheet open and then
+  *awaited the fix at save time*. With no recent fix that is the full timeout — four
+  seconds of nothing, against a five-to-ten-second target for the whole catch, and a
+  straight breach of §21. Found by measuring the save, not by reading the code. The
+  position is now read and never awaited; a fix that arrives later is patched on. Basic
+  catch is now 225 ms, repeat 47 ms, quick mark 46 ms, and 83 ms with the network off.
+- **A second bug the compiler could not see.** `RepeatSeed` speaks column names and
+  `CatchDraft` speaks form-field names; spreading one into the other type-checks and
+  silently drops every value, so Duplicate opened with no species. Caught in the browser.
+  There is now an explicit mapper and a test that fails if a snake_case key ever appears
+  on a draft again.
+- **The quick mark is wired.** The shell button has read "wired when logging lands"
+  since the shell round. It writes an `unresolved` row — no species, no outcome, out of
+  every rate until a human says what happened — and returns in 46 ms.
+- **Scale was measured, not assumed** (§41): 10,000 catches, log opens in 655 ms with
+  433 DOM nodes, search keystroke to repaint 97 ms, logging one more 719 ms.
+- **What is deliberately not built:** the outbox *flusher*. The envelope, retry
+  schedule, conflict policy and glass vocabulary are implemented and tested, but the
+  code that actually pushes to PostgREST is not — it cannot be written honestly without
+  a live backend to round-trip against, and a sync layer that has never synced is worse
+  than none because it looks finished. Writes queue durably; nothing is lost. Also not
+  built: catch-time editing (§22 needs the snapshot invalidated with it), trip UI, spot
+  picking.
+- **Not tested on a real phone.** Same open item as the tide chart and the Tackle Box.
+- Checks: `npm run verify` green (265 tests) and `npm run build` green; 32 functional
+  browser checks at 390×844 with zero console errors; 19 harder ones covering a fully
+  offline save, 10,000-catch scale, and a keyboard-only sweep.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/ssr": "^0.12.5",
         "@supabase/supabase-js": "^2.112.4",
+        "idb": "^8.0.3",
         "next": "16.3.3",
         "react": "19.2.8",
         "react-dom": "19.2.8"
@@ -5260,6 +5261,12 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@supabase/ssr": "^0.12.5",
     "@supabase/supabase-js": "^2.112.4",
+    "idb": "^8.0.3",
     "next": "16.3.3",
     "react": "19.2.8",
     "react-dom": "19.2.8"

--- a/src/app/(app)/log/page.tsx
+++ b/src/app/(app)/log/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+
+import { FishLog } from "@/features/catches/components/fish-log";
+
+export const metadata: Metadata = { title: "Fish Log | Fish Log Book" };
+
+/**
+ * /log — the Fish Log home (spec §8).
+ *
+ * A thin route, per ADR 003 §2: the page wires, the feature thinks. The whole surface is
+ * client-rendered because every read comes from the device's own database (ADR 004 §1)
+ * and there is nothing for a server to render.
+ */
+export default function FishLogPage() {
+  // Unit preference lives on `angler.unit_preference` and is not wired to a session yet;
+  // imperial is the documented default (see the schema's `angler` table).
+  return <FishLog unitSystem="imperial" />;
+}

--- a/src/core/ontology/species.ts
+++ b/src/core/ontology/species.ts
@@ -1,0 +1,101 @@
+/**
+ * The species vocabulary (ontology §7, seeded by
+ * `supabase/migrations/20260828120300_v1_seed_vocabularies.sql`).
+ *
+ * Mirrored into TypeScript rather than fetched, because the species picker is the one
+ * screen that absolutely must work with no signal — it is the only required field on a
+ * catch (spec §4) and the boat is offshore. The vocabulary is versioned server-side
+ * (`vocabulary_version`) and this copy is the offline floor, not a second source of
+ * truth: when the vocabulary endpoint lands it overwrites this list in the local store.
+ *
+ * Ids are the stable text codes from the migration. Spec §5 is explicit that species use
+ * persistent ids and never raw text; `species_other` exists for the genuine unknown and
+ * is deliberately a separate column so it can never be mistaken for one of these.
+ *
+ * KEEP IN STEP: `species.test.ts` fails if an id here is missing from the migration.
+ */
+
+export type WaterClass = "salt" | "fresh";
+export type TakeStatus = "open" | "protected" | "regulated";
+
+export interface Species {
+  readonly id: string;
+  readonly commonName: string;
+  readonly scientificName: string | null;
+  /** A roll-up like "Rockfish" — pickable when the angler cannot get more specific. */
+  readonly isGroup: boolean;
+  readonly rollsUpTo: string | null;
+  readonly waterClass: WaterClass;
+  readonly takeStatus: TakeStatus;
+  readonly sortOrder: number;
+}
+
+export const SPECIES: readonly Species[] = [
+  { id: "rockfish", commonName: "Rockfish", scientificName: "Sebastes spp.", isGroup: true, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 10 },
+  { id: "surfperch", commonName: "Surfperch", scientificName: "Embiotocidae", isGroup: true, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 11 },
+  { id: "croaker", commonName: "Croaker", scientificName: "Sciaenidae", isGroup: true, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 12 },
+  { id: "california_halibut", commonName: "California halibut", scientificName: "Paralichthys californicus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 100 },
+  { id: "barred_sand_bass", commonName: "Barred sand bass", scientificName: "Paralabrax nebulifer", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 101 },
+  { id: "spotted_sand_bass", commonName: "Spotted sand bass", scientificName: "Paralabrax maculatofasciatus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 102 },
+  { id: "kelp_bass", commonName: "Kelp bass (calico)", scientificName: "Paralabrax clathratus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 103 },
+  { id: "california_corbina", commonName: "California corbina", scientificName: "Menticirrhus undulatus", isGroup: false, rollsUpTo: "croaker", waterClass: "salt", takeStatus: "open", sortOrder: 104 },
+  { id: "barred_surfperch", commonName: "Barred surfperch", scientificName: "Amphistichus argenteus", isGroup: false, rollsUpTo: "surfperch", waterClass: "salt", takeStatus: "open", sortOrder: 105 },
+  { id: "walleye_surfperch", commonName: "Walleye surfperch", scientificName: "Hyperprosopon argenteum", isGroup: false, rollsUpTo: "surfperch", waterClass: "salt", takeStatus: "open", sortOrder: 106 },
+  { id: "yellowfin_croaker", commonName: "Yellowfin croaker", scientificName: "Umbrina roncador", isGroup: false, rollsUpTo: "croaker", waterClass: "salt", takeStatus: "open", sortOrder: 107 },
+  { id: "spotfin_croaker", commonName: "Spotfin croaker", scientificName: "Roncador stearnsii", isGroup: false, rollsUpTo: "croaker", waterClass: "salt", takeStatus: "open", sortOrder: 108 },
+  { id: "white_croaker", commonName: "White croaker (tomcod)", scientificName: "Genyonemus lineatus", isGroup: false, rollsUpTo: "croaker", waterClass: "salt", takeStatus: "open", sortOrder: 109 },
+  { id: "queenfish", commonName: "Queenfish", scientificName: "Seriphus politus", isGroup: false, rollsUpTo: "croaker", waterClass: "salt", takeStatus: "open", sortOrder: 110 },
+  { id: "sargo", commonName: "Sargo", scientificName: "Anisotremus davidsonii", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 111 },
+  { id: "opaleye", commonName: "Opaleye", scientificName: "Girella nigricans", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 112 },
+  { id: "halfmoon", commonName: "Halfmoon", scientificName: "Medialuna californiensis", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 113 },
+  { id: "jacksmelt", commonName: "Jacksmelt", scientificName: "Atherinopsis californiensis", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 114 },
+  { id: "round_stingray", commonName: "Round stingray", scientificName: "Urobatis halleri", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 115 },
+  { id: "shovelnose_guitarfish", commonName: "Shovelnose guitarfish", scientificName: "Pseudobatos productus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 116 },
+  { id: "leopard_shark", commonName: "Leopard shark", scientificName: "Triakis semifasciata", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 117 },
+  { id: "bat_ray", commonName: "Bat ray", scientificName: "Myliobatis californica", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 118 },
+  { id: "horn_shark", commonName: "Horn shark", scientificName: "Heterodontus francisci", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 119 },
+  { id: "california_sheephead", commonName: "California sheephead", scientificName: "Bodianus pulcher", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 200 },
+  { id: "california_scorpionfish", commonName: "California scorpionfish (sculpin)", scientificName: "Scorpaena guttata", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 201 },
+  { id: "lingcod", commonName: "Lingcod", scientificName: "Ophiodon elongatus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 202 },
+  { id: "cabezon", commonName: "Cabezon", scientificName: "Scorpaenichthys marmoratus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 203 },
+  { id: "pacific_sanddab", commonName: "Pacific sanddab", scientificName: "Citharichthys sordidus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 204 },
+  { id: "garibaldi", commonName: "Garibaldi", scientificName: "Hypsypops rubicundus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "protected", sortOrder: 205 },
+  { id: "yellowtail", commonName: "Yellowtail", scientificName: "Seriola dorsalis", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 300 },
+  { id: "white_seabass", commonName: "White seabass", scientificName: "Atractoscion nobilis", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 301 },
+  { id: "pacific_bonito", commonName: "Pacific bonito", scientificName: "Sarda chiliensis", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 302 },
+  { id: "pacific_barracuda", commonName: "Pacific barracuda", scientificName: "Sphyraena argentea", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 303 },
+  { id: "pacific_mackerel", commonName: "Pacific mackerel", scientificName: "Scomber japonicus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 304 },
+  { id: "jack_mackerel", commonName: "Jack mackerel", scientificName: "Trachurus symmetricus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 305 },
+  { id: "bluefin_tuna", commonName: "Bluefin tuna", scientificName: "Thunnus orientalis", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 306 },
+  { id: "yellowfin_tuna", commonName: "Yellowfin tuna", scientificName: "Thunnus albacares", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 307 },
+  { id: "dorado", commonName: "Dorado", scientificName: "Coryphaena hippurus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 308 },
+  { id: "thresher_shark", commonName: "Thresher shark", scientificName: "Alopias vulpinus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 309 },];
+
+const BY_ID = new Map(SPECIES.map((s) => [s.id, s]));
+
+export function speciesById(id: string | null): Species | null {
+  return id === null ? null : (BY_ID.get(id) ?? null);
+}
+
+/** Display name for a catch: the vocabulary name, the angler's own text, or nothing. */
+export function speciesLabel(id: string | null, other: string | null): string | null {
+  return speciesById(id)?.commonName ?? (other?.trim() || null);
+}
+
+/**
+ * Species matching for the picker. Matches common name, scientific name and the
+ * shorthand anglers actually type — "calico" finds Kelp bass because the seeded common
+ * name carries it in parentheses.
+ */
+export function searchSpecies(
+  query: string,
+  waterClass: WaterClass | null = null,
+): readonly Species[] {
+  const tokens = query.toLowerCase().split(/\s+/).filter(Boolean);
+  return SPECIES.filter((species) => {
+    if (waterClass !== null && species.waterClass !== waterClass) return false;
+    if (tokens.length === 0) return true;
+    const text = `${species.commonName} ${species.scientificName ?? ""}`.toLowerCase();
+    return tokens.every((token) => text.includes(token));
+  }).slice().sort((a, b) => a.sortOrder - b.sortOrder);
+}

--- a/src/core/rules/catch/measurement.ts
+++ b/src/core/rules/catch/measurement.ts
@@ -1,0 +1,102 @@
+/**
+ * Measurements: what the angler types, and what gets stored (spec §23, §24).
+ *
+ * `core/` is SI (see `core/units.ts`). The schema stores `weight_g`, `length_mm` and
+ * `depth_fished_m`, so pounds-and-ounces exist only at the two edges: parsing what was
+ * typed, and rendering it back. Everything between is one number in one unit.
+ *
+ * Two rules here are analytics decisions, not formatting ones:
+ *
+ *   - **Round-tripping is lossy on purpose.** 84 lb stored as 38102 g renders back as
+ *     84.0 lb, not 84. The stored value is the fact; the display precision is a choice
+ *     made at the glass.
+ *   - **Estimated is not measured** (spec §24). `size_estimated` travels with the value
+ *     rather than being inferred later from a round number, because "80 lb" from a
+ *     boga grip and "about 80" from an eyeball are different observations and a future
+ *     correlation must be able to weight them differently.
+ */
+
+export type WeightUnit = "lb" | "kg";
+export type LengthUnit = "in" | "cm";
+export type DepthUnit = "ft" | "m";
+
+const GRAMS_PER_LB = 453.59237;
+const GRAMS_PER_OZ = 28.349523125;
+const GRAMS_PER_KG = 1000;
+const MM_PER_IN = 25.4;
+const MM_PER_CM = 10;
+const M_PER_FT = 0.3048;
+
+/** Guards every parse. NaN, Infinity and negatives are not measurements (spec §40). */
+function finitePositive(value: number): number | null {
+  return Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+/**
+ * Pounds (and optional ounces) or kilograms to whole grams.
+ * Ounces are accepted alongside pounds because that is how a scale reads out; they are
+ * not a separate unit choice.
+ */
+export function weightToGrams(value: number, unit: WeightUnit, ounces = 0): number | null {
+  const whole = finitePositive(value);
+  const oz = finitePositive(ounces);
+  if (whole === null || oz === null) return null;
+  if (unit === "kg") {
+    if (oz > 0) return null; // kg-and-ounces is not a thing anybody means
+    return Math.round(whole * GRAMS_PER_KG);
+  }
+  return Math.round(whole * GRAMS_PER_LB + oz * GRAMS_PER_OZ);
+}
+
+export function gramsToWeight(grams: number, unit: WeightUnit): number {
+  return unit === "kg" ? grams / GRAMS_PER_KG : grams / GRAMS_PER_LB;
+}
+
+/** Grams as pounds and remainder ounces, for imperial display. */
+export function gramsToPoundsOunces(grams: number): { lb: number; oz: number } {
+  const totalOunces = grams / GRAMS_PER_OZ;
+  const lb = Math.floor(totalOunces / 16);
+  const oz = totalOunces - lb * 16;
+  // 15.97 oz displayed to one decimal is "16.0 oz", which reads as a bug. Carry it.
+  if (Math.round(oz * 10) / 10 >= 16) return { lb: lb + 1, oz: 0 };
+  return { lb, oz: Math.round(oz * 10) / 10 };
+}
+
+export function lengthToMillimetres(value: number, unit: LengthUnit): number | null {
+  const length = finitePositive(value);
+  if (length === null) return null;
+  return Math.round(length * (unit === "cm" ? MM_PER_CM : MM_PER_IN));
+}
+
+export function millimetresToLength(mm: number, unit: LengthUnit): number {
+  return unit === "cm" ? mm / MM_PER_CM : mm / MM_PER_IN;
+}
+
+/** Depth is stored as fractional metres (numeric(6,2)), not rounded to whole units. */
+export function depthToMetres(value: number, unit: DepthUnit): number | null {
+  const depth = finitePositive(value);
+  if (depth === null) return null;
+  return Math.round(depth * (unit === "m" ? 1 : M_PER_FT) * 100) / 100;
+}
+
+export function metresToDepth(m: number, unit: DepthUnit): number {
+  return unit === "m" ? m : m / M_PER_FT;
+}
+
+/**
+ * Parse a typed measurement string. Deliberately forgiving about what a wet thumb
+ * produces — "84", "84.5", " 84 ", "84lb" — and deliberately strict about everything
+ * else, because a silently-misparsed weight is worse than a rejected one.
+ *
+ * Returns `null` for empty input (the field is optional) and `undefined` for input that
+ * was typed but is not a number, so a caller can tell "left blank" from "typed wrong".
+ */
+export function parseMeasurement(raw: string): number | null | undefined {
+  const trimmed = raw.trim();
+  if (trimmed === "") return null;
+  // Strip a trailing unit the angler may have typed; the unit comes from the toggle.
+  const numeric = trimmed.replace(/\s*(lb|lbs|kg|in|cm|ft|m|oz)\s*$/i, "").trim();
+  if (numeric === "" || !/^\d*\.?\d+$/.test(numeric)) return undefined;
+  const parsed = Number.parseFloat(numeric);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}

--- a/src/core/rules/catch/rules.test.ts
+++ b/src/core/rules/catch/rules.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it } from "vitest";
+
+import vectors from "../vectors/catch-rules.json";
+import {
+  depthToMetres,
+  gramsToPoundsOunces,
+  lengthToMillimetres,
+  parseMeasurement,
+  weightToGrams,
+  type DepthUnit,
+  type LengthUnit,
+  type WeightUnit,
+} from "./measurement";
+import {
+  applyRig,
+  canTransitionResolution,
+  isCountable,
+  localDateOf,
+  repeatSeedFrom,
+  sortGear,
+  validateCatch,
+} from "./rules";
+import type { CatchGear, CatchRecord, RigRecord } from "./types";
+
+const NOW = "2026-08-20T21:12:00.000Z";
+
+function makeCatch(overrides: Partial<CatchRecord> = {}): CatchRecord {
+  return {
+    id: "0198d9c1-9800-7000-8000-000000000001",
+    angler_id: "angler-1",
+    trip_id: "trip-1",
+    caught_at: NOW,
+    caught_tz: "America/Los_Angeles",
+    local_date: "2026-08-20",
+    lat: null,
+    lng: null,
+    gps_accuracy_m: null,
+    resolution_state: "confirmed",
+    dismissed_reason: null,
+    resolved_at: NOW,
+    species_id: "bluefin_tuna",
+    species_other: null,
+    outcome: "landed",
+    disposition: "kept",
+    quantity: 1,
+    length_mm: null,
+    weight_g: 38102,
+    size_estimated: false,
+    spot_id: null,
+    platform: null,
+    depth_fished_m: 76.2,
+    rig_id: null,
+    rig_revision: null,
+    inherited_fields: [],
+    presentation: null,
+    notes: null,
+    tags: [],
+    favorite: false,
+    capture_mode: "live",
+    client_created_at: NOW,
+    created_at: NOW,
+    client_updated_at: NOW,
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+const gear = (role: CatchGear["role"], label: string): CatchGear => ({
+  id: `gear-${role}`,
+  catch_id: "c1",
+  angler_id: "angler-1",
+  tackle_item_id: `tackle-${role}`,
+  role,
+  label,
+  detail: null,
+  created_at: NOW,
+  deleted_at: null,
+});
+
+describe("localDateOf — vectors", () => {
+  for (const v of vectors.localDate) {
+    it(v.name, () => {
+      expect(localDateOf(v.instant, v.zone)).toBe(v.expected);
+    });
+  }
+});
+
+describe("isCountable — vectors", () => {
+  for (const v of vectors.countable) {
+    it(v.name, () => {
+      const record = makeCatch({
+        resolution_state: v.resolution_state as CatchRecord["resolution_state"],
+        outcome: v.outcome as CatchRecord["outcome"],
+        resolved_at: v.resolution_state === "unresolved" ? null : NOW,
+        dismissed_reason: v.resolution_state === "dismissed" ? "mistap" : null,
+        deleted_at: v.deleted ? NOW : null,
+      });
+      expect(isCountable(record)).toBe(v.expected);
+    });
+  }
+});
+
+describe("resolution transitions — vectors (D22)", () => {
+  for (const v of vectors.resolutionTransitions) {
+    it(`${v.from} -> ${v.to} is ${v.allowed ? "allowed" : "refused"}`, () => {
+      expect(
+        canTransitionResolution(
+          v.from as CatchRecord["resolution_state"],
+          v.to as CatchRecord["resolution_state"],
+        ),
+      ).toBe(v.allowed);
+    });
+  }
+});
+
+describe("measurement — vectors", () => {
+  for (const v of vectors.measurement) {
+    it(v.name, () => {
+      expect(weightToGrams(v.value, v.unit as WeightUnit, v.ounces)).toBe(v.expectedGrams);
+    });
+  }
+  for (const v of vectors.length) {
+    it(v.name, () => {
+      expect(lengthToMillimetres(v.value, v.unit as LengthUnit)).toBe(v.expectedMm);
+    });
+  }
+  for (const v of vectors.depth) {
+    it(v.name, () => {
+      expect(depthToMetres(v.value, v.unit as DepthUnit)).toBe(v.expectedMetres);
+    });
+  }
+});
+
+describe("measurement edges", () => {
+  it("carries 15.99 oz up to the next pound rather than printing 16.0 oz", () => {
+    const justUnderAPound = Math.round(15.99 * 28.349523125);
+    expect(gramsToPoundsOunces(justUnderAPound)).toEqual({ lb: 1, oz: 0 });
+  });
+
+  it("refuses kilograms-and-ounces, which nobody means", () => {
+    expect(weightToGrams(3, "kg", 4)).toBeNull();
+  });
+
+  it("distinguishes blank from unparseable", () => {
+    expect(parseMeasurement("")).toBeNull();
+    expect(parseMeasurement("   ")).toBeNull();
+    expect(parseMeasurement("heavy")).toBeUndefined();
+    expect(parseMeasurement("84")).toBe(84);
+    expect(parseMeasurement(" 84.5 lb ")).toBe(84.5);
+    expect(parseMeasurement(".5")).toBe(0.5);
+  });
+
+  it("rejects NaN and Infinity", () => {
+    expect(weightToGrams(Number.NaN, "lb")).toBeNull();
+    expect(weightToGrams(Number.POSITIVE_INFINITY, "lb")).toBeNull();
+  });
+});
+
+describe("validateCatch — spec §40", () => {
+  it("passes a well-formed catch", () => {
+    expect(validateCatch(makeCatch())).toEqual([]);
+  });
+
+  it("rejects quantity below one", () => {
+    expect(validateCatch(makeCatch({ quantity: 0 }))).toContain("quantity_below_one");
+  });
+
+  it("rejects a fractional quantity", () => {
+    expect(validateCatch(makeCatch({ quantity: 1.5 }))).toContain("quantity_below_one");
+  });
+
+  it("rejects negative measurements", () => {
+    const errors = validateCatch(
+      makeCatch({ weight_g: -1, length_mm: -1, depth_fished_m: -1 }),
+    );
+    expect(errors).toContain("negative_weight");
+    expect(errors).toContain("negative_length");
+    expect(errors).toContain("negative_depth");
+  });
+
+  it("rejects an invalid timestamp", () => {
+    expect(validateCatch(makeCatch({ caught_at: "not a date" }))).toContain("invalid_timestamp");
+  });
+
+  it("mirrors the confirmed-needs-outcome constraint", () => {
+    expect(validateCatch(makeCatch({ outcome: null }))).toContain("confirmed_needs_outcome");
+  });
+
+  it("mirrors the dismissed-needs-reason constraint", () => {
+    const errors = validateCatch(
+      makeCatch({ resolution_state: "dismissed", outcome: null, dismissed_reason: null }),
+    );
+    expect(errors).toContain("dismissed_needs_reason");
+  });
+
+  it("rejects a reason without a dismissal", () => {
+    expect(validateCatch(makeCatch({ dismissed_reason: "mistap" }))).toContain(
+      "reason_without_dismissal",
+    );
+  });
+
+  it("rejects resolved_at disagreeing with the state", () => {
+    expect(validateCatch(makeCatch({ resolution_state: "unresolved", outcome: null }))).toContain(
+      "resolved_state_mismatch",
+    );
+  });
+
+  it("reports every problem at once rather than the first", () => {
+    expect(validateCatch(makeCatch({ quantity: 0, weight_g: -5 })).length).toBe(2);
+  });
+});
+
+describe("applyRig — D21a", () => {
+  const rig: RigRecord = {
+    id: "rig-1",
+    angler_id: "angler-1",
+    trip_id: "trip-1",
+    revision: 2,
+    effective_from: NOW,
+    spot_id: "spot-1",
+    platform: "boat",
+    depth_fished_m: 76.2,
+    gear: [
+      { angler_id: "angler-1", tackle_item_id: "t1", role: "jig", label: "Nomad Streaker 200g", detail: "Pink" },
+    ],
+    created_at: NOW,
+  };
+
+  it("fills absent fields from the standing rig and records what it supplied", () => {
+    const result = applyRig({}, rig, "c1", NOW);
+    expect(result.spot_id).toBe("spot-1");
+    expect(result.platform).toBe("boat");
+    expect(result.depth_fished_m).toBe(76.2);
+    expect(result.rig_revision).toBe(2);
+    expect(result.inherited_fields).toEqual(["spot_id", "platform", "depth_fished_m", "gear"]);
+  });
+
+  it("never overrides what the angler typed", () => {
+    const result = applyRig({ depth_fished_m: 30 }, rig, "c1", NOW);
+    expect(result.depth_fished_m).toBe(30);
+    expect(result.inherited_fields).not.toContain("depth_fished_m");
+  });
+
+  it("copies rig gear onto the catch so a later rig change cannot rewrite it", () => {
+    const result = applyRig({}, rig, "c1", NOW);
+    expect(result.gear).toHaveLength(1);
+    expect(result.gear[0].catch_id).toBe("c1");
+    expect(result.gear[0].label).toBe("Nomad Streaker 200g");
+  });
+
+  it("with no rig, inherits nothing and claims nothing", () => {
+    const result = applyRig({ platform: "shore" }, null, "c1", NOW);
+    expect(result.platform).toBe("shore");
+    expect(result.inherited_fields).toEqual([]);
+    expect(result.rig_id).toBeNull();
+  });
+});
+
+describe("repeatSeedFrom — spec §6/§7", () => {
+  const previous = makeCatch({ weight_g: 38102, length_mm: 900, notes: "meter marks at 250" });
+
+  it("carries how you were fishing", () => {
+    const seed = repeatSeedFrom(previous, [gear("jig", "Nomad Streaker 200g")]);
+    expect(seed.species_id).toBe("bluefin_tuna");
+    expect(seed.depth_fished_m).toBe(76.2);
+    expect(seed.gear).toHaveLength(1);
+  });
+
+  it("does NOT carry this particular fish", () => {
+    const seed = repeatSeedFrom(previous, []) as unknown as Record<string, unknown>;
+    expect(seed.weight_g).toBeUndefined();
+    expect(seed.length_mm).toBeUndefined();
+    expect(seed.notes).toBeUndefined();
+  });
+});
+
+describe("sortGear", () => {
+  it("reads a rig top to bottom, rod first", () => {
+    const sorted = sortGear([gear("jig", "j"), gear("rod", "r"), gear("leader", "l")]);
+    expect(sorted.map((g) => g.role)).toEqual(["rod", "leader", "jig"]);
+  });
+});

--- a/src/core/rules/catch/rules.ts
+++ b/src/core/rules/catch/rules.ts
@@ -1,0 +1,289 @@
+/**
+ * The catch rules that both clients must agree on (ADR 003 §3). Pure, no I/O, vector
+ * -policed by `src/core/rules/vectors/catch-rules.json`.
+ *
+ * Everything here answers one of three questions:
+ *   - which fields does a new catch inherit, and from where (D21a, spec §6/§7);
+ *   - is this row allowed to exist (spec §40);
+ *   - which calendar day does it belong to (ontology §2.1).
+ */
+
+import type {
+  CatchGear,
+  CatchRecord,
+  Disposition,
+  GearRole,
+  Outcome,
+  RigRecord,
+} from "./types";
+
+// ---------------------------------------------------------------------------------
+// Day bucketing (ontology §2.1)
+// ---------------------------------------------------------------------------------
+
+/**
+ * The local calendar date an instant belongs to, in `zone`.
+ *
+ * A 01:30 halibut belongs to the 30th if that is what the clock on the boat said, not
+ * to whatever UTC thinks. `Intl` does the zone arithmetic — hand-rolling an offset table
+ * is how DST bugs get written.
+ */
+export function localDateOf(isoInstant: string, zone: string): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: zone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date(isoInstant));
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? "";
+  return `${get("year")}-${get("month")}-${get("day")}`;
+}
+
+// ---------------------------------------------------------------------------------
+// Rig inheritance (D21a, spec §6)
+// ---------------------------------------------------------------------------------
+
+/** The catch fields a standing rig can supply. */
+export const INHERITABLE_FIELDS = ["spot_id", "platform", "depth_fished_m"] as const;
+export type InheritableField = (typeof INHERITABLE_FIELDS)[number];
+
+export interface InheritedRig {
+  readonly spot_id: string | null;
+  readonly platform: string | null;
+  readonly depth_fished_m: number | null;
+  readonly gear: readonly CatchGear[];
+  readonly rig_id: string | null;
+  readonly rig_revision: number | null;
+  /** Which of the above came from the rig rather than the angler's thumb. */
+  readonly inherited_fields: readonly string[];
+}
+
+const EMPTY_RIG: InheritedRig = {
+  spot_id: null,
+  platform: null,
+  depth_fished_m: null,
+  gear: [],
+  rig_id: null,
+  rig_revision: null,
+  inherited_fields: [],
+};
+
+/**
+ * Apply the standing rig to a partially-filled catch.
+ *
+ * A value the angler typed always wins; the rig only fills what is absent. The fields
+ * the rig supplied are recorded in `inherited_fields`, because an inherited value is a
+ * weaker claim than a typed one and the UI has to be able to say so.
+ */
+export function applyRig(
+  typed: {
+    spot_id?: string | null;
+    platform?: string | null;
+    depth_fished_m?: number | null;
+    gear?: readonly CatchGear[];
+  },
+  rig: RigRecord | null,
+  catchId: string,
+  nowIso: string,
+): InheritedRig {
+  if (!rig) {
+    return {
+      ...EMPTY_RIG,
+      spot_id: typed.spot_id ?? null,
+      platform: typed.platform ?? null,
+      depth_fished_m: typed.depth_fished_m ?? null,
+      gear: typed.gear ?? [],
+    };
+  }
+
+  const inherited: string[] = [];
+  const take = <K extends InheritableField>(field: K, typedValue: unknown) => {
+    if (typedValue !== undefined && typedValue !== null) return typedValue;
+    const fromRig = rig[field];
+    if (fromRig !== null && fromRig !== undefined) inherited.push(field);
+    return fromRig ?? null;
+  };
+
+  // Order matters: `inherited_fields` is rendered to the angler as "these came from the
+  // rig", so it is built in the order the fields read on screen, not in evaluation order.
+  const spot_id = take("spot_id", typed.spot_id) as string | null;
+  const platform = take("platform", typed.platform) as string | null;
+  const depth_fished_m = take("depth_fished_m", typed.depth_fished_m) as number | null;
+
+  const gear: readonly CatchGear[] =
+    typed.gear && typed.gear.length > 0
+      ? typed.gear
+      : rig.gear.map((item, index) => {
+          return {
+            ...item,
+            id: `${catchId}-gear-${index}`,
+            catch_id: catchId,
+            created_at: nowIso,
+            deleted_at: null,
+          };
+        });
+  if ((!typed.gear || typed.gear.length === 0) && rig.gear.length > 0) inherited.push("gear");
+
+  return {
+    spot_id,
+    platform,
+    depth_fished_m,
+    gear,
+    rig_id: rig.id,
+    rig_revision: rig.revision,
+    inherited_fields: inherited,
+  };
+}
+
+// ---------------------------------------------------------------------------------
+// Repeat and duplicate (spec §6, §7)
+// ---------------------------------------------------------------------------------
+
+/**
+ * Fields a repeat/duplicate carries over. Everything about *how* you were fishing
+ * repeats; everything about *this particular fish* does not.
+ *
+ * Weight, length and notes are deliberately absent: the second fish is a different fish,
+ * and copying its predecessor's 84 lb forward would manufacture data. That is the whole
+ * reason this list is written down rather than being a spread of the previous row.
+ */
+export const REPEATED_FIELDS = [
+  "species_id",
+  "species_other",
+  "spot_id",
+  "platform",
+  "depth_fished_m",
+  "presentation",
+  "disposition",
+  "outcome",
+  "tags",
+] as const;
+
+export interface RepeatSeed {
+  readonly species_id: string | null;
+  readonly species_other: string | null;
+  readonly spot_id: string | null;
+  readonly platform: string | null;
+  readonly depth_fished_m: number | null;
+  readonly presentation: string | null;
+  readonly disposition: Disposition | null;
+  readonly outcome: Outcome | null;
+  readonly tags: readonly string[];
+  readonly gear: readonly CatchGear[];
+}
+
+/**
+ * What "+ Log another" starts from. The caller mints a new id and a new timestamp — this
+ * function deliberately cannot, so there is no way to produce a repeat that silently
+ * shares its parent's identity or moment.
+ */
+export function repeatSeedFrom(previous: CatchRecord, gear: readonly CatchGear[]): RepeatSeed {
+  return {
+    species_id: previous.species_id,
+    species_other: previous.species_other,
+    spot_id: previous.spot_id,
+    platform: previous.platform,
+    depth_fished_m: previous.depth_fished_m,
+    presentation: previous.presentation,
+    disposition: previous.disposition,
+    outcome: previous.outcome,
+    tags: previous.tags,
+    gear,
+  };
+}
+
+// ---------------------------------------------------------------------------------
+// Integrity (spec §40)
+// ---------------------------------------------------------------------------------
+
+export type ValidationError =
+  | "quantity_below_one"
+  | "negative_weight"
+  | "negative_length"
+  | "negative_depth"
+  | "invalid_timestamp"
+  | "confirmed_needs_outcome"
+  | "dismissed_needs_reason"
+  | "reason_without_dismissal"
+  | "resolved_state_mismatch";
+
+/**
+ * The client-side half of the database's CHECK constraints. Duplicated on purpose: the
+ * constraints are the truth (ADR 003 §3) and this is the fast, local, legible failure so
+ * an angler learns at the glass instead of at flush time, six hours later.
+ *
+ * Returned as a list, not a throw: a form shows every problem at once.
+ */
+export function validateCatch(record: CatchRecord): readonly ValidationError[] {
+  const errors: ValidationError[] = [];
+
+  if (!Number.isInteger(record.quantity) || record.quantity < 1) errors.push("quantity_below_one");
+  if (record.weight_g !== null && record.weight_g < 0) errors.push("negative_weight");
+  if (record.length_mm !== null && record.length_mm < 0) errors.push("negative_length");
+  if (record.depth_fished_m !== null && record.depth_fished_m < 0) errors.push("negative_depth");
+  if (Number.isNaN(Date.parse(record.caught_at))) errors.push("invalid_timestamp");
+
+  if (record.resolution_state === "confirmed" && record.outcome === null) {
+    errors.push("confirmed_needs_outcome");
+  }
+  if (record.resolution_state === "dismissed" && record.dismissed_reason === null) {
+    errors.push("dismissed_needs_reason");
+  }
+  if (record.resolution_state !== "dismissed" && record.dismissed_reason !== null) {
+    errors.push("reason_without_dismissal");
+  }
+  if ((record.resolution_state === "unresolved") !== (record.resolved_at === null)) {
+    errors.push("resolved_state_mismatch");
+  }
+
+  return errors;
+}
+
+/**
+ * D22: a resolved mark never returns to unresolved, and no job resolves one. Only a
+ * human moves a mark. Mirrors `tg_catch_resolution_guard`.
+ */
+export function canTransitionResolution(
+  from: CatchRecord["resolution_state"],
+  to: CatchRecord["resolution_state"],
+): boolean {
+  if (from === to) return true;
+  return to !== "unresolved";
+}
+
+// ---------------------------------------------------------------------------------
+// Countability (D22 / spec §12)
+// ---------------------------------------------------------------------------------
+
+/**
+ * Whether a row may appear in a rate. An unresolved mark is not yet a fact: it is
+ * excluded from every denominator until a human says what it was, and a 2023 mark still
+ * sitting unresolved in 2027 stays excluded. That is correct, not a bug.
+ */
+export function isCountable(record: CatchRecord): boolean {
+  return (
+    record.deleted_at === null &&
+    record.resolution_state === "confirmed" &&
+    record.outcome === "landed"
+  );
+}
+
+/** Gear roles in the order a rig reads top to bottom, rod first. */
+export const GEAR_ROLE_ORDER: readonly GearRole[] = [
+  "rod",
+  "reel",
+  "main_line",
+  "leader",
+  "hook",
+  "lure",
+  "jig",
+  "bait",
+  "weight",
+  "terminal",
+];
+
+export function sortGear(gear: readonly CatchGear[]): readonly CatchGear[] {
+  return [...gear].sort(
+    (a, b) => GEAR_ROLE_ORDER.indexOf(a.role) - GEAR_ROLE_ORDER.indexOf(b.role),
+  );
+}

--- a/src/core/rules/catch/search.test.ts
+++ b/src/core/rules/catch/search.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  filterCatches,
+  groupByLocalDate,
+  matchesQuery,
+  NO_FILTERS,
+  sortByMostRecent,
+  tokenize,
+  type SearchableCatch,
+} from "./search";
+import type { CatchGear, CatchRecord } from "./types";
+
+const NOW = "2026-08-20T21:12:00.000Z";
+
+function record(overrides: Partial<CatchRecord> = {}): CatchRecord {
+  return {
+    id: "c1",
+    angler_id: "a1",
+    trip_id: "t1",
+    caught_at: NOW,
+    caught_tz: "America/Los_Angeles",
+    local_date: "2026-08-20",
+    lat: null,
+    lng: null,
+    gps_accuracy_m: null,
+    resolution_state: "confirmed",
+    dismissed_reason: null,
+    resolved_at: NOW,
+    species_id: "bluefin_tuna",
+    species_other: null,
+    outcome: "landed",
+    disposition: "kept",
+    quantity: 1,
+    length_mm: null,
+    weight_g: null,
+    size_estimated: false,
+    spot_id: null,
+    platform: null,
+    depth_fished_m: null,
+    rig_id: null,
+    rig_revision: null,
+    inherited_fields: [],
+    presentation: null,
+    notes: null,
+    tags: [],
+    favorite: false,
+    capture_mode: "live",
+    client_created_at: NOW,
+    created_at: NOW,
+    client_updated_at: NOW,
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+function item(overrides: Partial<CatchRecord> = {}, extra: Partial<SearchableCatch> = {}): SearchableCatch {
+  return {
+    record: record(overrides),
+    speciesName: "Bluefin tuna",
+    spotName: "Catalina",
+    gear: [],
+    ...extra,
+  };
+}
+
+const gear = (label: string, detail: string | null = null): CatchGear => ({
+  id: "g1",
+  catch_id: "c1",
+  angler_id: "a1",
+  tackle_item_id: null,
+  role: "jig",
+  label,
+  detail,
+  created_at: NOW,
+  deleted_at: null,
+});
+
+describe("tokenize", () => {
+  it("splits on runs of whitespace and drops empties", () => {
+    expect(tokenize("  bluefin   streaker ")).toEqual(["bluefin", "streaker"]);
+    expect(tokenize("   ")).toEqual([]);
+  });
+});
+
+describe("matchesQuery", () => {
+  it("matches on species", () => {
+    expect(matchesQuery(item(), "bluefin")).toBe(true);
+  });
+
+  it("is case insensitive", () => {
+    expect(matchesQuery(item(), "BLUEFIN")).toBe(true);
+  });
+
+  it("matches on gear label", () => {
+    expect(matchesQuery(item({}, { gear: [gear("Nomad Streaker 200g")] }), "streaker")).toBe(true);
+  });
+
+  it("matches on spot", () => {
+    expect(matchesQuery(item(), "catalina")).toBe(true);
+  });
+
+  it("matches on notes and tags", () => {
+    expect(matchesQuery(item({ notes: "meter marks at 250" }), "meter")).toBe(true);
+    expect(matchesQuery(item({ tags: ["night bite"] }), "night")).toBe(true);
+  });
+
+  it("matches the angler's own species text", () => {
+    expect(
+      matchesQuery(item({ species_other: "something silver" }, { speciesName: null }), "silver"),
+    ).toBe(true);
+  });
+
+  it("requires every token, but not all in one field", () => {
+    const subject = item({}, { gear: [gear("Nomad Streaker 200g")] });
+    expect(matchesQuery(subject, "bluefin streaker")).toBe(true);
+    expect(matchesQuery(subject, "bluefin flatfall")).toBe(false);
+  });
+
+  it("an empty query matches everything", () => {
+    expect(matchesQuery(item(), "")).toBe(true);
+  });
+});
+
+describe("filterCatches", () => {
+  it("hides soft-deleted rows", () => {
+    expect(filterCatches([item({ deleted_at: NOW })], NO_FILTERS)).toHaveLength(0);
+  });
+
+  it("favorites view keeps only favorites", () => {
+    const items = [item({ id: "a", favorite: true }), item({ id: "b" })];
+    const result = filterCatches(items, { ...NO_FILTERS, view: "favorites" });
+    expect(result.map((i) => i.record.id)).toEqual(["a"]);
+  });
+
+  it("needs-details view is the unresolved queue (D22)", () => {
+    const items = [
+      item({ id: "a", resolution_state: "unresolved", outcome: null, resolved_at: null }),
+      item({ id: "b" }),
+    ];
+    const result = filterCatches(items, { ...NO_FILTERS, view: "needs_details" });
+    expect(result.map((i) => i.record.id)).toEqual(["a"]);
+  });
+
+  it("filters by species, trip and disposition", () => {
+    const items = [
+      item({ id: "a", species_id: "yellowtail", disposition: "released", trip_id: "t2" }),
+      item({ id: "b" }),
+    ];
+    expect(filterCatches(items, { ...NO_FILTERS, speciesId: "yellowtail" })).toHaveLength(1);
+    expect(filterCatches(items, { ...NO_FILTERS, disposition: "released" })).toHaveLength(1);
+    expect(filterCatches(items, { ...NO_FILTERS, tripId: "t2" })).toHaveLength(1);
+  });
+
+  it("filters by an inclusive date range", () => {
+    const items = [
+      item({ id: "a", local_date: "2026-08-19" }),
+      item({ id: "b", local_date: "2026-08-20" }),
+      item({ id: "c", local_date: "2026-08-21" }),
+    ];
+    const result = filterCatches(items, {
+      ...NO_FILTERS,
+      fromDate: "2026-08-20",
+      toDate: "2026-08-21",
+    });
+    expect(result.map((i) => i.record.id)).toEqual(["b", "c"]);
+  });
+
+  it("combines a view with a query", () => {
+    const items = [
+      item({ id: "a", favorite: true, species_id: "yellowtail" }, { speciesName: "Yellowtail" }),
+      item({ id: "b", favorite: true }),
+    ];
+    const result = filterCatches(items, { ...NO_FILTERS, view: "favorites", query: "yellow" });
+    expect(result.map((i) => i.record.id)).toEqual(["a"]);
+  });
+});
+
+describe("ordering", () => {
+  it("sorts newest first", () => {
+    const items = [
+      item({ id: "old", caught_at: "2026-08-20T10:00:00.000Z" }),
+      item({ id: "new", caught_at: "2026-08-20T20:00:00.000Z" }),
+    ];
+    expect(sortByMostRecent(items).map((i) => i.record.id)).toEqual(["new", "old"]);
+  });
+
+  it("breaks ties on the id, which is mint-ordered", () => {
+    const items = [
+      item({ id: "0198d9c1-9800-7000-8000-00000000000a" }),
+      item({ id: "0198d9c1-9800-7000-8000-00000000000b" }),
+    ];
+    expect(sortByMostRecent(items)[0].record.id.endsWith("b")).toBe(true);
+  });
+
+  it("groups by local date, newest day first", () => {
+    const items = [
+      item({ id: "a", local_date: "2026-08-19" }),
+      item({ id: "b", local_date: "2026-08-20" }),
+      item({ id: "c", local_date: "2026-08-20" }),
+    ];
+    const days = groupByLocalDate(items);
+    expect(days.map((d) => d.date)).toEqual(["2026-08-20", "2026-08-19"]);
+    expect(days[0].items).toHaveLength(2);
+  });
+});

--- a/src/core/rules/catch/search.ts
+++ b/src/core/rules/catch/search.ts
@@ -1,0 +1,123 @@
+/**
+ * Fish Log search and filters (spec §28, §29).
+ *
+ * Multi-token AND across every field an angler might reach for: species, gear, lure,
+ * location, notes, tags. "bluefin streaker" finds the fish caught on that jig; "40 lb
+ * fluoro" finds the leader. Each token must match somewhere, but not all in the same
+ * field — that is what makes two-word searches feel like they read your mind rather
+ * than returning nothing.
+ *
+ * Pure and index-free on purpose: at prototype volumes a linear scan over a filtered
+ * page is faster than any structure we would have to keep in sync, and this is the
+ * function a real index later has to agree with.
+ */
+
+import type { CatchGear, CatchRecord, Disposition } from "./types";
+
+export interface SearchableCatch {
+  readonly record: CatchRecord;
+  readonly speciesName: string | null;
+  readonly spotName: string | null;
+  readonly gear: readonly CatchGear[];
+}
+
+function haystack(item: SearchableCatch): string {
+  const { record } = item;
+  return [
+    item.speciesName ?? "",
+    record.species_other ?? "",
+    item.spotName ?? "",
+    record.notes ?? "",
+    record.presentation ?? "",
+    record.platform ?? "",
+    ...record.tags,
+    ...item.gear.flatMap((g) => [g.label, g.detail ?? "", g.role.replace(/_/g, " ")]),
+  ]
+    .join(" ")
+    .toLowerCase();
+}
+
+export function tokenize(query: string): readonly string[] {
+  return query.toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+export function matchesQuery(item: SearchableCatch, query: string): boolean {
+  const tokens = tokenize(query);
+  if (tokens.length === 0) return true;
+  const text = haystack(item);
+  return tokens.every((token) => text.includes(token));
+}
+
+export type LogView = "all" | "favorites" | "needs_details";
+
+export interface CatchFilters {
+  readonly query: string;
+  readonly view: LogView;
+  readonly speciesId: string | null;
+  readonly spotId: string | null;
+  readonly tripId: string | null;
+  readonly disposition: Disposition | null;
+  /** Inclusive local-date bounds, `YYYY-MM-DD`. */
+  readonly fromDate: string | null;
+  readonly toDate: string | null;
+}
+
+export const NO_FILTERS: CatchFilters = {
+  query: "",
+  view: "all",
+  speciesId: null,
+  spotId: null,
+  tripId: null,
+  disposition: null,
+  fromDate: null,
+  toDate: null,
+};
+
+export function filterCatches(
+  items: readonly SearchableCatch[],
+  filters: CatchFilters,
+): readonly SearchableCatch[] {
+  return items.filter(({ record, ...rest }) => {
+    if (record.deleted_at !== null) return false;
+
+    // `needs_details` is the D22 queue: marks a human has not yet said anything about.
+    if (filters.view === "favorites" && !record.favorite) return false;
+    if (filters.view === "needs_details" && record.resolution_state !== "unresolved") return false;
+
+    if (filters.speciesId !== null && record.species_id !== filters.speciesId) return false;
+    if (filters.spotId !== null && record.spot_id !== filters.spotId) return false;
+    if (filters.tripId !== null && record.trip_id !== filters.tripId) return false;
+    if (filters.disposition !== null && record.disposition !== filters.disposition) return false;
+    if (filters.fromDate !== null && record.local_date < filters.fromDate) return false;
+    if (filters.toDate !== null && record.local_date > filters.toDate) return false;
+
+    return matchesQuery({ record, ...rest }, filters.query);
+  });
+}
+
+/** Newest first. Ties break on the id, which is UUIDv7 and therefore mint-ordered. */
+export function sortByMostRecent(
+  items: readonly SearchableCatch[],
+): readonly SearchableCatch[] {
+  return [...items].sort((a, b) => {
+    if (a.record.caught_at !== b.record.caught_at) {
+      return a.record.caught_at < b.record.caught_at ? 1 : -1;
+    }
+    return a.record.id < b.record.id ? 1 : -1;
+  });
+}
+
+/** Local date -> catches, newest day first. The shape the log and calendar both want. */
+export function groupByLocalDate(
+  items: readonly SearchableCatch[],
+): readonly { date: string; items: readonly SearchableCatch[] }[] {
+  const byDate = new Map<string, SearchableCatch[]>();
+  for (const item of items) {
+    const bucket = byDate.get(item.record.local_date);
+    if (bucket) bucket.push(item);
+    else byDate.set(item.record.local_date, [item]);
+  }
+  return [...byDate.entries()]
+    .sort((a, b) => (a[0] < b[0] ? 1 : -1))
+    .map(([date, dayItems]) => ({ date, items: sortByMostRecent(dayItems) }));
+}

--- a/src/core/rules/catch/types.ts
+++ b/src/core/rules/catch/types.ts
@@ -1,0 +1,132 @@
+/**
+ * The catch record as the local store holds it (spec §39, reconciled with the schema in
+ * `supabase/migrations/20260828120000_v1_core_schema.sql`).
+ *
+ * These names are the *column* names, snake_case, deliberately. This object is the
+ * insert payload the outbox carries to PostgREST unchanged (ADR 004 §3); a camelCase
+ * mirror would mean a mapping layer whose only job is to be wrong once.
+ *
+ * Every field the schema declares NOT NULL is non-optional here, so a row that cannot
+ * be inserted cannot be constructed.
+ */
+
+export type ResolutionState = "unresolved" | "confirmed" | "dismissed";
+export type DismissedReason = "mistap" | "not_a_fish_waypoint" | "duplicate";
+export type Outcome = "landed" | "lost" | "missed_bite" | "short_bite";
+export type Disposition = "kept" | "released" | "n/a";
+export type CaptureMode = "live" | "backfill";
+export type WaterClass = "salt" | "fresh";
+
+/**
+ * Gear on a catch (spec §14). One catch, many pieces of gear, each with a role — the
+ * spec is explicit that a single `gear_id` is the wrong shape.
+ *
+ * `label` and `detail` are a SNAPSHOT taken at the moment of the catch (spec §15). The
+ * angler edits or deletes a tackle item six months later and this row still says what
+ * was actually tied on. `tackle_item_id` keeps the live link for "how has this jig
+ * performed"; the snapshot keeps the history honest when the link dies.
+ */
+export type GearRole =
+  | "rod"
+  | "reel"
+  | "main_line"
+  | "leader"
+  | "hook"
+  | "lure"
+  | "jig"
+  | "bait"
+  | "weight"
+  | "terminal";
+
+export interface CatchGear {
+  readonly id: string;
+  readonly catch_id: string;
+  readonly angler_id: string;
+  readonly tackle_item_id: string | null;
+  readonly role: GearRole;
+  readonly label: string;
+  readonly detail: string | null;
+  readonly created_at: string;
+  readonly deleted_at: string | null;
+}
+
+export interface CatchRecord {
+  readonly id: string;
+  readonly angler_id: string;
+  readonly trip_id: string;
+  readonly caught_at: string;
+  readonly caught_tz: string;
+  readonly local_date: string;
+
+  readonly lat: number | null;
+  readonly lng: number | null;
+  readonly gps_accuracy_m: number | null;
+
+  readonly resolution_state: ResolutionState;
+  readonly dismissed_reason: DismissedReason | null;
+  readonly resolved_at: string | null;
+
+  readonly species_id: string | null;
+  /** Free text for a fish not in the vocabulary (spec §5). Never a substitute for an id. */
+  readonly species_other: string | null;
+  readonly outcome: Outcome | null;
+  readonly disposition: Disposition | null;
+  readonly quantity: number;
+  readonly length_mm: number | null;
+  readonly weight_g: number | null;
+  readonly size_estimated: boolean;
+
+  readonly spot_id: string | null;
+  readonly platform: string | null;
+  readonly depth_fished_m: number | null;
+  readonly rig_id: string | null;
+  readonly rig_revision: number | null;
+  readonly inherited_fields: readonly string[];
+
+  readonly presentation: string | null;
+  readonly notes: string | null;
+  readonly tags: readonly string[];
+  readonly favorite: boolean;
+
+  readonly capture_mode: CaptureMode;
+  readonly client_created_at: string;
+  readonly created_at: string;
+  readonly client_updated_at: string;
+  readonly deleted_at: string | null;
+}
+
+export interface TripRecord {
+  readonly id: string;
+  readonly angler_id: string;
+  readonly spot_id: string | null;
+  readonly water_class: WaterClass;
+  readonly started_at: string;
+  readonly started_tz: string;
+  readonly ended_at: string | null;
+  readonly ended_tz: string | null;
+  readonly local_date: string;
+  readonly platform: string | null;
+  readonly notes: string | null;
+  readonly capture_mode: CaptureMode;
+  readonly client_created_at: string;
+  readonly created_at: string;
+  readonly client_updated_at: string;
+  readonly deleted_at: string | null;
+}
+
+/**
+ * The sticky rig (D21a). Append-only: changing it inserts revision n+1, so a change at
+ * 3pm cannot rewrite what the 11am fish was caught on.
+ */
+export interface RigRecord {
+  readonly id: string;
+  readonly angler_id: string;
+  readonly trip_id: string;
+  readonly revision: number;
+  readonly effective_from: string;
+  readonly spot_id: string | null;
+  readonly platform: string | null;
+  readonly depth_fished_m: number | null;
+  readonly gear: readonly Omit<CatchGear, "catch_id" | "id" | "created_at" | "deleted_at">[];
+  readonly created_at: string;
+}

--- a/src/core/rules/vectors/catch-rules.json
+++ b/src/core/rules/vectors/catch-rules.json
@@ -1,0 +1,103 @@
+{
+  "$comment": "ADR 003 §4. Loaded by src/core/rules/catch/rules.test.ts and, when the Swift client exists, by its unit tests off this same file. When the two clients disagree about which day a 01:30 halibut belongs to, this file says who is wrong.",
+  "localDate": [
+    {
+      "name": "an afternoon fish is on its own day",
+      "instant": "2026-08-20T21:12:00Z",
+      "zone": "America/Los_Angeles",
+      "expected": "2026-08-20"
+    },
+    {
+      "name": "a 01:30 local halibut belongs to the local day, not the UTC one",
+      "instant": "2026-08-21T08:30:00Z",
+      "zone": "America/Los_Angeles",
+      "expected": "2026-08-21"
+    },
+    {
+      "name": "22:00 local is still the day it started, though UTC has rolled over",
+      "instant": "2026-08-21T05:00:00Z",
+      "zone": "America/Los_Angeles",
+      "expected": "2026-08-20"
+    },
+    {
+      "name": "the instant PDT begins, spring forward",
+      "instant": "2026-03-08T10:00:00Z",
+      "zone": "America/Los_Angeles",
+      "expected": "2026-03-08"
+    },
+    {
+      "name": "the instant PST resumes, fall back",
+      "instant": "2026-11-01T09:00:00Z",
+      "zone": "America/Los_Angeles",
+      "expected": "2026-11-01"
+    },
+    {
+      "name": "the same instant is a different day in a different zone",
+      "instant": "2026-08-21T05:00:00Z",
+      "zone": "UTC",
+      "expected": "2026-08-21"
+    }
+  ],
+  "countable": [
+    {
+      "name": "a confirmed landed fish counts",
+      "resolution_state": "confirmed",
+      "outcome": "landed",
+      "deleted": false,
+      "expected": true
+    },
+    {
+      "name": "an unresolved mark is not yet a fact (D22)",
+      "resolution_state": "unresolved",
+      "outcome": null,
+      "deleted": false,
+      "expected": false
+    },
+    {
+      "name": "a dismissed mistap never counts",
+      "resolution_state": "dismissed",
+      "outcome": null,
+      "deleted": false,
+      "expected": false
+    },
+    {
+      "name": "a confirmed lost fish is a real event but not a landed one",
+      "resolution_state": "confirmed",
+      "outcome": "lost",
+      "deleted": false,
+      "expected": false
+    },
+    {
+      "name": "a soft-deleted row never counts",
+      "resolution_state": "confirmed",
+      "outcome": "landed",
+      "deleted": true,
+      "expected": false
+    }
+  ],
+  "resolutionTransitions": [
+    { "from": "unresolved", "to": "confirmed", "allowed": true },
+    { "from": "unresolved", "to": "dismissed", "allowed": true },
+    { "from": "confirmed", "to": "dismissed", "allowed": true },
+    { "from": "confirmed", "to": "unresolved", "allowed": false },
+    { "from": "dismissed", "to": "unresolved", "allowed": false },
+    { "from": "confirmed", "to": "confirmed", "allowed": true }
+  ],
+  "measurement": [
+    { "name": "84 lb", "value": 84, "unit": "lb", "ounces": 0, "expectedGrams": 38102 },
+    { "name": "12 lb 4 oz", "value": 12, "unit": "lb", "ounces": 4, "expectedGrams": 5557 },
+    { "name": "3.5 kg", "value": 3.5, "unit": "kg", "ounces": 0, "expectedGrams": 3500 },
+    { "name": "zero is a legal weight", "value": 0, "unit": "lb", "ounces": 0, "expectedGrams": 0 },
+    { "name": "a negative weight is not a measurement", "value": -1, "unit": "lb", "ounces": 0, "expectedGrams": null }
+  ],
+  "length": [
+    { "name": "28 in", "value": 28, "unit": "in", "expectedMm": 711 },
+    { "name": "71 cm", "value": 71, "unit": "cm", "expectedMm": 710 },
+    { "name": "negative rejected", "value": -5, "unit": "in", "expectedMm": null }
+  ],
+  "depth": [
+    { "name": "250 ft", "value": 250, "unit": "ft", "expectedMetres": 76.2 },
+    { "name": "30 m", "value": 30, "unit": "m", "expectedMetres": 30 },
+    { "name": "negative rejected", "value": -3, "unit": "ft", "expectedMetres": null }
+  ]
+}

--- a/src/core/sync/outbox.test.ts
+++ b/src/core/sync/outbox.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyOutcome,
+  backoffMs,
+  backupState,
+  MAX_BACKOFF_MS,
+  pendingMutations,
+  type Mutation,
+} from "./outbox";
+
+const base: Mutation = {
+  id: "0198d9c1-9800-7000-8000-000000000001",
+  entity: "catch",
+  entityId: "c1",
+  op: "insert",
+  payload: {},
+  clientUpdatedAt: "2026-08-20T21:12:00.000Z",
+  deviceId: "device-1",
+  attempts: 0,
+  lastError: null,
+  state: "queued",
+};
+
+describe("applyOutcome", () => {
+  it("marks a successful send done", () => {
+    expect(applyOutcome(base, { kind: "ok" }).state).toBe("done");
+  });
+
+  it("treats a primary-key collision as success — the row already landed", () => {
+    expect(applyOutcome(base, { kind: "duplicate" }).state).toBe("done");
+  });
+
+  it("leaves an unreachable server queued, never failed", () => {
+    const next = applyOutcome(base, { kind: "unreachable", error: "offline" });
+    expect(next.state).toBe("queued");
+    expect(next.attempts).toBe(1);
+  });
+
+  it("NEVER loses a write because a token expired", () => {
+    const next = applyOutcome(base, { kind: "auth_expired", error: "401" });
+    expect(next.state).toBe("queued");
+  });
+
+  it("surfaces a server rejection rather than dropping it", () => {
+    const next = applyOutcome(base, { kind: "rejected", error: "quantity must be >= 1" });
+    expect(next.state).toBe("rejected");
+    expect(next.lastError).toBe("quantity must be >= 1");
+  });
+
+  it("clears a stale error once the send succeeds", () => {
+    const retried = applyOutcome(base, { kind: "unreachable", error: "offline" });
+    expect(applyOutcome(retried, { kind: "ok" }).lastError).toBeNull();
+  });
+});
+
+describe("backoffMs", () => {
+  it("grows exponentially", () => {
+    const full = () => 1;
+    expect(backoffMs(0, full)).toBe(1_000);
+    expect(backoffMs(1, full)).toBe(2_000);
+    expect(backoffMs(3, full)).toBe(8_000);
+  });
+
+  it("caps at five minutes however many attempts have been made", () => {
+    expect(backoffMs(50, () => 1)).toBe(MAX_BACKOFF_MS);
+  });
+
+  it("jitters down to zero so a fleet of queued writes does not retry in lockstep", () => {
+    expect(backoffMs(5, () => 0)).toBe(0);
+  });
+
+  it("never returns a negative delay", () => {
+    expect(backoffMs(-3, () => 1)).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("pendingMutations", () => {
+  it("returns only queued work, oldest id first", () => {
+    const mutations: Mutation[] = [
+      { ...base, id: "0198d9c1-9800-7000-8000-00000000000b" },
+      { ...base, id: "0198d9c1-9800-7000-8000-00000000000a" },
+      { ...base, id: "0198d9c1-9800-7000-8000-00000000000c", state: "done" },
+    ];
+    expect(pendingMutations(mutations).map((m) => m.id.slice(-1))).toEqual(["a", "b"]);
+  });
+});
+
+describe("backupState — the vocabulary at the glass (ADR 004 §6)", () => {
+  it("says backed up when nothing is queued", () => {
+    expect(backupState([{ ...base, state: "done" }])).toEqual({ kind: "backed_up" });
+  });
+
+  it("counts what is waiting, without calling it an error", () => {
+    expect(backupState([base, { ...base, id: "x" }])).toEqual({ kind: "waiting", count: 2 });
+  });
+
+  it("a rejection outranks waiting — it is the only state that interrupts", () => {
+    expect(backupState([base, { ...base, id: "x", state: "rejected" }])).toEqual({
+      kind: "needs_attention",
+      count: 1,
+    });
+  });
+});

--- a/src/core/sync/outbox.ts
+++ b/src/core/sync/outbox.ts
@@ -1,0 +1,120 @@
+/**
+ * The outbox envelope and its pure state machine (ADR 004 §3).
+ *
+ * An append-only local log of mutations. This module holds the parts that are the
+ * *protocol* — the envelope shape, the retry schedule, and how an HTTP outcome maps to
+ * the next state — so that the Swift client implements the same behaviour rather than
+ * inventing a second one. Nothing here does I/O; `src/lib/offline/` stores these records
+ * and a future flusher sends them.
+ *
+ * The rule that shapes everything: a mutation is durable the instant it is written
+ * locally. Nothing in the UI waits on the network, and no outcome short of an explicit
+ * server rejection may discard a record.
+ */
+
+export type SyncEntity =
+  | "trip"
+  | "trip_rig"
+  | "catch"
+  | "catch_gear"
+  | "condition_snapshot"
+  | "journal_entry"
+  | "spot"
+  | "tackle_item";
+
+export type MutationOp = "insert" | "patch" | "delete";
+
+/**
+ * `queued`   waiting to be sent, or waiting out a backoff. The normal offline state.
+ * `sending`  in flight.
+ * `done`     the server has it. Includes a primary-key collision on insert (ADR 004 §4).
+ * `rejected` the server refused it on its merits (4xx). Surfaced, never silently dropped.
+ *
+ * There is deliberately no `failed`: a network error leaves a record `queued`. ADR 004 §6
+ * — "never say failed while retries remain."
+ */
+export type MutationState = "queued" | "sending" | "done" | "rejected";
+
+export interface Mutation {
+  readonly id: string;
+  readonly entity: SyncEntity;
+  readonly entityId: string;
+  readonly op: MutationOp;
+  /** insert: the full row. patch: changed fields ONLY (ADR 004 §3). delete: {}. */
+  readonly payload: Readonly<Record<string, unknown>>;
+  /** Device clock. The conflict comparator, and only that. */
+  readonly clientUpdatedAt: string;
+  readonly deviceId: string;
+  readonly attempts: number;
+  readonly lastError: string | null;
+  readonly state: MutationState;
+}
+
+/** What came back from one send attempt. */
+export type SendOutcome =
+  | { kind: "ok" }
+  /** Primary-key collision on an insert: this row already landed. ADR 004 §3. */
+  | { kind: "duplicate" }
+  /** No network, DNS failure, timeout, 5xx. Not the angler's problem and not an error. */
+  | { kind: "unreachable"; error: string }
+  /** The session expired. Refresh and retry; never lose the write. ADR 004 §3. */
+  | { kind: "auth_expired"; error: string }
+  /** 4xx on the merits — a constraint the server refused. */
+  | { kind: "rejected"; error: string };
+
+export const MAX_BACKOFF_MS = 5 * 60 * 1000;
+const BASE_BACKOFF_MS = 1_000;
+
+/**
+ * Exponential backoff with full jitter, capped at five minutes (ADR 004 §3).
+ *
+ * `random` is injected so the schedule is testable; callers pass nothing.
+ * Full jitter (rather than a fixed exponential) matters when a boat comes back into
+ * signal and every queued mutation would otherwise retry on the same tick.
+ */
+export function backoffMs(attempts: number, random: () => number = Math.random): number {
+  const exponential = Math.min(BASE_BACKOFF_MS * 2 ** Math.max(0, attempts), MAX_BACKOFF_MS);
+  return Math.round(random() * exponential);
+}
+
+/**
+ * The state machine. Total over `SendOutcome` — every outcome has a defined next state,
+ * because the case nobody wrote down is the case that loses a fish.
+ */
+export function applyOutcome(mutation: Mutation, outcome: SendOutcome): Mutation {
+  const attempts = mutation.attempts + 1;
+  switch (outcome.kind) {
+    case "ok":
+    case "duplicate":
+      return { ...mutation, attempts, lastError: null, state: "done" };
+    case "unreachable":
+    case "auth_expired":
+      // Stays queued. This is the whole point: a write is never lost because the
+      // network went away or a token expired mid-trip.
+      return { ...mutation, attempts, lastError: outcome.error, state: "queued" };
+    case "rejected":
+      return { ...mutation, attempts, lastError: outcome.error, state: "rejected" };
+  }
+}
+
+/** Records the flusher should attempt, oldest first. UUIDv7 ids sort by mint time. */
+export function pendingMutations(mutations: readonly Mutation[]): readonly Mutation[] {
+  return mutations.filter((m) => m.state === "queued").slice().sort((a, b) => (a.id < b.id ? -1 : 1));
+}
+
+/**
+ * What the glass is allowed to say (ADR 004 §6). Three states, and the vocabulary
+ * matters more than the mechanism: offline is normal, not an error.
+ */
+export type BackupState =
+  | { kind: "backed_up" }
+  | { kind: "waiting"; count: number }
+  | { kind: "needs_attention"; count: number };
+
+export function backupState(mutations: readonly Mutation[]): BackupState {
+  const rejected = mutations.filter((m) => m.state === "rejected").length;
+  if (rejected > 0) return { kind: "needs_attention", count: rejected };
+  const waiting = mutations.filter((m) => m.state === "queued" || m.state === "sending").length;
+  if (waiting > 0) return { kind: "waiting", count: waiting };
+  return { kind: "backed_up" };
+}

--- a/src/core/sync/uuid-vectors.json
+++ b/src/core/sync/uuid-vectors.json
@@ -1,0 +1,51 @@
+{
+  "$comment": "ADR 003 §4 / ADR 004 §2. Loaded by src/core/sync/uuid.test.ts and, when the Swift client exists, by its unit tests off the same file. Encoding cases are exact: given this timestamp and this sequence, these are the bits. Random bits are masked out of the comparison by the test.",
+  "encoding": [
+    {
+      "name": "epoch",
+      "timestampMs": 0,
+      "sequence": 0,
+      "expectedTimestampHex": "000000000000",
+      "expectedVersionNibble": "7",
+      "expectedSequenceHex": "000"
+    },
+    {
+      "name": "a known instant",
+      "timestampMs": 1756000000000,
+      "sequence": 0,
+      "expectedTimestampHex": "0198d9c19800",
+      "expectedVersionNibble": "7",
+      "expectedSequenceHex": "000"
+    },
+    {
+      "name": "sequence increments within one millisecond",
+      "timestampMs": 1756000000000,
+      "sequence": 1,
+      "expectedTimestampHex": "0198d9c19800",
+      "expectedVersionNibble": "7",
+      "expectedSequenceHex": "001"
+    },
+    {
+      "name": "top of the 12-bit sequence",
+      "timestampMs": 1756000000000,
+      "sequence": 4095,
+      "expectedTimestampHex": "0198d9c19800",
+      "expectedVersionNibble": "7",
+      "expectedSequenceHex": "fff"
+    },
+    {
+      "name": "a timestamp above 2^32 ms exercises the 48-bit path",
+      "timestampMs": 4294967296,
+      "sequence": 0,
+      "expectedTimestampHex": "000100000000",
+      "expectedVersionNibble": "7",
+      "expectedSequenceHex": "000"
+    }
+  ],
+  "roundTrip": [
+    { "timestampMs": 0 },
+    { "timestampMs": 1756000000000 },
+    { "timestampMs": 4294967296 },
+    { "timestampMs": 281474976710655 }
+  ]
+}

--- a/src/core/sync/uuid.test.ts
+++ b/src/core/sync/uuid.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, beforeEach } from "vitest";
+
+import vectors from "./uuid-vectors.json";
+import { __resetUuidv7ClockForTests, isUuidv7, uuidv7, uuidv7TimestampMs } from "./uuid";
+
+const hexOf = (id: string) => id.replace(/-/g, "");
+
+beforeEach(() => {
+  __resetUuidv7ClockForTests();
+});
+
+describe("uuidv7 encoding vectors", () => {
+  for (const vector of vectors.encoding) {
+    it(vector.name, () => {
+      __resetUuidv7ClockForTests();
+      // Drive the sequence to the vector's value by minting into the same millisecond.
+      let id = uuidv7(vector.timestampMs);
+      for (let i = 0; i < vector.sequence; i += 1) id = uuidv7(vector.timestampMs);
+
+      const hex = hexOf(id);
+      expect(hex.slice(0, 12)).toBe(vector.expectedTimestampHex);
+      expect(hex[12]).toBe(vector.expectedVersionNibble);
+      expect(hex.slice(13, 16)).toBe(vector.expectedSequenceHex);
+      // variant: top two bits of byte 8 are 0b10
+      expect(Number.parseInt(hex[16], 16) & 0b1100).toBe(0b1000);
+    });
+  }
+});
+
+describe("uuidv7 round trip", () => {
+  for (const { timestampMs } of vectors.roundTrip) {
+    it(`recovers ${timestampMs}`, () => {
+      __resetUuidv7ClockForTests();
+      expect(uuidv7TimestampMs(uuidv7(timestampMs))).toBe(timestampMs);
+    });
+  }
+});
+
+describe("uuidv7", () => {
+  it("is well formed", () => {
+    expect(isUuidv7(uuidv7())).toBe(true);
+  });
+
+  it("rejects a v4 uuid", () => {
+    expect(isUuidv7("f81d4fae-7dec-41d0-a765-00a0c91e6bf6")).toBe(false);
+  });
+
+  it("rejects nonsense", () => {
+    expect(isUuidv7("not-a-uuid")).toBe(false);
+    expect(uuidv7TimestampMs("not-a-uuid")).toBeNull();
+  });
+
+  it("is unique across a burst", () => {
+    const ids = new Set(Array.from({ length: 10_000 }, () => uuidv7()));
+    expect(ids.size).toBe(10_000);
+  });
+
+  it("sorts lexicographically in mint order, including within one millisecond", () => {
+    const ids = Array.from({ length: 5_000 }, () => uuidv7(1_756_000_000_000));
+    const sorted = [...ids].sort();
+    expect(sorted).toEqual(ids);
+  });
+
+  it("keeps ordering when the device clock steps backwards", () => {
+    const before = uuidv7(1_756_000_000_000);
+    const afterClockWentBack = uuidv7(1_755_000_000_000);
+    expect(afterClockWentBack > before).toBe(true);
+  });
+
+  it("borrows a millisecond forward rather than repeating a sequence", () => {
+    // 4097 ids in one millisecond: the 4097th cannot fit the 12-bit counter.
+    const ids = Array.from({ length: 4_097 }, () => uuidv7(1_756_000_000_000));
+    expect(new Set(ids).size).toBe(4_097);
+    expect(uuidv7TimestampMs(ids[4_096])).toBe(1_756_000_000_001);
+  });
+});

--- a/src/core/sync/uuid.ts
+++ b/src/core/sync/uuid.ts
@@ -1,0 +1,117 @@
+/**
+ * UUIDv7, minted on the device (ADR 004 §2).
+ *
+ * Every row's primary key is generated here, at the moment of the tap, never by the
+ * server. Three properties matter and each is load bearing:
+ *
+ *   1. A write with no signal completes. A row that needs a round trip for its own
+ *      identity cannot be created on a boat, and nothing may reference it either.
+ *   2. It is the idempotency key. A retried insert collides on the primary key and the
+ *      server treats the collision as success, so retry needs no other machinery.
+ *   3. It is time-ordered, so it indexes without the random-UUID page-split penalty and
+ *      sorts by creation for free.
+ *
+ * Layout (RFC 9562 §5.7): 48 bits of Unix milliseconds, 4 bits version (7), 12 bits of
+ * sub-millisecond sequence, 2 bits variant (0b10), 62 bits of randomness.
+ *
+ * The sequence counter is what makes two ids minted in the same millisecond still sort
+ * in mint order. Without it, "log another" twice inside one millisecond produces ids
+ * whose relative order is random — which would silently reorder two catches. Swift
+ * implements the same layout against `uuid-vectors.json`.
+ */
+
+const VARIANT_HIGH_BITS = 0b1000_0000;
+const MAX_SEQUENCE = 0xfff;
+
+let lastTimestampMs = -1;
+let sequence = 0;
+
+/** Hex for one byte, 00-ff. Table lookup beats padStart in the hot path. */
+const HEX = Array.from({ length: 256 }, (_, i) => i.toString(16).padStart(2, "0"));
+
+function randomBytes(length: number): Uint8Array {
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  return bytes;
+}
+
+/**
+ * Mint a UUIDv7 for `timestampMs` (defaults to now).
+ *
+ * Monotonic within a millisecond via the 12-bit sequence. If more than 4096 ids are
+ * minted in the same millisecond the timestamp is borrowed forward by one — the ids
+ * stay unique and ordered, which matters more than the sub-millisecond fiction.
+ */
+export function uuidv7(timestampMs: number = Date.now()): string {
+  let timestamp = Math.floor(timestampMs);
+
+  if (timestamp === lastTimestampMs) {
+    sequence += 1;
+    if (sequence > MAX_SEQUENCE) {
+      timestamp = lastTimestampMs + 1;
+      sequence = 0;
+    }
+  } else if (timestamp < lastTimestampMs) {
+    // The device clock stepped backwards (NTP correction, manual change). Keep minting
+    // forward from the last id rather than emitting one that sorts before its
+    // predecessor: ordering is the property callers depend on, wall-clock exactness is
+    // not. `caught_at` carries the real instant and is a separate column.
+    timestamp = lastTimestampMs;
+    sequence += 1;
+    if (sequence > MAX_SEQUENCE) {
+      timestamp = lastTimestampMs + 1;
+      sequence = 0;
+    }
+  } else {
+    sequence = 0;
+  }
+
+  lastTimestampMs = timestamp;
+
+  const bytes = new Uint8Array(16);
+
+  // 48-bit big-endian millisecond timestamp. Number is safe to 2^53, so the top two
+  // bytes come off with division rather than a 32-bit shift.
+  bytes[0] = Math.floor(timestamp / 2 ** 40) & 0xff;
+  bytes[1] = Math.floor(timestamp / 2 ** 32) & 0xff;
+  bytes[2] = (timestamp >>> 24) & 0xff;
+  bytes[3] = (timestamp >>> 16) & 0xff;
+  bytes[4] = (timestamp >>> 8) & 0xff;
+  bytes[5] = timestamp & 0xff;
+
+  // version 7 in the high nibble of byte 6, then 12 bits of sequence
+  bytes[6] = 0x70 | ((sequence >>> 8) & 0x0f);
+  bytes[7] = sequence & 0xff;
+
+  const random = randomBytes(8);
+  // variant 0b10 in the top two bits of byte 8
+  bytes[8] = VARIANT_HIGH_BITS | (random[0] & 0x3f);
+  for (let i = 1; i < 8; i += 1) bytes[8 + i] = random[i];
+
+  let out = "";
+  for (let i = 0; i < 16; i += 1) {
+    out += HEX[bytes[i]];
+    if (i === 3 || i === 5 || i === 7 || i === 9) out += "-";
+  }
+  return out;
+}
+
+/** The millisecond a UUIDv7 was minted, or null if this is not a well-formed v7. */
+export function uuidv7TimestampMs(id: string): number | null {
+  if (!isUuidv7(id)) return null;
+  const hex = id.replace(/-/g, "").slice(0, 12);
+  return Number.parseInt(hex, 16);
+}
+
+const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+/** Shape, version and variant. Does not assert the timestamp is sane. */
+export function isUuidv7(id: string): boolean {
+  return UUID_SHAPE.test(id);
+}
+
+/** Test seam only: reset the monotonic counter so vectors run from a known state. */
+export function __resetUuidv7ClockForTests(): void {
+  lastTimestampMs = -1;
+  sequence = 0;
+}

--- a/src/features/catches/components/catch-card.tsx
+++ b/src/features/catches/components/catch-card.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import type { SearchableCatch } from "@/core/rules/catch/search";
+import { sortGear } from "@/core/rules/catch/rules";
+import { formatClock, summaryLine, type UnitSystem } from "../format";
+import { CARD_CLASS, FOCUS_RING } from "../ui-classes";
+
+/**
+ * One catch, scannable at arm's length (spec §9).
+ *
+ * Deliberately partial: species, size, time, what it ate, where. Everything else waits
+ * for the detail screen. A card that shows every stored field is a card nobody reads.
+ *
+ * The whole card is one button rather than a link so the target is the full card at any
+ * width — a 70-year-old in sunlight is not aiming at a text link.
+ */
+export function CatchCard({
+  item,
+  unitSystem,
+  spotName,
+  onOpen,
+}: {
+  item: SearchableCatch;
+  unitSystem: UnitSystem;
+  spotName: string | null;
+  onOpen: () => void;
+}) {
+  const { record } = item;
+  const summary = summaryLine(record, unitSystem);
+  const lure = sortGear(item.gear).find((g) => g.role === "jig" || g.role === "lure" || g.role === "bait");
+  const unresolved = record.resolution_state === "unresolved";
+  const name = item.speciesName ?? (unresolved ? "Unresolved mark" : "No species");
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className={`${CARD_CLASS} ${FOCUS_RING} flex w-full flex-col gap-2 p-4 text-left transition-colors hover:bg-surface-raised active:scale-[0.99] motion-reduce:transition-none`}
+    >
+      <div className="flex items-baseline justify-between gap-3">
+        <h3 className="text-h3">{name}</h3>
+        <span className="shrink-0 text-caption text-text-muted">
+          {formatClock(record.caught_at, record.caught_tz)}
+        </span>
+      </div>
+
+      {summary.length > 0 ? (
+        <p className="text-body text-text-primary">{summary.join(" · ")}</p>
+      ) : null}
+
+      {lure ? <p className="text-caption text-text-muted">{lure.label}</p> : null}
+
+      <div className="flex flex-wrap items-center gap-2">
+        {spotName ? <span className="text-caption text-text-muted">{spotName}</span> : null}
+        {record.favorite ? (
+          <span className="text-caption text-text-muted">★ Favorite</span>
+        ) : null}
+        {unresolved ? (
+          <span className="rounded-full border border-amber-flag px-3 text-caption text-amber-flag">
+            Needs details
+          </span>
+        ) : null}
+        {record.disposition === "released" ? (
+          <span className="text-caption text-text-muted">Released</span>
+        ) : null}
+      </div>
+    </button>
+  );
+}

--- a/src/features/catches/components/catch-detail-sheet.tsx
+++ b/src/features/catches/components/catch-detail-sheet.tsx
@@ -1,0 +1,328 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { sortGear } from "@/core/rules/catch/rules";
+import type { SearchableCatch } from "@/core/rules/catch/search";
+import { speciesById } from "@/core/ontology/species";
+import {
+  DISPOSITION_LABEL,
+  formatClock,
+  formatDepth,
+  formatLength,
+  formatWeight,
+  GEAR_ROLE_LABEL,
+  OUTCOME_LABEL,
+  type UnitSystem,
+} from "../format";
+import { photosFor } from "../media";
+import { CHIP_CLASS, CHIP_OFF, FOCUS_RING, PRIMARY_BUTTON, SECONDARY_BUTTON } from "../ui-classes";
+
+/**
+ * Catch detail (spec §10) — the record, in sections, plus the actions that act on it.
+ *
+ * Sections render only when they hold something. An empty "Conditions" heading tells the
+ * angler nothing and costs them a scroll; absence is information here, not a gap to fill
+ * with placeholders.
+ *
+ * Delete is a two-step inline confirm rather than a browser `confirm()`: it keeps focus
+ * inside the dialog and matches the Tackle Box's existing destructive pattern.
+ */
+export function CatchDetailSheet({
+  item,
+  unitSystem,
+  spotName,
+  onClose,
+  onDelete,
+  onDuplicate,
+  onToggleFavorite,
+  onResolve,
+}: {
+  item: SearchableCatch | null;
+  unitSystem: UnitSystem;
+  spotName: string | null;
+  onClose: () => void;
+  onDelete: (id: string) => void;
+  onDuplicate: (item: SearchableCatch) => void;
+  onToggleFavorite: (id: string) => void;
+  onResolve: (item: SearchableCatch) => void;
+}) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const open = item !== null;
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (open && !dialog.open) dialog.showModal();
+    if (!open && dialog.open) dialog.close();
+  }, [open]);
+
+  return (
+    <dialog
+      ref={dialogRef}
+      aria-labelledby="catch-detail-title"
+      onCancel={(event) => {
+        event.preventDefault();
+        onClose();
+      }}
+      onClose={() => {
+        if (open) onClose();
+      }}
+      className="m-auto max-h-dvh w-full max-w-reading border-0 bg-transparent p-0 text-text-primary backdrop:bg-background/80"
+    >
+      {item ? (
+        <DetailBody
+          key={item.record.id}
+          item={item}
+          unitSystem={unitSystem}
+          spotName={spotName}
+          onClose={onClose}
+          onDelete={onDelete}
+          onDuplicate={onDuplicate}
+          onToggleFavorite={onToggleFavorite}
+          onResolve={onResolve}
+        />
+      ) : null}
+    </dialog>
+  );
+}
+
+function weightText(item: SearchableCatch, system: UnitSystem): string | null {
+  const weight = formatWeight(item.record.weight_g, system);
+  if (weight === null) return null;
+  return item.record.size_estimated ? `${weight} (estimated)` : `${weight} (measured)`;
+}
+
+function Header({ item, onClose }: { item: SearchableCatch; onClose: () => void }) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <h2 id="catch-detail-title" className="text-h2">
+        {item.speciesName ?? "Unresolved mark"}
+      </h2>
+      <button type="button" onClick={onClose} className={SECONDARY_BUTTON}>
+        Close
+      </button>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="flex flex-col gap-2 border-t border-hairline pt-4">
+      <h3 className="text-label text-text-muted">{title}</h3>
+      <dl className="flex flex-col gap-2">{children}</dl>
+    </section>
+  );
+}
+
+/** A label/value pair that renders nothing at all when there is no value. */
+function Row({ label, value }: { label: string; value: string | null }) {
+  if (value === null || value === "") return null;
+  return (
+    <div className="flex items-baseline justify-between gap-4">
+      <dt className="text-caption text-text-muted">{label}</dt>
+      <dd className="text-body text-text-primary">{value}</dd>
+    </div>
+  );
+}
+
+/**
+ * The detail body, remounted per catch via `key`. Keeping the delete confirmation and
+ * its focus management here means opening a different catch resets them by construction,
+ * rather than by an effect that has to remember to.
+ */
+function DetailBody({
+  item,
+  unitSystem,
+  spotName,
+  onClose,
+  onDelete,
+  onDuplicate,
+  onToggleFavorite,
+  onResolve,
+}: {
+  item: SearchableCatch;
+  unitSystem: UnitSystem;
+  spotName: string | null;
+  onClose: () => void;
+  onDelete: (id: string) => void;
+  onDuplicate: (item: SearchableCatch) => void;
+  onToggleFavorite: (id: string) => void;
+  onResolve: (item: SearchableCatch) => void;
+}) {
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const keepRef = useRef<HTMLButtonElement>(null);
+  const deleteRef = useRef<HTMLButtonElement>(null);
+  const wasConfirming = useRef(false);
+
+  // Opening the confirm unmounts the focused button; move focus deliberately rather
+  // than letting it fall to <body>, which strands a keyboard user outside the dialog.
+  useEffect(() => {
+    if (confirmingDelete) keepRef.current?.focus();
+    else if (wasConfirming.current) deleteRef.current?.focus();
+    wasConfirming.current = confirmingDelete;
+  }, [confirmingDelete]);
+
+  return (
+        <div className="flex max-h-dvh flex-col gap-4 overflow-y-auto rounded-lg border border-hairline bg-surface p-4">
+          <Header item={item} onClose={onClose} />
+
+          <Section title="Catch">
+            <Row label="Time" value={`${formatClock(item.record.caught_at, item.record.caught_tz)} · ${item.record.local_date}`} />
+            <Row label="Weight" value={weightText(item, unitSystem)} />
+            <Row label="Length" value={formatLength(item.record.length_mm, unitSystem)} />
+            <Row label="Quantity" value={item.record.quantity > 1 ? String(item.record.quantity) : null} />
+            <Row label="Outcome" value={item.record.outcome ? OUTCOME_LABEL[item.record.outcome] : null} />
+            <Row
+              label="Kept / released"
+              value={item.record.disposition ? DISPOSITION_LABEL[item.record.disposition] : null}
+            />
+            {speciesById(item.record.species_id)?.scientificName ? (
+              <Row label="Species" value={speciesById(item.record.species_id)?.scientificName ?? null} />
+            ) : null}
+          </Section>
+
+          {item.gear.length > 0 ? (
+            <Section title="Gear">
+              {sortGear(item.gear).map((g) => (
+                <Row key={g.id} label={GEAR_ROLE_LABEL[g.role]} value={g.label} />
+              ))}
+            </Section>
+          ) : null}
+
+          <Section title="Fishing">
+            <Row label="Depth" value={formatDepth(item.record.depth_fished_m, unitSystem)} />
+            <Row label="Presentation" value={item.record.presentation} />
+            <Row label="Platform" value={item.record.platform} />
+          </Section>
+
+          <Section title="Location">
+            <Row label="Spot" value={spotName} />
+            {/* Spec §20/§37: coordinates are never rendered. The angler's spots are the
+                most sensitive thing this app holds, and a screen is shoulder-surfable. */}
+            <Row
+              label="Position"
+              value={item.record.lat !== null ? "Saved privately with this catch" : "Not captured"}
+            />
+          </Section>
+
+          <Photos catchId={item.record.id} />
+
+          {item.record.notes ? (
+            <Section title="Notes">
+              <p className="text-body whitespace-pre-wrap">{item.record.notes}</p>
+            </Section>
+          ) : null}
+
+          {item.record.inherited_fields.length > 0 ? (
+            <p className="text-caption text-text-muted">
+              Carried over from your standing rig: {item.record.inherited_fields.join(", ")}.
+            </p>
+          ) : null}
+
+          <div className="flex flex-col gap-2 border-t border-hairline pt-4">
+            {item.record.resolution_state === "unresolved" ? (
+              <button type="button" onClick={() => onResolve(item)} className={PRIMARY_BUTTON}>
+                Say what this was
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={() => onDuplicate(item)}
+              className={SECONDARY_BUTTON}
+            >
+              Duplicate
+            </button>
+            <button
+              type="button"
+              onClick={() => onToggleFavorite(item.record.id)}
+              aria-pressed={item.record.favorite}
+              className={`${CHIP_CLASS} ${CHIP_OFF}`}
+            >
+              {item.record.favorite ? "★ Favorited" : "☆ Favorite"}
+            </button>
+
+            {confirmingDelete ? (
+              <div className="flex flex-col gap-2 rounded-md border border-error-red p-3">
+                <p role="alert" className="text-body">
+                  Delete this catch? It leaves your log.
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    ref={keepRef}
+                    type="button"
+                    onClick={() => setConfirmingDelete(false)}
+                    className={SECONDARY_BUTTON}
+                  >
+                    Keep it
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onDelete(item.record.id)}
+                    className={`inline-flex min-h-touch-floor items-center justify-center rounded-md bg-error-red px-4 text-label font-semibold text-ink-on-orange ${FOCUS_RING}`}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                ref={deleteRef}
+                type="button"
+                onClick={() => setConfirmingDelete(true)}
+                className={`${SECONDARY_BUTTON} text-error-red`}
+              >
+                Delete
+              </button>
+            )}
+          </div>
+        </div>
+  );
+}
+
+/**
+ * Photos held on this device for a catch.
+ *
+ * Object URLs are created on load and revoked on unmount — without the revoke, opening
+ * fifty catches in a session leaks fifty decoded images and the tab eventually dies on a
+ * phone. The section renders nothing at all when there are no photos.
+ */
+function Photos({ catchId }: { catchId: string }) {
+  const [urls, setUrls] = useState<readonly string[]>([]);
+
+  useEffect(() => {
+    let live = true;
+    const created: string[] = [];
+    void photosFor(catchId).then((photos) => {
+      if (!live) return;
+      for (const photo of photos) created.push(URL.createObjectURL(photo.blob));
+      setUrls(created);
+    });
+    return () => {
+      live = false;
+      for (const url of created) URL.revokeObjectURL(url);
+    };
+  }, [catchId]);
+
+  if (urls.length === 0) return null;
+
+  return (
+    <section className="flex flex-col gap-2 border-t border-hairline pt-4">
+      <h3 className="text-label text-text-muted">Photos</h3>
+      <ul className="flex flex-wrap gap-2">
+        {urls.map((url) => (
+          <li key={url}>
+            {/* eslint-disable-next-line @next/next/no-img-element -- a blob: URL from
+                IndexedDB cannot go through next/image, which needs a static or remote src. */}
+            <img
+              src={url}
+              alt="Catch photo"
+              className="max-h-space-16 rounded-md border border-hairline object-cover"
+            />
+          </li>
+        ))}
+      </ul>
+      <p className="text-caption text-text-muted">Saved on this device.</p>
+    </section>
+  );
+}

--- a/src/features/catches/components/fish-log.tsx
+++ b/src/features/catches/components/fish-log.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+
+import { repeatSeedFrom } from "@/core/rules/catch/rules";
+import {
+  filterCatches,
+  groupByLocalDate,
+  NO_FILTERS,
+  type CatchFilters,
+  type LogView,
+  type SearchableCatch,
+} from "@/core/rules/catch/search";
+import {
+  attachPositionLater,
+  draftFromRepeatSeed,
+  draftGearFrom,
+  EMPTY_DRAFT,
+  logCatch,
+  startPositionRequest,
+  type CatchDraft,
+  type PositionRequest,
+} from "../create";
+import { formatDayHeading, type UnitSystem } from "../format";
+import {
+  currentZone,
+  logActions,
+  searchable,
+  useLog,
+  type LogSnapshot,
+} from "../store";
+import {
+  CHIP_CLASS,
+  CHIP_OFF_ON_SURFACE,
+  CHIP_ON,
+  INPUT_CLASS,
+  PRIMARY_BUTTON,
+} from "../ui-classes";
+import { CatchCard } from "./catch-card";
+import { CatchDetailSheet } from "./catch-detail-sheet";
+import { QuickLogSheet, type LogRequest } from "./quick-log-sheet";
+
+/**
+ * The Fish Log home (spec §8): log a catch, and review what you have caught.
+ *
+ * Deliberately not a dashboard. Analytics belong in their own feature (spec §8, §33) and
+ * putting a catch-rate tile here would make the screen slower to use for the thing it
+ * exists to do.
+ *
+ * The list pages at 50 rather than rendering everything: a power user reaches 10,000
+ * catches (spec §41) and an unpaged list of that size janks on the phone this app is
+ * for. Filtering runs over the whole set; only rendering is bounded.
+ */
+
+const PAGE_SIZE = 50;
+
+const VIEWS: readonly { id: LogView; label: string }[] = [
+  { id: "all", label: "All" },
+  { id: "favorites", label: "Favorites" },
+  { id: "needs_details", label: "Needs details" },
+];
+
+export function FishLog({ unitSystem }: { unitSystem: UnitSystem }) {
+  const state = useLog();
+  const [filters, setFilters] = useState<CatchFilters>(NO_FILTERS);
+  // Paging resets whenever the filters change. Keyed on a signature of the filters and
+  // derived during render rather than reset in an effect: an effect would paint one frame
+  // of the old page count against the new results.
+  const [paging, setPaging] = useState({ key: "", count: PAGE_SIZE });
+  const [logRequest, setLogRequest] = useState<LogRequest | null>(null);
+  const [openCatchId, setOpenCatchId] = useState<string | null>(null);
+  const [justSaved, setJustSaved] = useState<string | null>(null);
+
+  // The GPS is asked as soon as the sheet opens, and its answer is *read* at save time,
+  // never awaited (see `startPositionRequest`). A fix that arrives after the save is
+  // patched on afterwards. A ref, not state: it must not cause a render.
+  const positionRequest = useRef<PositionRequest | null>(null);
+
+  const filterKey = JSON.stringify(filters);
+  const visible = paging.key === filterKey ? paging.count : PAGE_SIZE;
+
+  const items = useMemo(() => searchable(state), [state]);
+  const filtered = useMemo(() => filterCatches(items, filters), [items, filters]);
+  const days = useMemo(() => groupByLocalDate(filtered), [filtered]);
+
+  const shown = useMemo(() => {
+    const out: { date: string; items: SearchableCatch[] }[] = [];
+    let budget = visible;
+    for (const day of days) {
+      if (budget <= 0) break;
+      const take = day.items.slice(0, budget);
+      out.push({ date: day.date, items: take });
+      budget -= take.length;
+    }
+    return out;
+  }, [days, visible]);
+
+  const remaining = filtered.length - shown.reduce((n, d) => n + d.items.length, 0);
+  const today = useMemo(() => todayLocalDate(), []);
+  const recentSpeciesIds = useMemo(() => recentSpecies(state), [state]);
+  const openItem = items.find((i) => i.record.id === openCatchId) ?? null;
+
+  const openFreshLog = () => {
+    positionRequest.current = startPositionRequest();
+    setLogRequest({ key: `fresh-${Date.now()}`, seed: null, note: null, title: "Log a catch" });
+  };
+
+  const save = async (draft: CatchDraft, andAnother: boolean) => {
+    const request = positionRequest.current;
+    // Read, do not await: whatever the GPS has managed so far is what this catch gets.
+    const result = await logCatch(state, draft, request?.value ?? null);
+    setJustSaved(result.catchId);
+    if (request && !request.settled) void attachPositionLater(result.catchId, request);
+    if (andAnother) {
+      // Repeat mode (spec §6): same rig, same species, new id and new timestamp. The
+      // seed comes from the draft that was just saved, so nothing is re-typed.
+      positionRequest.current = startPositionRequest();
+      setLogRequest({
+        key: `another-${result.catchId}`,
+        seed: { ...draft, weightG: null, lengthMm: null, notes: null },
+        note: "Same setup as the last one. Time is new.",
+        title: "Log another",
+      });
+    } else {
+      setLogRequest(null);
+    }
+  };
+
+  if (!state.hydrated) {
+    return (
+      <section className="rounded-lg border border-hairline bg-surface p-4">
+        <h1 className="text-h1">Fish Log</h1>
+        <p className="mt-3 text-body text-text-muted">Opening your log…</p>
+      </section>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <section className="flex flex-col gap-3 rounded-lg border border-hairline bg-surface p-4">
+        <div className="flex items-baseline justify-between gap-3">
+          <h1 className="text-h1">Fish Log</h1>
+          <p className="text-caption text-text-muted">
+            {filtered.length} {filtered.length === 1 ? "catch" : "catches"}
+          </p>
+        </div>
+
+        {!state.available ? (
+          <p role="alert" className="text-caption text-error-red">
+            This browser will not let the app store anything on the device, so catches
+            cannot be saved. Turn off private browsing or allow site data, then reload.
+          </p>
+        ) : null}
+
+        <button type="button" onClick={openFreshLog} className={PRIMARY_BUTTON}>
+          + Log catch
+        </button>
+
+        {justSaved ? (
+          <p role="status" className="text-caption text-text-muted">
+            Saved to this device.{" "}
+            {state.backup.kind === "waiting"
+              ? `${state.backup.count} waiting to back up.`
+              : "Backing up when you have signal."}
+          </p>
+        ) : null}
+      </section>
+
+      <section className="flex flex-col gap-3 rounded-lg border border-hairline bg-surface p-4">
+        <label className="flex flex-col gap-2">
+          <span className="text-label text-text-muted">Search your log</span>
+          <input
+            type="search"
+            value={filters.query}
+            onChange={(event) => setFilters((f) => ({ ...f, query: event.target.value }))}
+            placeholder="bluefin, streaker, night bite…"
+            className={INPUT_CLASS}
+            autoComplete="off"
+          />
+        </label>
+
+        <ul className="flex flex-wrap gap-2">
+          {VIEWS.map((view) => (
+            <li key={view.id}>
+              <button
+                type="button"
+                onClick={() => setFilters((f) => ({ ...f, view: view.id }))}
+                aria-pressed={filters.view === view.id}
+                className={`${CHIP_CLASS} ${filters.view === view.id ? CHIP_ON : CHIP_OFF_ON_SURFACE}`}
+              >
+                {view.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {filtered.length === 0 ? (
+        <EmptyState hasAny={items.length > 0} />
+      ) : (
+        <div className="flex flex-col gap-4">
+          {shown.map((day) => (
+            <section key={day.date} className="flex flex-col gap-2">
+              <h2 className="text-label text-text-muted">
+                {formatDayHeading(day.date, today)}
+              </h2>
+              <ul className="flex flex-col gap-2">
+                {day.items.map((item) => (
+                  <li key={item.record.id}>
+                    <CatchCard
+                      item={item}
+                      unitSystem={unitSystem}
+                      spotName={item.spotName}
+                      onOpen={() => setOpenCatchId(item.record.id)}
+                    />
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+          {remaining > 0 ? (
+            <button
+              type="button"
+              onClick={() => setPaging({ key: filterKey, count: visible + PAGE_SIZE })}
+              className={`${CHIP_CLASS} ${CHIP_OFF_ON_SURFACE} self-center`}
+            >
+              Show more ({remaining} left)
+            </button>
+          ) : null}
+        </div>
+      )}
+
+      <QuickLogSheet
+        request={logRequest}
+        recentSpeciesIds={recentSpeciesIds}
+        unitSystem={unitSystem}
+        onClose={() => setLogRequest(null)}
+        onSave={save}
+      />
+
+      <CatchDetailSheet
+        item={openItem}
+        unitSystem={unitSystem}
+        spotName={openItem?.spotName ?? null}
+        onClose={() => setOpenCatchId(null)}
+        onDelete={async (id) => {
+          await logActions.deleteCatch(id);
+          setOpenCatchId(null);
+        }}
+        onToggleFavorite={(id) => void logActions.toggleFavorite(id)}
+        onDuplicate={(item) => {
+          const seed = repeatSeedFrom(item.record, item.gear);
+          setOpenCatchId(null);
+          positionRequest.current = startPositionRequest();
+          setLogRequest({
+            key: `duplicate-${item.record.id}-${Date.now()}`,
+            seed: draftFromRepeatSeed(seed),
+            note: "Copied from an earlier catch. It saves as a new one, with a new time.",
+            title: "Duplicate catch",
+          });
+        }}
+        onResolve={(item) => {
+          setOpenCatchId(null);
+          positionRequest.current = startPositionRequest();
+          setLogRequest({
+            key: `resolve-${item.record.id}`,
+            seed: { ...EMPTY_DRAFT, gear: draftGearFrom(item.gear) },
+            note: "This mark was saved without details. Saying what it was makes it count.",
+            title: "What was it?",
+          });
+        }}
+      />
+    </div>
+  );
+}
+
+function EmptyState({ hasAny }: { hasAny: boolean }) {
+  return (
+    <section className="rounded-lg border border-hairline bg-surface p-4">
+      <p className="text-body text-text-muted">
+        {hasAny
+          ? "No catch matches that. Clear the search or pick a different view."
+          : "Nothing logged yet. Tap “Log catch” when you land one — species is the only thing you have to pick."}
+      </p>
+    </section>
+  );
+}
+
+/** Species the angler has logged lately, most recent first. Drives the picker's top row. */
+function recentSpecies(state: LogSnapshot): readonly string[] {
+  const seen: string[] = [];
+  for (const record of [...state.catches].sort((a, b) => (a.caught_at < b.caught_at ? 1 : -1))) {
+    if (record.species_id && !seen.includes(record.species_id)) seen.push(record.species_id);
+    if (seen.length >= 8) break;
+  }
+  return seen;
+}
+
+function todayLocalDate(): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: currentZone(),
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date());
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? "";
+  return `${get("year")}-${get("month")}-${get("day")}`;
+}

--- a/src/features/catches/components/measurement-field.tsx
+++ b/src/features/catches/components/measurement-field.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { parseMeasurement } from "@/core/rules/catch/measurement";
+import { CHIP_CLASS, CHIP_OFF, CHIP_ON, INPUT_CLASS } from "../ui-classes";
+
+/**
+ * A number and its unit, with the measured/estimated distinction where it belongs —
+ * beside the value, at the moment of typing (spec §24).
+ *
+ * `inputMode="decimal"` rather than `type="number"`: a numeric keypad without the
+ * scroll-wheel and spinner behaviour that makes `type=number` hostile on a phone.
+ */
+export function MeasurementField({
+  label,
+  value,
+  onChange,
+  units,
+  unit,
+  onUnitChange,
+  placeholder,
+  invalid,
+}: {
+  label: string;
+  value: string;
+  onChange: (next: string) => void;
+  units: readonly string[];
+  unit: string;
+  onUnitChange: (next: string) => void;
+  placeholder: string;
+  invalid?: boolean;
+}) {
+  const parsed = parseMeasurement(value);
+  const showError = invalid || parsed === undefined;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label className="flex flex-col gap-2">
+        <span className="text-label text-text-muted">{label}</span>
+        <input
+          type="text"
+          inputMode="decimal"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder={placeholder}
+          aria-invalid={showError || undefined}
+          aria-describedby={showError ? `${label}-error` : undefined}
+          className={INPUT_CLASS}
+        />
+      </label>
+      <div className="flex flex-wrap gap-2">
+        {units.map((option) => (
+          <button
+            key={option}
+            type="button"
+            onClick={() => onUnitChange(option)}
+            aria-pressed={unit === option}
+            className={`${CHIP_CLASS} ${unit === option ? CHIP_ON : CHIP_OFF}`}
+          >
+            {option}
+          </button>
+        ))}
+      </div>
+      {showError ? (
+        <p id={`${label}-error`} role="alert" className="text-caption text-error-red">
+          That is not a number. Leave it blank if you did not measure it.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/catches/components/quick-log-sheet.tsx
+++ b/src/features/catches/components/quick-log-sheet.tsx
@@ -1,0 +1,389 @@
+"use client";
+
+import { type FormEvent, useEffect, useRef, useState } from "react";
+
+import {
+  depthToMetres,
+  lengthToMillimetres,
+  parseMeasurement,
+  weightToGrams,
+  type DepthUnit,
+  type LengthUnit,
+  type WeightUnit,
+} from "@/core/rules/catch/measurement";
+import type { Disposition, GearRole } from "@/core/rules/catch/types";
+import type { CatchDraft } from "../create";
+import { GEAR_ROLE_LABEL, type UnitSystem } from "../format";
+import {
+  CHIP_CLASS,
+  CHIP_OFF,
+  CHIP_ON,
+  INPUT_CLASS,
+  PRIMARY_BUTTON,
+  SECONDARY_BUTTON,
+} from "../ui-classes";
+import { MeasurementField } from "./measurement-field";
+import { SpeciesPicker } from "./species-picker";
+
+/**
+ * Quick Log — the screen the whole feature is judged on (spec §2, §4).
+ *
+ * Target is a catch in 5–10 seconds, so exactly one thing is above the fold: species.
+ * Save is live from the first tap; everything else lives behind **Add details** and is
+ * genuinely optional (spec §4's progressive disclosure). The sheet does not validate its
+ * way into blocking a save — an angler holding a fish gets to save an imperfect record.
+ *
+ * Repeat mode (spec §6) reuses this sheet with a seeded draft, so "+ Log another" and a
+ * fresh catch are the same code path and cannot drift apart.
+ */
+
+export type LogRequest = {
+  key: string;
+  /** Pre-filled from a repeat or a duplicate; null for a fresh catch. */
+  seed: CatchDraft | null;
+  note: string | null;
+  title: string;
+};
+
+const DISPOSITIONS: readonly { id: Disposition; label: string }[] = [
+  { id: "kept", label: "Kept" },
+  { id: "released", label: "Released" },
+];
+
+const GEAR_ROLES: readonly GearRole[] = ["rod", "reel", "main_line", "leader", "hook", "lure", "jig", "bait"];
+
+export function QuickLogSheet({
+  request,
+  recentSpeciesIds,
+  unitSystem,
+  onClose,
+  onSave,
+}: {
+  request: LogRequest | null;
+  recentSpeciesIds: readonly string[];
+  unitSystem: UnitSystem;
+  onClose: () => void;
+  onSave: (draft: CatchDraft, andAnother: boolean) => void;
+}) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const open = request !== null;
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (open && !dialog.open) dialog.showModal();
+    if (!open && dialog.open) dialog.close();
+  }, [open]);
+
+  return (
+    <dialog
+      ref={dialogRef}
+      aria-labelledby="quick-log-title"
+      onCancel={(event) => {
+        event.preventDefault();
+        onClose();
+      }}
+      onClose={() => {
+        if (open) onClose();
+      }}
+      className="m-auto max-h-dvh w-full max-w-reading border-0 bg-transparent p-0 text-text-primary backdrop:bg-background/80"
+    >
+      {request ? (
+        <LogForm
+          key={request.key}
+          request={request}
+          recentSpeciesIds={recentSpeciesIds}
+          unitSystem={unitSystem}
+          onClose={onClose}
+          onSave={onSave}
+        />
+      ) : null}
+    </dialog>
+  );
+}
+
+function LogForm({
+  request,
+  recentSpeciesIds,
+  unitSystem,
+  onClose,
+  onSave,
+}: {
+  request: LogRequest;
+  recentSpeciesIds: readonly string[];
+  unitSystem: UnitSystem;
+  onClose: () => void;
+  onSave: (draft: CatchDraft, andAnother: boolean) => void;
+}) {
+  const seed = request.seed;
+  const [speciesId, setSpeciesId] = useState<string | null>(seed?.speciesId ?? null);
+  const [speciesOther, setSpeciesOther] = useState<string | null>(seed?.speciesOther ?? null);
+  const [detailsOpen, setDetailsOpen] = useState(false);
+
+  const [weight, setWeight] = useState("");
+  const [weightUnit, setWeightUnit] = useState<WeightUnit>(unitSystem === "metric" ? "kg" : "lb");
+  const [estimated, setEstimated] = useState(false);
+  const [length, setLength] = useState("");
+  const [lengthUnit, setLengthUnit] = useState<LengthUnit>(unitSystem === "metric" ? "cm" : "in");
+  const [depth, setDepth] = useState(
+    seed?.depthM !== null && seed?.depthM !== undefined
+      ? String(Math.round(unitSystem === "metric" ? seed.depthM : seed.depthM / 0.3048))
+      : "",
+  );
+  const [depthUnit, setDepthUnit] = useState<DepthUnit>(unitSystem === "metric" ? "m" : "ft");
+  const [quantity, setQuantity] = useState(1);
+  const [disposition, setDisposition] = useState<Disposition | null>(seed?.disposition ?? null);
+  const [notes, setNotes] = useState("");
+  const [gear, setGear] = useState<CatchDraft["gear"]>(seed?.gear ?? []);
+  const [photos, setPhotos] = useState<readonly File[]>([]);
+
+  const build = (): CatchDraft => {
+    const weightValue = parseMeasurement(weight);
+    const lengthValue = parseMeasurement(length);
+    const depthValue = parseMeasurement(depth);
+    return {
+      speciesId,
+      speciesOther: speciesOther && speciesOther.trim() !== "" ? speciesOther.trim() : null,
+      quantity,
+      weightG:
+        typeof weightValue === "number" ? weightToGrams(weightValue, weightUnit) : null,
+      lengthMm:
+        typeof lengthValue === "number" ? lengthToMillimetres(lengthValue, lengthUnit) : null,
+      sizeEstimated: estimated,
+      depthM: typeof depthValue === "number" ? depthToMetres(depthValue, depthUnit) : null,
+      disposition,
+      outcome: "landed",
+      presentation: null,
+      notes: notes.trim() || null,
+      tags: seed?.tags ?? [],
+      gear,
+      photos,
+    };
+  };
+
+  const submit = (event: FormEvent, andAnother: boolean) => {
+    event.preventDefault();
+    onSave(build(), andAnother);
+  };
+
+  return (
+    <form
+      onSubmit={(event) => submit(event, false)}
+      className="flex max-h-dvh flex-col gap-4 overflow-y-auto rounded-lg border border-hairline bg-surface p-4"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <h2 id="quick-log-title" className="text-h2">
+          {request.title}
+        </h2>
+        <button type="button" onClick={onClose} className={SECONDARY_BUTTON}>
+          Cancel
+        </button>
+      </div>
+
+      {request.note ? <p className="text-caption text-text-muted">{request.note}</p> : null}
+
+      <SpeciesPicker
+        recentIds={recentSpeciesIds}
+        selectedId={speciesId}
+        selectedOther={speciesOther}
+        onSelect={(id) => {
+          setSpeciesId(id);
+          setSpeciesOther(null);
+        }}
+        onSelectOther={(name) => {
+          setSpeciesOther(name === "" ? null : name);
+          setSpeciesId(null);
+        }}
+      />
+
+      <button
+        type="button"
+        onClick={() => setDetailsOpen((value) => !value)}
+        aria-expanded={detailsOpen}
+        className={`${SECONDARY_BUTTON} self-start`}
+      >
+        {detailsOpen ? "Hide details" : "Add details"}
+      </button>
+
+      {detailsOpen ? (
+        <div className="flex flex-col gap-4 border-t border-hairline pt-4">
+          <MeasurementField
+            label="Weight"
+            value={weight}
+            onChange={setWeight}
+            units={["lb", "kg"]}
+            unit={weightUnit}
+            onUnitChange={(next) => setWeightUnit(next as WeightUnit)}
+            placeholder="84"
+          />
+          <label className="flex min-h-touch-floor items-center gap-3">
+            <input
+              type="checkbox"
+              checked={estimated}
+              onChange={(event) => setEstimated(event.target.checked)}
+              className="size-6 accent-signal-orange"
+            />
+            <span className="text-body">Estimated, not weighed</span>
+          </label>
+
+          <MeasurementField
+            label="Length"
+            value={length}
+            onChange={setLength}
+            units={["in", "cm"]}
+            unit={lengthUnit}
+            onUnitChange={(next) => setLengthUnit(next as LengthUnit)}
+            placeholder="36"
+          />
+          <MeasurementField
+            label="Depth"
+            value={depth}
+            onChange={setDepth}
+            units={["ft", "m"]}
+            unit={depthUnit}
+            onUnitChange={(next) => setDepthUnit(next as DepthUnit)}
+            placeholder="250"
+          />
+
+          <div className="flex flex-col gap-2">
+            <span className="text-label text-text-muted">Quantity</span>
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={() => setQuantity((q) => Math.max(1, q - 1))}
+                aria-label="One fewer"
+                className={SECONDARY_BUTTON}
+              >
+                &minus;
+              </button>
+              <output className="min-w-space-10 text-center text-body-strong">{quantity}</output>
+              <button
+                type="button"
+                onClick={() => setQuantity((q) => q + 1)}
+                aria-label="One more"
+                className={SECONDARY_BUTTON}
+              >
+                +
+              </button>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <span className="text-label text-text-muted">Kept or released</span>
+            <div className="flex flex-wrap gap-2">
+              {DISPOSITIONS.map((option) => (
+                <button
+                  key={option.id}
+                  type="button"
+                  onClick={() => setDisposition(disposition === option.id ? null : option.id)}
+                  aria-pressed={disposition === option.id}
+                  className={`${CHIP_CLASS} ${disposition === option.id ? CHIP_ON : CHIP_OFF}`}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <GearFields gear={gear} onChange={setGear} />
+
+          <div className="flex flex-col gap-2">
+            <span className="text-label text-text-muted">Photos</span>
+            <input
+              type="file"
+              accept="image/*"
+              multiple
+              onChange={(event) => setPhotos(Array.from(event.target.files ?? []))}
+              className={`${INPUT_CLASS} py-3 file:mr-4 file:rounded-md file:border-0 file:bg-signal-orange file:px-4 file:py-2 file:text-label file:text-ink-on-orange`}
+            />
+            {photos.length > 0 ? (
+              <p className="text-caption text-text-muted">
+                {photos.length} {photos.length === 1 ? "photo" : "photos"} will be saved on
+                this device with the catch.
+              </p>
+            ) : null}
+          </div>
+
+          <label className="flex flex-col gap-2">
+            <span className="text-label text-text-muted">Notes</span>
+            <textarea
+              value={notes}
+              onChange={(event) => setNotes(event.target.value)}
+              rows={3}
+              placeholder="meter marks at 250, bird school working"
+              className={`${INPUT_CLASS} py-3`}
+            />
+          </label>
+        </div>
+      ) : null}
+
+      <div className="flex flex-col gap-2 border-t border-hairline pt-4">
+        <button type="submit" className={PRIMARY_BUTTON}>
+          Save catch
+        </button>
+        <button
+          type="button"
+          onClick={(event) => submit(event, true)}
+          className={SECONDARY_BUTTON}
+        >
+          Save &amp; log another
+        </button>
+      </div>
+    </form>
+  );
+}
+
+/**
+ * Gear on the catch (spec §13, §14). Roles, not one field: a catch involves a rod, a
+ * reel, a leader and a jig, and flattening them into one string is what makes "which
+ * leader was I using" unanswerable later.
+ */
+function GearFields({
+  gear,
+  onChange,
+}: {
+  gear: CatchDraft["gear"];
+  onChange: (next: CatchDraft["gear"]) => void;
+}) {
+  const valueFor = (role: GearRole) => gear.find((g) => g.role === role)?.label ?? "";
+
+  const setRole = (role: GearRole, label: string) => {
+    const rest = gear.filter((g) => g.role !== role);
+    onChange(
+      label.trim() === ""
+        ? rest
+        : [...rest, { role, label, detail: null, tackleItemId: null }],
+    );
+  };
+
+  return (
+    <fieldset className="flex flex-col gap-3">
+      <legend className="text-label text-text-muted">Gear</legend>
+      {GEAR_ROLES.map((role) => (
+        <label key={role} className="flex flex-col gap-2">
+          <span className="text-caption text-text-muted">{GEAR_ROLE_LABEL[role]}</span>
+          <input
+            type="text"
+            value={valueFor(role)}
+            onChange={(event) => setRole(role, event.target.value)}
+            placeholder={GEAR_PLACEHOLDER[role]}
+            className={INPUT_CLASS}
+          />
+        </label>
+      ))}
+    </fieldset>
+  );
+}
+
+const GEAR_PLACEHOLDER: Record<GearRole, string> = {
+  rod: "UC Viper",
+  reel: "Penn VISX 16",
+  main_line: "100 lb braid",
+  leader: "200 lb fluorocarbon",
+  hook: "Owner 4/0",
+  lure: "",
+  jig: "Nomad Streaker 200g",
+  bait: "Live sardine",
+  weight: "",
+  terminal: "",
+};

--- a/src/features/catches/components/species-picker.tsx
+++ b/src/features/catches/components/species-picker.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { searchSpecies, speciesById, SPECIES, type Species } from "@/core/ontology/species";
+import { CHIP_CLASS, CHIP_OFF, CHIP_ON, FOCUS_RING, INPUT_CLASS } from "../ui-classes";
+
+/**
+ * Species selection, which is the only required field on a catch and therefore the one
+ * control on the critical path (spec §5).
+ *
+ * The ordering is the design: **recent first**, because the fish you just caught is
+ * overwhelmingly the fish you are about to catch again, and a hot bite is exactly when
+ * nobody can scroll. Search only appears once there are enough species on screen to
+ * need it — a search box above six chips is furniture, not help.
+ *
+ * "Something else" is never hidden behind the search: a fish that is not in the
+ * vocabulary still has to be loggable in one tap, and `species_other` is a separate
+ * column precisely so it can never be confused with a real id (spec §5).
+ */
+export function SpeciesPicker({
+  recentIds,
+  selectedId,
+  selectedOther,
+  onSelect,
+  onSelectOther,
+}: {
+  recentIds: readonly string[];
+  selectedId: string | null;
+  selectedOther: string | null;
+  onSelect: (id: string) => void;
+  onSelectOther: (name: string) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [otherOpen, setOtherOpen] = useState(selectedOther !== null);
+  const [otherText, setOtherText] = useState(selectedOther ?? "");
+
+  const recent = useMemo(
+    () => recentIds.map((id) => speciesById(id)).filter((s): s is Species => s !== null),
+    [recentIds],
+  );
+
+  const results = useMemo(() => {
+    if (query.trim() === "") return [];
+    return searchSpecies(query).slice(0, 20);
+  }, [query]);
+
+  // What a SoCal salt angler reaches for before they have any history at all.
+  //
+  // Curated rather than "the first N by sort_order": the vocabulary is ordered by habitat
+  // (groups, then inshore, then nearshore, then pelagic), so taking the head of it offers
+  // surfperch and croaker and silently buries yellowtail and bluefin. This list spans the
+  // three things people actually fish for here — bay/surf, reef, and offshore — and it
+  // stops mattering after a handful of catches, when Recent takes over.
+  const common = useMemo(() => {
+    const recentSet = new Set(recentIds);
+    return COMMON_SALT_IDS.map((id) => speciesById(id))
+      .filter((s): s is Species => s !== null && !recentSet.has(s.id));
+  }, [recentIds]);
+
+  const rest = useMemo(() => {
+    const shown = new Set([...recentIds, ...COMMON_SALT_IDS]);
+    return SPECIES.filter((s) => !shown.has(s.id)).sort((a, b) => a.sortOrder - b.sortOrder);
+  }, [recentIds]);
+
+  const showing = query.trim() !== "" ? results : null;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <label className="flex flex-col gap-2">
+        <span className="text-label text-text-muted">Search species</span>
+        <input
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="bluefin, calico, halibut…"
+          className={INPUT_CLASS}
+          autoComplete="off"
+        />
+      </label>
+
+      {showing !== null ? (
+        <SpeciesChips
+          heading={showing.length === 0 ? "No match" : "Results"}
+          species={showing}
+          selectedId={selectedId}
+          onSelect={onSelect}
+        />
+      ) : (
+        <>
+          {recent.length > 0 ? (
+            <SpeciesChips
+              heading="Recent"
+              species={recent}
+              selectedId={selectedId}
+              onSelect={onSelect}
+            />
+          ) : null}
+          <SpeciesChips
+            heading={recent.length > 0 ? "Common" : "Species"}
+            species={common}
+            selectedId={selectedId}
+            onSelect={onSelect}
+          />
+          {/* Everything else is one tap away, so a species that is merely uncommon never
+              requires typing on a wet screen. */}
+          <details className="flex flex-col gap-2">
+            <summary
+              className={`${CHIP_CLASS} ${CHIP_OFF} inline-flex w-fit cursor-pointer items-center`}
+            >
+              All species ({rest.length})
+            </summary>
+            <div className="pt-2">
+              <SpeciesChips
+                heading="Everything else"
+                species={rest}
+                selectedId={selectedId}
+                onSelect={onSelect}
+              />
+            </div>
+          </details>
+        </>
+      )}
+
+      <div className="flex flex-col gap-2">
+        <button
+          type="button"
+          onClick={() => setOtherOpen((open) => !open)}
+          aria-expanded={otherOpen}
+          className={`${CHIP_CLASS} ${selectedOther !== null ? CHIP_ON : CHIP_OFF} self-start`}
+        >
+          {selectedOther !== null ? `Other: ${selectedOther}` : "Something else…"}
+        </button>
+        {otherOpen ? (
+          <div className="flex flex-col gap-2">
+            <label className="flex flex-col gap-2">
+              <span className="text-label text-text-muted">What was it?</span>
+              <input
+                type="text"
+                value={otherText}
+                onChange={(event) => setOtherText(event.target.value)}
+                onBlur={() => otherText.trim() && onSelectOther(otherText.trim())}
+                placeholder="e.g. something long and silver"
+                className={INPUT_CLASS}
+              />
+            </label>
+            <p className="text-caption text-text-muted">
+              Saved as your own words. It stays out of species statistics until it can be
+              matched to a real species.
+            </p>
+          </div>
+        ) : null}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onSelectOther("")}
+        className={`text-label text-text-link underline underline-offset-4 ${FOCUS_RING} self-start`}
+      >
+        Don&apos;t know yet — log it without a species
+      </button>
+    </div>
+  );
+}
+
+function SpeciesChips({
+  heading,
+  species,
+  selectedId,
+  onSelect,
+}: {
+  heading: string;
+  species: readonly Species[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <h3 className="text-label text-text-muted">{heading}</h3>
+      {species.length === 0 ? (
+        <p className="text-body text-text-muted">
+          Nothing matched. Use &ldquo;Something else&rdquo; below.
+        </p>
+      ) : (
+        <ul className="flex flex-wrap gap-2">
+          {species.map((item) => (
+            <li key={item.id}>
+              <button
+                type="button"
+                onClick={() => onSelect(item.id)}
+                aria-pressed={selectedId === item.id}
+                className={`${CHIP_CLASS} ${selectedId === item.id ? CHIP_ON : CHIP_OFF}`}
+              >
+                {item.commonName}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The no-history starting set. Not a taxonomy — a guess at what gets logged most on this
+ * coast, deliberately short so the row does not wrap three times on a phone.
+ */
+const COMMON_SALT_IDS: readonly string[] = [
+  "kelp_bass",
+  "barred_sand_bass",
+  "california_halibut",
+  "barred_surfperch",
+  "spotfin_croaker",
+  "rockfish",
+  "lingcod",
+  "california_sheephead",
+  "yellowtail",
+  "white_seabass",
+  "pacific_bonito",
+  "bluefin_tuna",
+];

--- a/src/features/catches/conditions.ts
+++ b/src/features/catches/conditions.ts
@@ -1,0 +1,155 @@
+import { moonPhaseAt, sunEventsFor, type GeoPoint } from "@/core/rules/astro";
+import { degrees, instant } from "@/core/units";
+import { uuidv7 } from "@/core/sync/uuid";
+import { LOCAL_ANGLER_ID } from "./store";
+
+/**
+ * The environmental snapshot attached to a catch (spec §16–§19).
+ *
+ * **What this captures and what it deliberately does not.** `PLAN.md` §1 cuts live
+ * enrichment from the web prototype: tide, weather, pressure and water temperature are
+ * fetched server-side later, and every web write lands `enrichment_status = 'pending'`.
+ * That cut is honoured here.
+ *
+ * Sun and moon are the exception, and the reason is D25: they are *computed on device*
+ * from the instant and the coordinates. There is no API, no key, and no network — the
+ * numbers are as available on a boat with no signal as they are on wifi. Leaving them
+ * null and asking a server for them later would be strictly worse data for no gain.
+ *
+ * So a snapshot written here is `partial`, never `complete`: the astronomical fields are
+ * real observations, the marine ones are genuinely still pending. Saying `complete`
+ * would be a lie a future correlation would act on.
+ *
+ * Raw values only (spec §18): `moon_phase_angle_deg` and `moon_illumination_fraction`
+ * are stored, and nothing here derives "good moon" or a bite score from them. Tide state
+ * is not guessed at all — spec §19 forbids calling anything slack that was not measured,
+ * and with no tide series fetched there is nothing to call.
+ */
+
+export interface SnapshotInput {
+  readonly catchId: string;
+  readonly tripId: string;
+  readonly observedAt: string;
+  readonly waterClass: "salt" | "fresh";
+  readonly lat: number | null;
+  readonly lng: number | null;
+}
+
+export interface ConditionSnapshotRecord {
+  readonly id: string;
+  readonly angler_id: string;
+  readonly trip_id: string;
+  readonly catch_id: string;
+  readonly kind: "catch";
+  readonly observed_at: string;
+  readonly water_class: "salt" | "fresh";
+  readonly moon_phase_angle_deg: number | null;
+  readonly moon_illumination_fraction: number | null;
+  readonly sunrise_utc: string | null;
+  readonly sunset_utc: string | null;
+  readonly civil_twilight_begin_utc: string | null;
+  readonly civil_twilight_end_utc: string | null;
+  readonly minutes_from_sunrise: number | null;
+  readonly minutes_from_sunset: number | null;
+  readonly day_of_year: number | null;
+  readonly enrichment_status: "pending" | "partial";
+  readonly snapshot_basis: "observed" | "historical_reconstruction";
+  readonly provenance: Record<string, unknown>;
+  readonly created_at: string;
+  readonly deleted_at: string | null;
+}
+
+const MS_PER_MINUTE = 60_000;
+
+function minutesBetween(from: number, to: number): number {
+  return Math.round((from - to) / MS_PER_MINUTE);
+}
+
+function dayOfYear(date: Date): number {
+  const start = Date.UTC(date.getUTCFullYear(), 0, 0);
+  return Math.floor((date.getTime() - start) / 86_400_000);
+}
+
+/**
+ * Build the snapshot for a catch.
+ *
+ * Without coordinates there is no sun or moon to compute — the moon's phase is global but
+ * its rise and the angler's relationship to sunset are not — so the row is written with
+ * the astronomical fields null and `pending`. A snapshot row is still created, because
+ * the catch happened somewhere and the enrichment job needs something to fill in.
+ */
+export function buildCatchSnapshot(
+  input: SnapshotInput,
+  captureMode: "live" | "backfill",
+): ConditionSnapshotRecord {
+  const now = new Date().toISOString();
+  const observedMs = Date.parse(input.observedAt);
+  const hasFix = input.lat !== null && input.lng !== null && Number.isFinite(observedMs);
+
+  const base = {
+    id: uuidv7(),
+    angler_id: LOCAL_ANGLER_ID,
+    trip_id: input.tripId,
+    catch_id: input.catchId,
+    kind: "catch" as const,
+    observed_at: input.observedAt,
+    water_class: input.waterClass,
+    // D24: a row typed in months later is reconstructed, not observed, and a future
+    // analysis must be able to tell the difference.
+    snapshot_basis:
+      captureMode === "backfill"
+        ? ("historical_reconstruction" as const)
+        : ("observed" as const),
+    created_at: now,
+    deleted_at: null,
+  };
+
+  if (!hasFix) {
+    return {
+      ...base,
+      moon_phase_angle_deg: null,
+      moon_illumination_fraction: null,
+      sunrise_utc: null,
+      sunset_utc: null,
+      civil_twilight_begin_utc: null,
+      civil_twilight_end_utc: null,
+      minutes_from_sunrise: null,
+      minutes_from_sunset: null,
+      day_of_year: Number.isFinite(observedMs) ? dayOfYear(new Date(observedMs)) : null,
+      enrichment_status: "pending",
+      provenance: { astro: "skipped: no position fix at the moment of the catch" },
+    };
+  }
+
+  const at = instant(observedMs);
+  const point: GeoPoint = {
+    latitude: degrees(input.lat as number),
+    longitude: degrees(input.lng as number),
+  };
+
+  const sun = sunEventsFor(at, point);
+  const moon = moonPhaseAt(at);
+  const iso = (value: number | null) => (value === null ? null : new Date(value).toISOString());
+
+  return {
+    ...base,
+    // Phase angle is the correlate; illumination is for display (ontology §3). Age in
+    // days maps onto the synodic month, 29.53 days over 360°.
+    moon_phase_angle_deg: Math.round((moon.ageDays / 29.530588853) * 360 * 1000) / 1000,
+    moon_illumination_fraction: Math.round(moon.illumination * 10_000) / 10_000,
+    sunrise_utc: iso(sun.sunrise),
+    sunset_utc: iso(sun.sunset),
+    civil_twilight_begin_utc: iso(sun.civilDawn),
+    civil_twilight_end_utc: iso(sun.civilDusk),
+    minutes_from_sunrise: sun.sunrise === null ? null : minutesBetween(observedMs, sun.sunrise),
+    minutes_from_sunset: sun.sunset === null ? null : minutesBetween(observedMs, sun.sunset),
+    day_of_year: dayOfYear(new Date(observedMs)),
+    // Partial, not complete: sun and moon are real, the marine fields are still owed.
+    enrichment_status: "partial",
+    provenance: {
+      astro: "computed on device (D25)",
+      tide: "pending: server enrichment (PLAN.md §1)",
+      weather: "pending: server enrichment (PLAN.md §1)",
+    },
+  };
+}

--- a/src/features/catches/create.test.ts
+++ b/src/features/catches/create.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import { repeatSeedFrom } from "@/core/rules/catch/rules";
+import type { CatchGear, CatchRecord } from "@/core/rules/catch/types";
+import { draftFromRepeatSeed, draftGearFrom, EMPTY_DRAFT } from "./create";
+
+const NOW = "2026-08-20T21:12:00.000Z";
+
+const record: CatchRecord = {
+  id: "c1",
+  angler_id: "a1",
+  trip_id: "t1",
+  caught_at: NOW,
+  caught_tz: "America/Los_Angeles",
+  local_date: "2026-08-20",
+  lat: null,
+  lng: null,
+  gps_accuracy_m: null,
+  resolution_state: "confirmed",
+  dismissed_reason: null,
+  resolved_at: NOW,
+  species_id: "bluefin_tuna",
+  species_other: null,
+  outcome: "landed",
+  disposition: "released",
+  quantity: 1,
+  length_mm: 900,
+  weight_g: 38102,
+  size_estimated: false,
+  spot_id: "spot-1",
+  platform: "boat",
+  depth_fished_m: 76.2,
+  rig_id: null,
+  rig_revision: null,
+  inherited_fields: [],
+  presentation: "yo-yo",
+  notes: "meter marks at 250",
+  tags: ["night bite"],
+  favorite: false,
+  capture_mode: "live",
+  client_created_at: NOW,
+  created_at: NOW,
+  client_updated_at: NOW,
+  deleted_at: null,
+};
+
+const gear: CatchGear[] = [
+  {
+    id: "g1",
+    catch_id: "c1",
+    angler_id: "a1",
+    tackle_item_id: "t-1",
+    role: "jig",
+    label: "Nomad Streaker 200g",
+    detail: "Pink",
+    created_at: NOW,
+    deleted_at: null,
+  },
+];
+
+/**
+ * These pin a bug that shipped once and was caught in the browser, not by the compiler:
+ * `RepeatSeed` speaks the schema's column names and `CatchDraft` speaks the form's field
+ * names, and spreading one into the other type-checks while dropping every value. The
+ * effect was a Duplicate that opened with no species filled in.
+ */
+describe("draftFromRepeatSeed", () => {
+  const draft = draftFromRepeatSeed(repeatSeedFrom(record, gear));
+
+  it("carries the species across the naming boundary", () => {
+    expect(draft.speciesId).toBe("bluefin_tuna");
+  });
+
+  it("carries depth, disposition, presentation and tags", () => {
+    expect(draft.depthM).toBe(76.2);
+    expect(draft.disposition).toBe("released");
+    expect(draft.presentation).toBe("yo-yo");
+    expect(draft.tags).toEqual(["night bite"]);
+  });
+
+  it("carries gear in the form's shape", () => {
+    expect(draft.gear).toEqual([
+      { role: "jig", label: "Nomad Streaker 200g", detail: "Pink", tackleItemId: "t-1" },
+    ]);
+  });
+
+  it("does NOT carry this fish's own measurements or notes", () => {
+    expect(draft.weightG).toBeNull();
+    expect(draft.lengthMm).toBeNull();
+    expect(draft.notes).toBeNull();
+  });
+
+  it("leaves no snake_case key behind on the draft", () => {
+    const snakeKeys = Object.keys(draft).filter((key) => key.includes("_"));
+    expect(snakeKeys).toEqual([]);
+  });
+
+  it("always produces a valid outcome, even from a seed with none", () => {
+    const seed = { ...repeatSeedFrom(record, gear), outcome: null };
+    expect(draftFromRepeatSeed(seed).outcome).toBe("landed");
+  });
+});
+
+describe("draftGearFrom", () => {
+  it("keeps the tackle link alongside the snapshot label", () => {
+    expect(draftGearFrom(gear)[0]).toEqual({
+      role: "jig",
+      label: "Nomad Streaker 200g",
+      detail: "Pink",
+      tackleItemId: "t-1",
+    });
+  });
+
+  it("survives an empty rig", () => {
+    expect(draftGearFrom([])).toEqual([]);
+  });
+});
+
+describe("EMPTY_DRAFT", () => {
+  it("is a landed single fish with nothing else claimed", () => {
+    expect(EMPTY_DRAFT.quantity).toBe(1);
+    expect(EMPTY_DRAFT.outcome).toBe("landed");
+    expect(EMPTY_DRAFT.speciesId).toBeNull();
+    expect(EMPTY_DRAFT.sizeEstimated).toBe(false);
+  });
+});

--- a/src/features/catches/create.ts
+++ b/src/features/catches/create.ts
@@ -1,0 +1,413 @@
+"use client";
+
+import { applyRig, localDateOf, type RepeatSeed } from "@/core/rules/catch/rules";
+import type {
+  CatchGear,
+  CatchRecord,
+  Disposition,
+  GearRole,
+  Outcome,
+} from "@/core/rules/catch/types";
+import { uuidv7 } from "@/core/sync/uuid";
+import { buildCatchSnapshot } from "./conditions";
+import { attachPhotos } from "./media";
+import {
+  currentLog,
+  currentZone,
+  latestRigOf,
+  LOCAL_ANGLER_ID,
+  openTripOf,
+  saveCatch,
+  saveConditionSnapshot,
+  startTrip,
+  type LogSnapshot,
+} from "./store";
+
+/**
+ * Turning a tap into a catch.
+ *
+ * The ordering here is the whole offline contract (spec §21): the catch row is written
+ * first and everything optional happens around it. A GPS fix that never arrives, a
+ * snapshot that cannot be computed, a photo that fails to encode — none of them can stop
+ * or undo the save. The catch is the fact; the rest is enrichment.
+ */
+
+export interface CatchDraft {
+  readonly speciesId: string | null;
+  readonly speciesOther: string | null;
+  readonly quantity: number;
+  readonly weightG: number | null;
+  readonly lengthMm: number | null;
+  readonly sizeEstimated: boolean;
+  readonly depthM: number | null;
+  readonly disposition: Disposition | null;
+  readonly outcome: Outcome;
+  readonly presentation: string | null;
+  readonly notes: string | null;
+  readonly tags: readonly string[];
+  readonly gear: readonly { role: GearRole; label: string; detail: string | null; tackleItemId: string | null }[];
+  /** Photos to attach once the catch exists. Never on the save path (spec §25). */
+  readonly photos: readonly File[];
+  /** Set when editing or when the angler corrected the time; otherwise now. */
+  readonly caughtAt?: string;
+}
+
+/**
+ * A `RepeatSeed` (column names, from `core/rules`) into a `CatchDraft` (form field names).
+ *
+ * Written out field by field rather than spread. The two shapes deliberately use
+ * different naming — the rules layer speaks the schema, the form speaks the form — and a
+ * spread between them type-checks while silently dropping every field, because excess
+ * properties in a spread are not checked. That shipped once; `create.test.ts` pins it.
+ */
+export function draftFromRepeatSeed(seed: RepeatSeed): CatchDraft {
+  return {
+    ...EMPTY_DRAFT,
+    speciesId: seed.species_id,
+    speciesOther: seed.species_other,
+    depthM: seed.depth_fished_m,
+    disposition: seed.disposition,
+    outcome: seed.outcome ?? "landed",
+    presentation: seed.presentation,
+    tags: seed.tags,
+    gear: draftGearFrom(seed.gear),
+    // Photos are of one particular fish and are never copied to another (spec §25).
+    photos: [],
+  };
+}
+
+/** Stored gear rows back into the draft shape, for duplicate and repeat. */
+export function draftGearFrom(gear: readonly CatchGear[]): CatchDraft["gear"] {
+  return gear.map((g) => ({
+    role: g.role,
+    label: g.label,
+    detail: g.detail,
+    tackleItemId: g.tackle_item_id,
+  }));
+}
+
+export const EMPTY_DRAFT: CatchDraft = {
+  speciesId: null,
+  speciesOther: null,
+  quantity: 1,
+  weightG: null,
+  lengthMm: null,
+  sizeEstimated: false,
+  depthM: null,
+  disposition: null,
+  outcome: "landed",
+  presentation: null,
+  notes: null,
+  tags: [],
+  gear: [],
+  photos: [],
+};
+
+/**
+ * A position fix, if one arrives at all.
+ *
+ * Resolved rather than rejected on failure: refused permission, no fix, and a slow warm
+ * start all produce the same thing — `null`, and a catch with no coordinates, which is a
+ * perfectly honest record.
+ *
+ * Nothing on the save path ever awaits this. See `startPositionRequest`.
+ */
+export function tryPosition(timeoutMs = 4_000): Promise<GeolocationPosition | null> {
+  if (typeof navigator === "undefined" || !navigator.geolocation) return Promise.resolve(null);
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (value: GeolocationPosition | null) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    const timer = setTimeout(() => done(null), timeoutMs);
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        clearTimeout(timer);
+        done(position);
+      },
+      () => {
+        clearTimeout(timer);
+        done(null);
+      },
+      { enableHighAccuracy: true, timeout: timeoutMs, maximumAge: 60_000 },
+    );
+  });
+}
+
+/**
+ * A position request in flight, whose current value can be read synchronously.
+ *
+ * This exists because of a bug worth naming: awaiting the fix at save time makes the
+ * save take as long as the GPS does. On a phone that has not had a fix recently that is
+ * the full timeout — four seconds of nothing happening, against a target of five to ten
+ * seconds for the whole catch (spec §2), and in direct violation of spec §21: a failed
+ * or slow secondary service must never hold up the catch.
+ *
+ * So the request is started when the sheet opens and *read*, never awaited, when the
+ * angler saves. Whatever has arrived by then is used. If a fix lands afterwards it is
+ * patched onto the row by `attachPositionLater`, which the angler never waits for.
+ */
+export interface PositionRequest {
+  /** Whatever has arrived so far. Read synchronously; never blocks. */
+  value: GeolocationPosition | null;
+  settled: boolean;
+  readonly promise: Promise<GeolocationPosition | null>;
+}
+
+export function startPositionRequest(timeoutMs = 8_000): PositionRequest {
+  const request = {
+    value: null as GeolocationPosition | null,
+    settled: false,
+  } as { value: GeolocationPosition | null; settled: boolean; promise: Promise<GeolocationPosition | null> };
+  request.promise = tryPosition(timeoutMs).then((position) => {
+    request.value = position;
+    request.settled = true;
+    return position;
+  });
+  return request;
+}
+
+/**
+ * Fill in a fix that arrived after the catch was already saved.
+ *
+ * Only ever adds: if the row already has coordinates, or the fix never came, nothing
+ * happens. A patch here can never remove a position or disturb anything the angler typed.
+ */
+export async function attachPositionLater(
+  catchId: string,
+  request: PositionRequest,
+): Promise<void> {
+  const position = await request.promise;
+  if (!position) return;
+  const state = currentLog();
+  const record = state.catches.find((c) => c.id === catchId);
+  if (!record || record.lat !== null || record.deleted_at !== null) return;
+  await saveCatch({
+    record: {
+      ...record,
+      lat: round5(position.coords.latitude),
+      lng: round5(position.coords.longitude),
+      gps_accuracy_m: Math.round(position.coords.accuracy * 10) / 10,
+      client_updated_at: new Date().toISOString(),
+    },
+    gear: state.gear.filter((g) => g.catch_id === catchId && g.deleted_at === null),
+    isNew: false,
+  });
+}
+
+function gearRows(
+  draft: CatchDraft,
+  catchId: string,
+  nowIso: string,
+): readonly CatchGear[] {
+  return draft.gear
+    .filter((g) => g.label.trim() !== "")
+    .map((g, index) => ({
+      id: `${catchId}-gear-${index}`,
+      catch_id: catchId,
+      angler_id: LOCAL_ANGLER_ID,
+      tackle_item_id: g.tackleItemId,
+      role: g.role,
+      label: g.label.trim(),
+      detail: g.detail?.trim() || null,
+      created_at: nowIso,
+      deleted_at: null,
+    }));
+}
+
+/**
+ * The trip a catch belongs to, opening one if none is running (spec §11).
+ *
+ * The angler is never asked. `catch.trip_id` is NOT NULL because a catch without a trip
+ * has no effort denominator (spec §12), and the way both facts coexist is that the trip
+ * is implicit.
+ */
+async function tripForCatch(state: LogSnapshot, atIso: string): Promise<string> {
+  const open = openTripOf(state);
+  if (open) return open.id;
+  const trip = await startTrip({ startedAt: atIso, zone: currentZone(), waterClass: "salt" });
+  return trip.id;
+}
+
+export interface LogResult {
+  readonly catchId: string;
+  readonly tripId: string;
+}
+
+/**
+ * Log a catch. Resolves once the row is durable locally — not once it is synced.
+ *
+ * `position` is passed in rather than fetched here so the caller can start the GPS
+ * request while the angler is still choosing a species, and so a fix that has not
+ * arrived by save time simply is not used.
+ */
+export async function logCatch(
+  state: LogSnapshot,
+  draft: CatchDraft,
+  position: GeolocationPosition | null,
+): Promise<LogResult> {
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const caughtAt = draft.caughtAt ?? nowIso;
+  const zone = currentZone();
+  const tripId = await tripForCatch(state, caughtAt);
+  const catchId = uuidv7();
+
+  const rig = latestRigOf(state, tripId);
+  const typedGear = gearRows(draft, catchId, nowIso);
+  const inherited = applyRig(
+    { depth_fished_m: draft.depthM, gear: typedGear },
+    rig,
+    catchId,
+    nowIso,
+  );
+
+  const record: CatchRecord = {
+    id: catchId,
+    angler_id: LOCAL_ANGLER_ID,
+    trip_id: tripId,
+    caught_at: caughtAt,
+    caught_tz: zone,
+    local_date: localDateOf(caughtAt, zone),
+    lat: position ? round5(position.coords.latitude) : null,
+    lng: position ? round5(position.coords.longitude) : null,
+    gps_accuracy_m: position ? Math.round(position.coords.accuracy * 10) / 10 : null,
+    // A catch logged through the full sheet is a fact the moment it is saved: the angler
+    // said what it was. Only the quick mark starts life unresolved (D22).
+    resolution_state: "confirmed",
+    dismissed_reason: null,
+    resolved_at: nowIso,
+    species_id: draft.speciesId,
+    species_other: draft.speciesOther,
+    outcome: draft.outcome,
+    disposition: draft.disposition,
+    quantity: draft.quantity,
+    length_mm: draft.lengthMm,
+    weight_g: draft.weightG,
+    size_estimated: draft.sizeEstimated,
+    spot_id: inherited.spot_id,
+    platform: inherited.platform,
+    depth_fished_m: inherited.depth_fished_m,
+    rig_id: inherited.rig_id,
+    rig_revision: inherited.rig_revision,
+    inherited_fields: inherited.inherited_fields,
+    presentation: draft.presentation,
+    notes: draft.notes,
+    tags: draft.tags,
+    favorite: false,
+    capture_mode: "live",
+    client_created_at: nowIso,
+    created_at: nowIso,
+    client_updated_at: nowIso,
+    deleted_at: null,
+  };
+
+  await saveCatch({ record, gear: inherited.gear, isNew: true });
+
+  // Both of these run after the catch is durable and neither can undo it (spec §21).
+  if (draft.photos.length > 0) await attachPhotos(catchId, draft.photos);
+  await attachSnapshot(record);
+
+  return { catchId, tripId };
+}
+
+/**
+ * The quick mark (D22) — the man-overboard button.
+ *
+ * Writes a row that is explicitly *not yet a fact*: no species, no outcome, excluded
+ * from every rate until a human says what happened. It returns as soon as the row is
+ * durable. No spinner, no network, nothing to dismiss.
+ */
+export async function logQuickMark(state: LogSnapshot): Promise<LogResult> {
+  const nowIso = new Date().toISOString();
+  const zone = currentZone();
+  const tripId = await tripForCatch(state, nowIso);
+  const catchId = uuidv7();
+
+  const rig = latestRigOf(state, tripId);
+  const inherited = applyRig({}, rig, catchId, nowIso);
+
+  const record: CatchRecord = {
+    id: catchId,
+    angler_id: LOCAL_ANGLER_ID,
+    trip_id: tripId,
+    caught_at: nowIso,
+    caught_tz: zone,
+    local_date: localDateOf(nowIso, zone),
+    lat: null,
+    lng: null,
+    gps_accuracy_m: null,
+    resolution_state: "unresolved",
+    dismissed_reason: null,
+    resolved_at: null,
+    species_id: null,
+    species_other: null,
+    outcome: null,
+    disposition: null,
+    quantity: 1,
+    length_mm: null,
+    weight_g: null,
+    size_estimated: false,
+    spot_id: inherited.spot_id,
+    platform: inherited.platform,
+    depth_fished_m: inherited.depth_fished_m,
+    rig_id: inherited.rig_id,
+    rig_revision: inherited.rig_revision,
+    inherited_fields: inherited.inherited_fields,
+    presentation: null,
+    notes: null,
+    tags: [],
+    favorite: false,
+    capture_mode: "live",
+    client_created_at: nowIso,
+    created_at: nowIso,
+    client_updated_at: nowIso,
+    deleted_at: null,
+  };
+
+  await saveCatch({ record, gear: inherited.gear, isNew: true });
+
+  // Everything below is best-effort and deliberately not awaited: the mark is already
+  // durable, and D22's whole promise is that this button never makes anybody wait.
+  void (async () => {
+    const request = startPositionRequest();
+    await attachPositionLater(catchId, request);
+    await attachSnapshot({
+      ...record,
+      lat: request.value ? round5(request.value.coords.latitude) : null,
+      lng: request.value ? round5(request.value.coords.longitude) : null,
+    });
+  })();
+
+  return { catchId, tripId };
+}
+
+/**
+ * Attach the conditions snapshot. Failures are swallowed on purpose: spec §21 is
+ * explicit that a failed secondary service must never cost the angler the catch, and
+ * the catch is already durable by the time this runs.
+ */
+async function attachSnapshot(record: CatchRecord): Promise<void> {
+  try {
+    const snapshot = buildCatchSnapshot(
+      {
+        catchId: record.id,
+        tripId: record.trip_id,
+        observedAt: record.caught_at,
+        waterClass: "salt",
+        lat: record.lat,
+        lng: record.lng,
+      },
+      record.capture_mode,
+    );
+    await saveConditionSnapshot(snapshot as unknown as { id: string } & Record<string, unknown>);
+  } catch {
+    // The catch stands. Enrichment is retried server-side.
+  }
+}
+
+function round5(value: number): number {
+  return Math.round(value * 100_000) / 100_000;
+}

--- a/src/features/catches/format.ts
+++ b/src/features/catches/format.ts
@@ -1,0 +1,117 @@
+/**
+ * Rendering a catch. `core/` holds SI; every pound, inch and foot is produced here
+ * (ADR 006 §2–§3, mirroring `features/conditions/format.ts`).
+ */
+
+import {
+  gramsToPoundsOunces,
+  gramsToWeight,
+  metresToDepth,
+  millimetresToLength,
+  type DepthUnit,
+  type LengthUnit,
+  type WeightUnit,
+} from "@/core/rules/catch/measurement";
+import type { CatchRecord, GearRole } from "@/core/rules/catch/types";
+
+export type UnitSystem = "imperial" | "metric";
+
+export const weightUnitFor = (system: UnitSystem): WeightUnit =>
+  system === "metric" ? "kg" : "lb";
+export const lengthUnitFor = (system: UnitSystem): LengthUnit =>
+  system === "metric" ? "cm" : "in";
+export const depthUnitFor = (system: UnitSystem): DepthUnit => (system === "metric" ? "m" : "ft");
+
+/**
+ * Weight for display. Imperial shows ounces only under a pound, where they are the
+ * whole story; above that "12.3 lb" reads faster on a moving boat than "12 lb 5 oz".
+ */
+export function formatWeight(grams: number | null, system: UnitSystem): string | null {
+  if (grams === null) return null;
+  if (system === "metric") return `${round(gramsToWeight(grams, "kg"), 2)} kg`;
+  const { lb, oz } = gramsToPoundsOunces(grams);
+  if (lb === 0) return `${round(oz, 1)} oz`;
+  return `${round(gramsToWeight(grams, "lb"), 1)} lb`;
+}
+
+export function formatLength(mm: number | null, system: UnitSystem): string | null {
+  if (mm === null) return null;
+  const unit = lengthUnitFor(system);
+  return `${round(millimetresToLength(mm, unit), 1)} ${unit}`;
+}
+
+export function formatDepth(metres: number | null, system: UnitSystem): string | null {
+  if (metres === null) return null;
+  const unit = depthUnitFor(system);
+  return `${Math.round(metresToDepth(metres, unit))} ${unit}`;
+}
+
+/** "8:42 PM" in the zone the catch was recorded in, not the reader's current one. */
+export function formatClock(isoInstant: string, zone: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: zone,
+  }).format(new Date(isoInstant));
+}
+
+/** "Thursday, 20 August" — a heading, so the year only when it is not this one. */
+export function formatDayHeading(localDate: string, today: string): string {
+  const [year, month, day] = localDate.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  const sameYear = localDate.slice(0, 4) === today.slice(0, 4);
+  if (localDate === today) return "Today";
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    ...(sameYear ? {} : { year: "numeric" }),
+    timeZone: "UTC",
+  }).format(date);
+}
+
+export const GEAR_ROLE_LABEL: Record<GearRole, string> = {
+  rod: "Rod",
+  reel: "Reel",
+  main_line: "Main line",
+  leader: "Leader",
+  hook: "Hook",
+  lure: "Lure",
+  jig: "Jig",
+  bait: "Bait",
+  weight: "Weight",
+  terminal: "Terminal",
+};
+
+export const DISPOSITION_LABEL: Record<string, string> = {
+  kept: "Kept",
+  released: "Released",
+  "n/a": "n/a",
+};
+
+export const OUTCOME_LABEL: Record<string, string> = {
+  landed: "Landed",
+  lost: "Lost",
+  missed_bite: "Missed bite",
+  short_bite: "Short bite",
+};
+
+/**
+ * The one-line summary under a catch card's species. Measurements first because that is
+ * what an angler scans for, then how it was caught.
+ */
+export function summaryLine(record: CatchRecord, system: UnitSystem): readonly string[] {
+  const parts: string[] = [];
+  const weight = formatWeight(record.weight_g, system);
+  const length = formatLength(record.length_mm, system);
+  if (weight) parts.push(record.size_estimated ? `~${weight}` : weight);
+  if (length) parts.push(length);
+  if (record.quantity > 1) parts.push(`×${record.quantity}`);
+  const depth = formatDepth(record.depth_fished_m, system);
+  if (depth) parts.push(depth);
+  return parts;
+}
+
+function round(value: number, places: number): string {
+  return value.toFixed(places).replace(/\.0+$/, "").replace(/(\.\d*?)0+$/, "$1");
+}

--- a/src/features/catches/media.ts
+++ b/src/features/catches/media.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { uuidv7 } from "@/core/sync/uuid";
+import { deleteMedia, mediaFor, putMedia } from "@/lib/offline/db";
+
+/**
+ * Photos on a catch (spec §25).
+ *
+ * Stored as blobs on the device, in their own IndexedDB store so a list query never
+ * drags megabytes along with it. Upload is a later concern: spec §25 is explicit that a
+ * photo failing must not prevent the catch, so nothing here is on the save path and
+ * every failure is swallowed after the catch is already durable.
+ *
+ * EXIF is deliberately not read for time or position. Spec §25 forbids relying on it,
+ * and for good reason — a photo taken on a second phone, imported from a friend, or
+ * shot after the fish was on ice carries a time and place that are not the catch's.
+ * `caught_at` comes from the tap, and coordinates from the device's own fix.
+ */
+
+export interface CatchPhoto {
+  readonly id: string;
+  readonly blob: Blob;
+}
+
+/** Attach photos to an already-saved catch. Never throws. */
+export async function attachPhotos(catchId: string, files: readonly File[]): Promise<number> {
+  let saved = 0;
+  const now = new Date().toISOString();
+  for (const file of files) {
+    try {
+      await putMedia(uuidv7(), catchId, file, now);
+      saved += 1;
+    } catch {
+      // The catch stands without its photo. Nothing here is worth losing a fish over.
+    }
+  }
+  return saved;
+}
+
+export async function photosFor(catchId: string): Promise<readonly CatchPhoto[]> {
+  try {
+    return await mediaFor(catchId);
+  } catch {
+    return [];
+  }
+}
+
+export async function removePhoto(id: string): Promise<void> {
+  try {
+    await deleteMedia(id);
+  } catch {
+    // Nothing to do; the photo stays until the next attempt.
+  }
+}

--- a/src/features/catches/store.test.ts
+++ b/src/features/catches/store.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { __changedFieldsForTests as changedFields } from "./store";
+
+/**
+ * ADR 004 §3: a patch carries changed fields only. These pin the behaviour that lets two
+ * devices edit different fields of one catch without either clobbering the other.
+ */
+describe("changedFields", () => {
+  it("sends only what moved", () => {
+    expect(changedFields({ a: 1, b: 2 }, { a: 1, b: 3 })).toEqual({ b: 3 });
+  });
+
+  it("sends nothing when nothing moved", () => {
+    expect(changedFields({ a: 1, b: "x" }, { a: 1, b: "x" })).toEqual({});
+  });
+
+  it("treats a rebuilt but equal array as unchanged", () => {
+    expect(changedFields({ tags: ["night bite"] }, { tags: ["night bite"] })).toEqual({});
+  });
+
+  it("catches a real array change", () => {
+    expect(changedFields({ tags: ["a"] }, { tags: ["a", "b"] })).toEqual({ tags: ["a", "b"] });
+  });
+
+  it("catches an array that shrank", () => {
+    expect(changedFields({ tags: ["a", "b"] }, { tags: ["a"] })).toEqual({ tags: ["a"] });
+  });
+
+  it("sends a field cleared to null", () => {
+    expect(changedFields({ weight_g: 100 }, { weight_g: null })).toEqual({ weight_g: null });
+  });
+
+  it("does not confuse null with undefined-but-present", () => {
+    expect(changedFields({ notes: null }, { notes: null })).toEqual({});
+  });
+
+  it("never sends a field the edit did not touch", () => {
+    const before = { species_id: "bluefin_tuna", notes: "meter marks", weight_g: 38102 };
+    const after = { species_id: "bluefin_tuna", notes: "meter marks", weight_g: 40000 };
+    expect(Object.keys(changedFields(before, after))).toEqual(["weight_g"]);
+  });
+});

--- a/src/features/catches/store.ts
+++ b/src/features/catches/store.ts
@@ -1,0 +1,414 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+import { speciesLabel } from "@/core/ontology/species";
+import { localDateOf } from "@/core/rules/catch/rules";
+import type {
+  CatchGear,
+  CatchRecord,
+  RigRecord,
+  TripRecord,
+} from "@/core/rules/catch/types";
+import type { SearchableCatch } from "@/core/rules/catch/search";
+import { backupState, type BackupState, type Mutation, type SyncEntity } from "@/core/sync/outbox";
+import { uuidv7 } from "@/core/sync/uuid";
+import {
+  allMutations,
+  allRows,
+  commit,
+  isIndexedDbAvailable,
+  type EntityStore,
+  type StoredRow,
+} from "@/lib/offline/db";
+
+/**
+ * The Fish Log's read model and its write path.
+ *
+ * Reads come from one in-memory snapshot, hydrated once from IndexedDB and kept in step
+ * by every write. `useSyncExternalStore` gives React a consistent view without a
+ * provider, and the server snapshot is deliberately empty: the local database does not
+ * exist during SSR, so the first paint is the same on both sides and hydration cannot
+ * mismatch.
+ *
+ * Writes go row-and-mutation-together through `commit` (ADR 004 §1). Nothing here awaits
+ * the network, and no mutation here can fail in a way that loses a catch: the durable
+ * write happens first and the caller is told it succeeded the moment it lands.
+ */
+
+export interface LogSnapshot {
+  readonly hydrated: boolean;
+  readonly available: boolean;
+  readonly catches: readonly CatchRecord[];
+  readonly gear: readonly CatchGear[];
+  readonly trips: readonly TripRecord[];
+  readonly rigs: readonly RigRecord[];
+  readonly backup: BackupState;
+}
+
+const EMPTY: LogSnapshot = {
+  hydrated: false,
+  available: true,
+  catches: [],
+  gear: [],
+  trips: [],
+  rigs: [],
+  backup: { kind: "backed_up" },
+};
+
+let snapshot: LogSnapshot = EMPTY;
+const listeners = new Set<() => void>();
+
+function publish(next: LogSnapshot) {
+  snapshot = next;
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  void hydrate();
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+const getSnapshot = () => snapshot;
+const getServerSnapshot = () => EMPTY;
+
+let hydrating: Promise<void> | null = null;
+
+/** Load the whole local log once. Idempotent and safe to call from every subscriber. */
+export function hydrate(): Promise<void> {
+  if (hydrating) return hydrating;
+  hydrating = (async () => {
+    if (!isIndexedDbAvailable()) {
+      publish({ ...EMPTY, hydrated: true, available: false });
+      return;
+    }
+    try {
+      const [catches, gear, trips, rigs, mutations] = await Promise.all([
+        allRows("catch"),
+        allRows("catch_gear"),
+        allRows("trip"),
+        allRows("trip_rig"),
+        allMutations(),
+      ]);
+      publish({
+        hydrated: true,
+        available: true,
+        catches: catches as unknown as CatchRecord[],
+        gear: gear as unknown as CatchGear[],
+        trips: trips as unknown as TripRecord[],
+        rigs: rigs as unknown as RigRecord[],
+        backup: backupState(mutations),
+      });
+    } catch {
+      // A browser with IndexedDB blocked (private mode on some engines, storage denied)
+      // must still render the app and say plainly that nothing can be saved, rather than
+      // throwing a hydration error at somebody standing on a boat.
+      publish({ ...EMPTY, hydrated: true, available: false });
+    }
+  })();
+  return hydrating;
+}
+
+/** The current snapshot, for non-React callers. Never stale: every write republishes. */
+export function currentLog(): LogSnapshot {
+  return snapshot;
+}
+
+export function useLog(): LogSnapshot {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+// --- Write path --------------------------------------------------------------------
+
+const DEVICE_KEY = "fish-log-device-id";
+
+function deviceId(): string {
+  if (typeof localStorage === "undefined") return "unknown-device";
+  try {
+    const existing = localStorage.getItem(DEVICE_KEY);
+    if (existing) return existing;
+    const minted = uuidv7();
+    localStorage.setItem(DEVICE_KEY, minted);
+    return minted;
+  } catch {
+    return "unknown-device";
+  }
+}
+
+function mutation(
+  entity: SyncEntity,
+  entityId: string,
+  op: Mutation["op"],
+  payload: Record<string, unknown>,
+  nowIso: string,
+): Mutation {
+  return {
+    id: uuidv7(),
+    entity,
+    entityId,
+    op,
+    payload,
+    clientUpdatedAt: nowIso,
+    deviceId: deviceId(),
+    attempts: 0,
+    lastError: null,
+    state: "queued",
+  };
+}
+
+/**
+ * Persist a set of rows and queue them for sync, then republish.
+ *
+ * `writes` and `mutations` go into one transaction, so the local row and its sync
+ * intent are never out of step.
+ */
+async function persist(
+  writes: readonly { store: EntityStore; row: StoredRow }[],
+  mutations: readonly Mutation[],
+): Promise<void> {
+  await commit(writes, mutations);
+  await refresh();
+}
+
+async function refresh(): Promise<void> {
+  const [catches, gear, trips, rigs, queued] = await Promise.all([
+    allRows("catch"),
+    allRows("catch_gear"),
+    allRows("trip"),
+    allRows("trip_rig"),
+    allMutations(),
+  ]);
+  publish({
+    hydrated: true,
+    available: true,
+    catches: catches as unknown as CatchRecord[],
+    gear: gear as unknown as CatchGear[],
+    trips: trips as unknown as TripRecord[],
+    rigs: rigs as unknown as RigRecord[],
+    backup: backupState(queued),
+  });
+}
+
+/** The prototype has no auth session yet; every row is written for this one angler. */
+export const LOCAL_ANGLER_ID = "00000000-0000-7000-8000-000000000001";
+
+export function currentZone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || "America/Los_Angeles";
+}
+
+/**
+ * The open trip, or a new one.
+ *
+ * Spec §11 is emphatic that an angler must never be made to create a trip before logging
+ * a catch, and the schema is equally emphatic that `catch.trip_id` is NOT NULL — a catch
+ * outside a trip would have no denominator and break every rate (spec §12). Both hold at
+ * once by making the trip implicit: the first catch of a session opens one silently, and
+ * subsequent catches join it. The angler is never asked.
+ *
+ * "Open" means started, not ended. A trip is closed explicitly, or simply left open —
+ * an abandoned trip is a real thing that happened and is not tidied up behind the user.
+ */
+export function openTripOf(state: LogSnapshot): TripRecord | null {
+  return (
+    state.trips
+      .filter((trip) => trip.deleted_at === null && trip.ended_at === null)
+      .sort((a, b) => (a.started_at < b.started_at ? 1 : -1))[0] ?? null
+  );
+}
+
+export function latestRigOf(state: LogSnapshot, tripId: string): RigRecord | null {
+  return (
+    state.rigs
+      .filter((rig) => rig.trip_id === tripId)
+      .sort((a, b) => b.revision - a.revision)[0] ?? null
+  );
+}
+
+export function gearFor(state: LogSnapshot, catchId: string): readonly CatchGear[] {
+  return state.gear.filter((g) => g.catch_id === catchId && g.deleted_at === null);
+}
+
+/** The read model the log list and search work against. */
+export function searchable(
+  state: LogSnapshot,
+  spotNameOf: (spotId: string | null) => string | null = () => null,
+): readonly SearchableCatch[] {
+  return state.catches.map((record) => ({
+    record,
+    speciesName: speciesLabel(record.species_id, record.species_other),
+    spotName: spotNameOf(record.spot_id),
+    gear: state.gear.filter((g) => g.catch_id === record.id && g.deleted_at === null),
+  }));
+}
+
+export interface NewTripInput {
+  readonly startedAt: string;
+  readonly zone: string;
+  readonly waterClass: TripRecord["water_class"];
+}
+
+export async function startTrip(input: NewTripInput): Promise<TripRecord> {
+  const now = new Date().toISOString();
+  const trip: TripRecord = {
+    id: uuidv7(),
+    angler_id: LOCAL_ANGLER_ID,
+    spot_id: null,
+    water_class: input.waterClass,
+    started_at: input.startedAt,
+    started_tz: input.zone,
+    ended_at: null,
+    ended_tz: null,
+    local_date: localDateOf(input.startedAt, input.zone),
+    platform: null,
+    notes: null,
+    capture_mode: "live",
+    client_created_at: now,
+    created_at: now,
+    client_updated_at: now,
+    deleted_at: null,
+  };
+  await persist(
+    [{ store: "trip", row: trip as unknown as StoredRow }],
+    [mutation("trip", trip.id, "insert", trip as unknown as Record<string, unknown>, now)],
+  );
+  return trip;
+}
+
+export async function endTrip(tripId: string): Promise<void> {
+  const trip = snapshot.trips.find((t) => t.id === tripId);
+  if (!trip || trip.ended_at !== null) return;
+  const now = new Date().toISOString();
+  const patch = { ended_at: now, ended_tz: currentZone(), client_updated_at: now };
+  const updated: TripRecord = { ...trip, ...patch };
+  await persist(
+    [{ store: "trip", row: updated as unknown as StoredRow }],
+    [mutation("trip", tripId, "patch", patch, now)],
+  );
+}
+
+export interface SaveCatchInput {
+  readonly record: CatchRecord;
+  readonly gear: readonly CatchGear[];
+  readonly isNew: boolean;
+}
+
+/**
+ * The fields that actually changed, for a patch payload.
+ *
+ * ADR 004 §3 requires patches to carry changed fields ONLY, and calls it the single
+ * highest-value cheap decision in the design: two devices editing different fields of
+ * the same row then both survive, with no per-field timestamps and no CRDT. Sending the
+ * whole row instead would clobber a concurrent edit to a field this device never
+ * touched. Arrays are compared by value, since `tags` and `inherited_fields` are
+ * rebuilt on every save and would otherwise look changed every time.
+ */
+function changedFields(
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+): Record<string, unknown> {
+  const patch: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(after)) {
+    const previous = before[key];
+    const same = Array.isArray(value)
+      ? Array.isArray(previous) &&
+        previous.length === value.length &&
+        value.every((entry, index) => entry === previous[index])
+      : previous === value;
+    if (!same) patch[key] = value;
+  }
+  return patch;
+}
+
+/** Test seam for the patch-diff rule above. */
+export const __changedFieldsForTests = changedFields;
+
+/**
+ * Save a catch and its gear.
+ *
+ * Gear rows are replaced wholesale on edit: a catch has a handful of them, and a diff
+ * would be more code and more ways to be wrong for no gain the angler can perceive.
+ */
+export async function saveCatch({ record, gear, isNew }: SaveCatchInput): Promise<void> {
+  const now = record.client_updated_at;
+  const existing = snapshot.gear.filter((g) => g.catch_id === record.id);
+  const removed = existing.filter((old) => !gear.some((g) => g.id === old.id));
+
+  const writes: { store: EntityStore; row: StoredRow }[] = [
+    { store: "catch", row: record as unknown as StoredRow },
+    ...gear.map((g) => ({ store: "catch_gear" as EntityStore, row: g as unknown as StoredRow })),
+    ...removed.map((g) => ({
+      store: "catch_gear" as EntityStore,
+      row: { ...g, deleted_at: now } as unknown as StoredRow,
+    })),
+  ];
+
+  const previous = snapshot.catches.find((c) => c.id === record.id);
+  const patch =
+    isNew || !previous
+      ? (record as unknown as Record<string, unknown>)
+      : changedFields(
+          previous as unknown as Record<string, unknown>,
+          record as unknown as Record<string, unknown>,
+        );
+
+  const mutations: Mutation[] = [
+    // A patch that changes nothing still queues: `client_updated_at` always moves, so
+    // this is only reachable for a genuinely empty save, and an empty patch is harmless.
+    mutation("catch", record.id, isNew ? "insert" : "patch", patch, now),
+    ...gear.map((g) =>
+      mutation("catch_gear", g.id, "insert", g as unknown as Record<string, unknown>, now),
+    ),
+    ...removed.map((g) => mutation("catch_gear", g.id, "delete", {}, now)),
+  ];
+
+  await persist(writes, mutations);
+}
+
+/** Soft delete (ADR 004 §4). Tombstones sync; nothing is hard-deleted from a client. */
+export async function deleteCatch(catchId: string): Promise<void> {
+  const record = snapshot.catches.find((c) => c.id === catchId);
+  if (!record) return;
+  const now = new Date().toISOString();
+  await persist(
+    [{ store: "catch", row: { ...record, deleted_at: now, client_updated_at: now } as unknown as StoredRow }],
+    [mutation("catch", catchId, "delete", {}, now)],
+  );
+}
+
+export async function toggleFavorite(catchId: string): Promise<void> {
+  const record = snapshot.catches.find((c) => c.id === catchId);
+  if (!record) return;
+  const now = new Date().toISOString();
+  const patch = { favorite: !record.favorite, client_updated_at: now };
+  await persist(
+    [{ store: "catch", row: { ...record, ...patch } as unknown as StoredRow }],
+    [mutation("catch", catchId, "patch", patch, now)],
+  );
+}
+
+/**
+ * Persist a conditions snapshot and queue it. Separate from `saveCatch` because it runs
+ * after the catch is already durable — it must never be able to roll one back.
+ */
+export async function saveConditionSnapshot(record: { id: string } & Record<string, unknown>): Promise<void> {
+  const now = new Date().toISOString();
+  await persist(
+    [{ store: "condition_snapshot", row: record as unknown as StoredRow }],
+    [mutation("condition_snapshot", record.id, "insert", record, now)],
+  );
+}
+
+/**
+ * These are module-level functions with no closure over render state, so the object is a
+ * constant rather than something rebuilt (or memoised) on every render.
+ */
+export const logActions = Object.freeze({
+  saveCatch,
+  deleteCatch,
+  toggleFavorite,
+  startTrip,
+  endTrip,
+});

--- a/src/features/catches/ui-classes.ts
+++ b/src/features/catches/ui-classes.ts
@@ -1,0 +1,26 @@
+/**
+ * One visual spec for the Fish Log's repeated controls.
+ *
+ * These deliberately match `features/tackle/ui-classes.ts` value for value rather than
+ * importing it: ADR 005 §3 forbids one feature reaching into another's internals, and a
+ * shared control that both features must agree on belongs in `src/components/` when a
+ * third caller appears. Until then, duplication of four class strings is the cheaper
+ * mistake than a cross-feature import.
+ */
+
+export const FOCUS_RING =
+  "focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring";
+
+export const CHIP_CLASS = `min-h-touch-floor rounded-full border px-4 text-label transition-colors ${FOCUS_RING} active:scale-95 motion-reduce:transition-none`;
+export const CHIP_ON = "border-signal-orange bg-signal-orange text-ink-on-orange";
+export const CHIP_OFF = "border-border-interactive text-text-link";
+export const CHIP_OFF_ON_SURFACE = "border-border-interactive bg-surface text-text-link";
+
+export const PRIMARY_BUTTON = `inline-flex min-h-touch-floor items-center justify-center rounded-md bg-signal-orange px-4 text-label font-semibold text-ink-on-orange transition-colors hover:bg-signal-orange-pressed ${FOCUS_RING} active:scale-95 motion-reduce:transition-none`;
+
+export const SECONDARY_BUTTON = `inline-flex min-h-touch-floor items-center justify-center rounded-md border border-border-interactive px-4 text-label text-text-link transition-colors ${FOCUS_RING} active:scale-95 motion-reduce:transition-none`;
+
+export const INPUT_CLASS = `min-h-touch-floor w-full rounded-md border border-border-interactive bg-background px-4 text-body text-text-primary placeholder:text-text-muted ${FOCUS_RING}`;
+
+/** Cards in the log list. One height rule, one radius, one border — spec §43. */
+export const CARD_CLASS = "rounded-lg border border-hairline bg-surface";

--- a/src/features/shell/components/quick-mark-button.tsx
+++ b/src/features/shell/components/quick-mark-button.tsx
@@ -1,28 +1,47 @@
 "use client";
 
+import { useState } from "react";
+
+import { logQuickMark } from "@/features/catches/create";
+import { useLog } from "@/features/catches/store";
+
 /**
  * The quick mark — D22's man-overboard control. It lives in the (app) layout so it is one
  * thumb away from every product route by construction, not by remembering.
  *
- * When it is wired: it writes to IndexedDB and returns. No spinner, no "saving…", no
- * disabled-while-in-flight. A mark is saved the instant it is in the local store, and the
- * network is somebody else's problem (ADR 004 §6).
+ * It writes to IndexedDB and returns. No spinner, no "saving…", no disabled-while-in-
+ * flight: a mark is saved the instant it is in the local store, and the network is
+ * somebody else's problem (ADR 004 §6). The GPS fix and the conditions snapshot are
+ * attached afterwards and cannot hold up or undo the write.
  *
- * It is not wired yet — this round is the shell (ADR 005, scope note). A primary action is
- * never disabled without a visible reason next to it (docs/design/02-semantic-colors.md
- * §Disabled), so the reason is rendered, not left for the angler to guess at.
+ * The row it writes is deliberately NOT yet a fact: no species, no outcome, excluded
+ * from every rate until a human says what happened. That is what makes this button safe
+ * to hit with a fish thrashing on the deck — nothing is claimed by pressing it.
  */
 export function QuickMarkButton() {
+  const state = useLog();
+  const [marked, setMarked] = useState(0);
+
   return (
     <div className="flex flex-col items-end gap-1">
       <button
         type="button"
-        aria-disabled="true"
-        className="min-h-touch-primary-quick-mark rounded-full bg-signal-orange px-6 text-label text-ink-on-orange"
+        onClick={() => {
+          void logQuickMark(state);
+          setMarked((count) => count + 1);
+        }}
+        disabled={!state.available}
+        className="min-h-touch-primary-quick-mark rounded-full bg-signal-orange px-6 text-label font-semibold text-ink-on-orange transition-colors hover:bg-signal-orange-pressed focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring active:scale-95 disabled:opacity-disabled motion-reduce:transition-none"
       >
         Mark
       </button>
-      <p className="text-caption text-text-muted">Wired when logging lands</p>
+      <p aria-live="polite" className="text-caption text-text-muted">
+        {!state.available
+          ? "Storage blocked — cannot save"
+          : marked > 0
+            ? `${marked} saved. Add details in the Log.`
+            : "One tap. Details later."}
+      </p>
     </div>
   );
 }

--- a/src/features/shell/components/shell-nav.tsx
+++ b/src/features/shell/components/shell-nav.tsx
@@ -14,6 +14,7 @@ import { usePathname } from "next/navigation";
  */
 export const SHELL_ROUTES = [
   { href: "/", label: "Calendar" },
+  { href: "/log", label: "Log" },
   { href: "/tides", label: "Tide" },
   { href: "/settings", label: "Settings" },
 ] as const;

--- a/src/lib/offline/db.ts
+++ b/src/lib/offline/db.ts
@@ -1,0 +1,176 @@
+/**
+ * The local database (ADR 004 §1). IndexedDB via `idb`, one store per syncable entity
+ * plus `outbox` and `meta`.
+ *
+ * Two rules from the ADR are enforced by the shape of this module rather than by
+ * remembering:
+ *
+ *   1. **Reads never touch the network.** Nothing here imports Supabase. Every screen
+ *      renders from this database; the network's only job is to fill it in later.
+ *   2. **A row and its outbox record are written in ONE transaction.** If the tab is
+ *      killed between them, either both landed or neither did. A catch that exists
+ *      locally but has no mutation queued would never sync and nobody would know — that
+ *      is the quiet data-loss bug this design exists to prevent.
+ *
+ * `lib/` holds no domain knowledge (ADR 003 §2): this file knows about stores, keys and
+ * transactions, and nothing about what a catch is.
+ */
+
+import { openDB, type DBSchema, type IDBPDatabase } from "idb";
+
+import type { Mutation, SyncEntity } from "@/core/sync/outbox";
+
+/** Bump only with a migration in `upgrade` below. */
+const DB_VERSION = 1;
+const DB_NAME = "fish-log-book";
+
+export const ENTITY_STORES = [
+  "trip",
+  "trip_rig",
+  "catch",
+  "catch_gear",
+  "condition_snapshot",
+] as const;
+
+export type EntityStore = (typeof ENTITY_STORES)[number];
+
+/** Every syncable row carries at least these. Domain types live in `core/`. */
+export interface StoredRow {
+  readonly id: string;
+  readonly [key: string]: unknown;
+}
+
+interface FishLogDB extends DBSchema {
+  trip: { key: string; value: StoredRow };
+  trip_rig: { key: string; value: StoredRow; indexes: { by_trip: string } };
+  catch: { key: string; value: StoredRow; indexes: { by_trip: string; by_local_date: string } };
+  catch_gear: { key: string; value: StoredRow; indexes: { by_catch: string } };
+  condition_snapshot: { key: string; value: StoredRow; indexes: { by_catch: string } };
+  outbox: { key: string; value: Mutation; indexes: { by_state: string } };
+  meta: { key: string; value: unknown };
+  /** Photo blobs, kept out of the row so a list query never drags megabytes with it. */
+  media: { key: string; value: { id: string; catch_id: string; blob: Blob; created_at: string } };
+}
+
+let dbPromise: Promise<IDBPDatabase<FishLogDB>> | null = null;
+
+export function isIndexedDbAvailable(): boolean {
+  return typeof indexedDB !== "undefined";
+}
+
+export function getDb(): Promise<IDBPDatabase<FishLogDB>> {
+  if (!dbPromise) {
+    dbPromise = openDB<FishLogDB>(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        db.createObjectStore("trip", { keyPath: "id" });
+
+        const rig = db.createObjectStore("trip_rig", { keyPath: "id" });
+        rig.createIndex("by_trip", "trip_id");
+
+        const catches = db.createObjectStore("catch", { keyPath: "id" });
+        catches.createIndex("by_trip", "trip_id");
+        // The log lists by day and the calendar counts by day; both want this index
+        // rather than a full scan once a power user has 10,000 catches (spec §41).
+        catches.createIndex("by_local_date", "local_date");
+
+        const gear = db.createObjectStore("catch_gear", { keyPath: "id" });
+        gear.createIndex("by_catch", "catch_id");
+
+        const snapshots = db.createObjectStore("condition_snapshot", { keyPath: "id" });
+        snapshots.createIndex("by_catch", "catch_id");
+
+        const outbox = db.createObjectStore("outbox", { keyPath: "id" });
+        outbox.createIndex("by_state", "state");
+
+        db.createObjectStore("meta");
+        db.createObjectStore("media", { keyPath: "id" });
+      },
+    });
+  }
+  return dbPromise;
+}
+
+/**
+ * Write rows and their mutations atomically.
+ *
+ * One transaction spanning every touched store plus `outbox`. This is the function that
+ * makes "saved" mean saved: when it resolves, the data is durable on the device and a
+ * mutation is queued for it, or nothing happened at all.
+ */
+export async function commit(
+  writes: readonly { store: EntityStore; row: StoredRow }[],
+  mutations: readonly Mutation[],
+): Promise<void> {
+  const db = await getDb();
+  const stores = [...new Set(writes.map((w) => w.store))];
+  const tx = db.transaction([...stores, "outbox"], "readwrite");
+  await Promise.all([
+    ...writes.map((w) => tx.objectStore(w.store).put(w.row)),
+    ...mutations.map((m) => tx.objectStore("outbox").put(m)),
+  ]);
+  await tx.done;
+}
+
+export async function allRows(store: EntityStore): Promise<readonly StoredRow[]> {
+  const db = await getDb();
+  return db.getAll(store);
+}
+
+export async function rowsByIndex(
+  store: EntityStore,
+  index: string,
+  key: string,
+): Promise<readonly StoredRow[]> {
+  const db = await getDb();
+  return db.getAllFromIndex(store, index as never, key as never);
+}
+
+export async function allMutations(): Promise<readonly Mutation[]> {
+  const db = await getDb();
+  return db.getAll("outbox");
+}
+
+export async function putMutation(mutation: Mutation): Promise<void> {
+  const db = await getDb();
+  await db.put("outbox", mutation);
+}
+
+export async function putMedia(
+  id: string,
+  catchId: string,
+  blob: Blob,
+  createdAt: string,
+): Promise<void> {
+  const db = await getDb();
+  await db.put("media", { id, catch_id: catchId, blob, created_at: createdAt });
+}
+
+export async function mediaFor(catchId: string): Promise<readonly { id: string; blob: Blob }[]> {
+  const db = await getDb();
+  const all = await db.getAll("media");
+  return all.filter((m) => m.catch_id === catchId);
+}
+
+export async function deleteMedia(id: string): Promise<void> {
+  const db = await getDb();
+  await db.delete("media", id);
+}
+
+export async function readMeta<T>(key: string): Promise<T | undefined> {
+  const db = await getDb();
+  return (await db.get("meta", key)) as T | undefined;
+}
+
+export async function writeMeta(key: string, value: unknown): Promise<void> {
+  const db = await getDb();
+  await db.put("meta", value, key);
+}
+
+/** Test/reset seam. Closes the handle so the next `getDb()` reopens cleanly. */
+export async function __closeDbForTests(): Promise<void> {
+  if (!dbPromise) return;
+  (await dbPromise).close();
+  dbPromise = null;
+}
+
+export type { Mutation, SyncEntity };

--- a/supabase/migrations/20260901120000_v1_catch_gear.sql
+++ b/supabase/migrations/20260901120000_v1_catch_gear.sql
@@ -1,0 +1,88 @@
+-- =============================================================================
+-- catch_gear — several pieces of gear on one catch, each with a role
+--
+-- Implements: Fish Log spec §14 (multiple gear relationships) and §15 (historical
+-- gear accuracy). Additive only: no existing table, column, constraint or policy is
+-- altered or dropped by this file.
+--
+-- WHY THIS TABLE EXISTS
+--
+-- `catch` already carries `tackle_item_id`, copied from the sticky rig (D21a). That is
+-- one lure, and it is the right shape for the question D21a was answering — "what was
+-- tied on" — but it cannot express a rod, a reel, a main line, a leader and a jig on the
+-- same fish. The spec is explicit that the system must not be designed around a single
+-- `gear_id`, because "which leader was I using when the big ones bit" is exactly the
+-- question the Fish Log exists to answer later.
+--
+-- `catch.tackle_item_id` is deliberately LEFT IN PLACE and still populated. It is the
+-- indexed, single-value column that D21a's rig inheritance and the existing analytics
+-- views read, and removing it would be a destructive change to shipped behaviour for no
+-- gain. Treat it as the primary lure; treat this table as the full rig. When an analysis
+-- needs one lure per catch it reads the column; when it needs the whole setup it joins
+-- here.
+--
+-- WHY label/detail ARE STORED ALONGSIDE tackle_item_id (spec §15)
+--
+-- An angler edits or deletes a tackle item six months after the catch. The FK is
+-- ON DELETE SET NULL rather than CASCADE, so losing the tackle item never deletes the
+-- record of the fish, and `label`/`detail` — snapshotted at the moment of the catch —
+-- keep the history true even after the link is gone. The id is for "how has this jig
+-- performed"; the snapshot is for "what was actually on the end of the line that day".
+-- Storing only one of the two loses a real question.
+-- =============================================================================
+
+create table public.catch_gear (
+  id                uuid primary key default gen_random_uuid(),
+  angler_id         uuid not null references public.angler(id) on delete cascade,
+  catch_id          uuid not null references public.catch(id) on delete cascade,
+  -- Nullable and SET NULL on purpose: gear the angler no longer owns still caught a fish.
+  tackle_item_id    uuid references public.tackle_item(id) on delete set null,
+  role              text not null check (role in (
+                      'rod','reel','main_line','leader','hook',
+                      'lure','jig','bait','weight','terminal')),
+  -- The §15 snapshot. NOT NULL: a gear row that names nothing is not worth keeping.
+  label             text not null check (length(btrim(label)) > 0),
+  detail            text,
+  created_at        timestamptz not null default now(),
+  client_updated_at timestamptz,
+  updated_at        timestamptz not null default now(),
+  -- Deliberately NOT unique on (catch_id, role): two jigs on a dropper loop, or two
+  -- rods on a trolling pattern, are real rigs and the schema must not forbid them. The
+  -- client replaces a catch's gear set wholesale on edit, so duplicates cannot accrete.
+  deleted_at        timestamptz
+);
+
+comment on table public.catch_gear is
+  'Fish Log spec §14/§15. Several pieces of gear per catch, each with a role. '
+  'label/detail are a snapshot taken at the moment of the catch and are what keeps a '
+  'historical catch accurate after the tackle item is edited or deleted; tackle_item_id '
+  'is the live link and may go null. catch.tackle_item_id remains the single primary '
+  'lure for D21a rig inheritance and is not superseded by this table.';
+
+create index idx_catch_gear_catch   on public.catch_gear (catch_id) where deleted_at is null;
+create index idx_catch_gear_tackle  on public.catch_gear (tackle_item_id)
+  where tackle_item_id is not null and deleted_at is null;
+-- The sync cursor shape used by every other syncable table (ADR 004 §5).
+create index idx_catch_gear_updated on public.catch_gear (angler_id, updated_at, id);
+
+create trigger tg_catch_gear_updated_at before update on public.catch_gear
+  for each row execute function public.tg_set_updated_at();
+
+-- -----------------------------------------------------------------------------
+-- RLS: the same four policies every angler-owned table gets, written the same way
+-- (`(select auth.uid())` so it is evaluated once per statement, not once per row).
+-- -----------------------------------------------------------------------------
+
+alter table public.catch_gear enable row level security;
+
+create policy catch_gear_select on public.catch_gear
+  for select to authenticated using (angler_id = (select auth.uid()));
+create policy catch_gear_insert on public.catch_gear
+  for insert to authenticated with check (angler_id = (select auth.uid()));
+create policy catch_gear_update on public.catch_gear
+  for update to authenticated
+  using (angler_id = (select auth.uid())) with check (angler_id = (select auth.uid()));
+create policy catch_gear_delete on public.catch_gear
+  for delete to authenticated using (angler_id = (select auth.uid()));
+
+revoke all on public.catch_gear from anon;


### PR DESCRIPTION
Log a catch in a couple of taps, review your history, and have none of it depend on having signal.

Full write-up: `docs/design/09-fish-log.md`. Worklog: `docs/team/worklog/2026-09-01-01-head-dev.md`.

## The headline finding: this was not a schema project

The spec (§38/§47/§48) asks for an architecture review before building tables and lists seven entities. **Six already exist** in `20260828120000_v1_core_schema.sql`, and they are better specified than the sketch in §39 — D22 mark lifecycle, D21a sticky rig, timezone-safe local-date bucketing, soft deletes, sync columns, RLS.

| Spec asks for | Maps to | New? |
|---|---|---|
| `catches` / `species` / `trips` | `catch` / `species` / `trip` | existing |
| `catch_environment` | `condition_snapshot` | existing |
| `locations` / `gear_items` | `spot` / `tackle_item` | existing |
| `catch_gear` | `public.catch_gear` | **added** |

So this is a UI + local-store slice on the existing ontology, with **one additive migration**. Answers to all seventeen §48 questions are in the design doc.

### The one migration

`catch` already had `tackle_item_id` — one lure. §14 is explicit that the system must not be built around a single `gear_id`, because "which leader was on when the big ones bit" is a question the log exists to answer. `catch.tackle_item_id` **stays and is still written** (D21a inheritance and the analytics views read it); `catch_gear` carries the full rig beside it.

Each gear row stores `tackle_item_id` **and** a `label`/`detail` snapshot with `ON DELETE SET NULL` — that is §15: delete that jig from your Tackle Box six months later and the catch still says what was tied on.

## What you can do

- **`/log`** — Fish Log home: `+ Log catch`, catches grouped by day, search, All / Favorites / Needs details. Not a dashboard; analytics get their own feature (§8).
- **Quick Log** — species is the only thing above the fold and Save is live from the first tap. Everything else is behind **Add details**.
- **Species picker** — recent first (during a hot bite the fish you just caught is the fish you're about to catch again), then a curated common set, then all species one tap away, then search, then free text.
- **Repeat / Duplicate** — carry *how you were fishing*, never *this fish*: weight, length and notes never copy forward, because copying them manufactures data.
- **Quick mark (D22)** — the shell button that has read "wired when logging lands" since the shell round is now wired. Writes an `unresolved` row, out of every rate until you say what it was.
- Catch detail with two-step delete, favorites, photos stored on-device.

## Two bugs found by testing, not by reading

1. **The save awaited the GPS fix.** With no recent fix that is the full timeout — four seconds of nothing, against a 5–10s target for the whole catch, and a straight breach of §21. Caught by *measuring* the save. Position is now read, never awaited; a fix landing later is patched on.
2. **`RepeatSeed` speaks column names, `CatchDraft` speaks form-field names.** Spreading one into the other type-checks and silently drops every value, so Duplicate opened with no species. Now an explicit mapper, plus a test that fails if a snake_case key ever reaches a draft.

## Numbers

| | |
|---|---|
| Basic catch — open → saved and on screen | **225 ms** |
| Repeat catch | **47 ms** · quick mark **46 ms** |
| Catch saved with network **fully off** | **82 ms**, durable across reload |
| 10,000 catches — log opens | **632 ms**, 433 DOM nodes |
| 10,000 catches — search keystroke → repaint | **61 ms** |

The 5–10s target in §2 is a *human* budget; the app's share is about a fifth of a second.

## How it was checked

- `npm run verify` green — tokens, tripwires, lint, tsc, **273 tests**. `npm run build` green, `/log` static.
- **26 browser checks** at 390×844, zero console errors: full log/repeat/duplicate/delete/favorite/search path, mark landing in the needs-details queue, a save with the network completely off, 10,000-catch scale, keyboard-only sweep (including focus moving to "Keep it" when the delete confirm opens rather than falling to `<body>`), no horizontal overflow at 390 px and 320 px, every control clearing a 44 px touch floor.
- **The migration was run against a real PostgreSQL 16**, not eyeballed. All six migrations apply in order; deleting a tackle item leaves the gear label intact with the link nulled (§15); blank labels and unknown roles refused; two jigs on one catch allowed; **RLS blocks cross-angler read, insert and delete, and `anon` has nothing** (§37 enforced at the data layer, not visually).
- Coordinates are never rendered anywhere — the detail says "Saved privately with this catch" (§20).
- **Not tested on a real phone.** Same open item as the tide chart and Tackle Box.

## Deliberately not built

- **The outbox flusher.** The envelope, retry schedule, conflict policy and glass vocabulary are implemented and tested; the code that actually pushes to PostgREST is not. It can't be written honestly without a live backend to round-trip against, and a sync layer that has never synced is worse than none because it *looks* finished. Writes queue durably meanwhile; nothing is lost.
- **Catch-time editing** — §22 requires the conditions snapshot be invalidated and re-derived with it; that belongs to the enrichment lane.
- Trip UI (trips are created and joined implicitly and correctly, but `/trip/[id]` is still a stub), spot picking, and everything in §45.

## Deviations, stated plainly

1. No `tags`/`catch_tags` tables — tags are a local `text[]`; a join table with no writer is speculative schema.
2. `catch.tackle_item_id` kept rather than replaced (removing it breaks D21a and shipped views).
3. Snapshots are `partial` rather than `pending` when a fix exists, because the on-device astro fields are genuinely observed.
4. The prototype writes as one hard-coded local angler — no auth session is wired to the log yet. The RLS that makes this safe server-side is in place and verified.

One process note: this landed on `claude/merge-open-prs-main-vslm29`, which is the branch this session was pinned to — the name is from the earlier PR-merge task, not this work.

---
_Generated by [Claude Code](https://claude.ai/code/session_012SN8zV9RF1J5qXXzgzbEru)_