### PR TITLE
architect + ux-ui: 2026-09-01 post-merge code review — backup badge honesty + heading fixes

### DIFF
--- a/docs/team/HANDOFF.md
+++ b/docs/team/HANDOFF.md
@@ -4,9 +4,17 @@
 Written to be self-contained. If you are picking this up cold, read this file top to
 bottom before touching anything.
 
-**Last updated:** 2026-08-28 (late)
-**Project state:** design and research complete for V1 scope. **No application code
-written yet.** The Next.js app in `src/` is an unmodified starter skeleton.
+**Last updated:** 2026-09-01 (pm, architect + ux-ui review)
+**Project state:** design and research complete for V1 scope; the app build is underway.
+The Next.js app in `src/` is **no longer a starter skeleton**: as of 2026-09-01 it has a
+design-token system, the shell (nav, backup badge, quick mark), an immersive tide screen
+with cached fixtures, the tackle-box inventory, a fish-log MVP with Quick Log and setup
+screens, and the local offline store (`idb`) plus outbox/uuidv7 core — 303 passing tests.
+Sync to Supabase is **not** wired yet: every screen's backup badge reads "Saved on this
+device", which is the truth. The next large piece is the outbox flusher and the schema
+migrations validating against a live project (two no-reply rulings sit with the owner —
+Supabase region + offline scope, and the live-tide-data decision; the tide fixture window
+expires **2026-09-04**).
 
 ---
 

--- a/docs/team/reviews/2026-09-01-architect-ux-ui-review.md
+++ b/docs/team/reviews/2026-09-01-architect-ux-ui-review.md
@@ -1,0 +1,134 @@
+# Joint code review — architect + ux-ui — 2026-09-01 (afternoon)
+
+**Scope.** Everything that landed on `main` today: tide work (#10), tackle box (#11),
+category pages (#12), fish-log MVP (#13), the morning staff-meeting minutes +
+quick-mark opt-in + setup screens (#15), fish-log setup (#16), on top of the shell.
+Plus a review of the meeting document itself
+(`docs/team/meetings/2026-09-01-september-staff-meeting.md`).
+
+**Method.** Fresh `npm ci` off `main` (`a64bac6`), full `npm run verify`, then module-by-module
+reads of the new code (`catches`, `setup`, `lib/offline`, `core/sync`, `shell`), then a
+14-route headless-browser smoke (status codes + console/page errors at 390px), DOM and
+ARIA probes, and a visual sweep of the new screens. No fabrication: every claim below was
+observed in code or in the live DOM — and the "cleared" list is written down too.
+
+`npm run verify` on `main` before any edits: **tokens ✓ · tripwires ✓ · lint ✓ · tsc 0 errors ✓ · 303/303 tests ✓**.
+Main was **not** broken at rest. The errors were of a different kind: things the code
+*says* that aren't true, and heading structure.
+
+---
+
+## A. Errors found — fixed in this PR (4)
+
+### E1 — Every screen claims "Backed up" with a green dot. Nothing has ever been backed up. — SEVERE
+`readBackupState()` returned `{ kind: "settled" }` unconditionally
+(`src/features/shell/queries/backup-state.ts`), and the badge maps `settled` →
+green dot + **"Backed up"** on every screen (`shell-frame.tsx` header). Zero rows have
+ever left this device — the sync store and flusher don't exist yet. ADR 004 §6 reserves
+"Backed up" for *on the server*; this was the most fish-shaped sentence in the product
+and the meeting's own #1 defect.
+
+**Fix:** new state `{ kind: "local-only" }` — the only honest state while the outbox
+store is unbuilt — rendered as **"Saved on this device"** with the quiet grey dot.
+Green is now earned only by `settled`. Existing vocabulary contract tests kept; new test
+pins `local-only` → the new words.
+Files: `backup-state.ts`, `backup-badge.tsx`, `backup-state.test.ts`.
+
+### E2 — `/tides` has no `h1` at all (WCAG 1.3.1)
+The immersive tide canvas is built from buttons and readouts; the only headings on the
+whole route were the `h2`s inside the four dormant sheets (station / moon / date /
+cached-days). A screen-reader landmark outline of the app's flagship screen was empty.
+
+**Fix:** `<h1 className="sr-only">Tide</h1>` at the root of both render branches.
+Zero visual change (verified by screenshot).
+File: `src/features/conditions/tide-screen.tsx`.
+
+### E3 — Tackle category pages skip a heading level (h1 → h3)
+`/tackle/hooks` etc. render the category `h1`, then card titles and empty-state titles
+at `h3` with no `h2` between. The same component is correct on the main box page, where
+the visible **"All gear" h2** genuinely heads the section — which is how it slipped through.
+
+**Fix:** when scoped to a category, the inventory section now emits an unseen
+`<h2 className="sr-only">All {category}</h2>` so the outline walks h1 → h2 → h3 on both
+pages. Zero visual change (verified in DOM: `H1:Hooks | H2:sr:All hooks`).
+File: `src/features/tackle/components/tackle-inventory-list.tsx`.
+
+### E4 — `docs/team/HANDOFF.md` first paragraph was false
+"**No application code written yet.** The Next.js app in src/ is an unmodified starter
+skeleton." — written 2026-08-28, now wrong by ~2,500+ lines of application code and is
+the document every new agent is told to read first (the meeting flagged this too).
+
+**Fix:** header paragraph rewritten to today's truth, including the two owner rulings
+still pending and the **2026-09-04 fixture expiry** date.
+
+---
+
+## B. Suspected errors, investigated, cleared — written down so nobody re-burns the hour
+
+1. **"Marksaved" (missing space in the quick-mark toast)** — looks jammed in a
+   screenshot, but the DOM string is `"Mark saved"` with the space. Rendering artifact,
+   not a typo. Cleared.
+2. **"Quick Log sheet has no dialog semantics"** — probe error. The sheet *is* a native
+   `<dialog>` (`showModal()`), `aria-labelledby="quick-log-title"`, closes on Escape,
+   labelled by a real `h2`. Rest-element queries missed its implicit role. Cleared.
+3. **"`tsc` errors: `idb` not found"** — stale `node_modules` from before a branch
+   switch. `npm ci` after checkout; 0 errors. Cleared.
+4. **"Meeting said 281 tests, repo has 303"** — the minutes were written at 6 a.m.;
+   three PRs landed after. Both numbers true at time of writing. Not a doc error.
+   (Same for 6 → 7 migrations.)
+5. **"/log has h1 but no h2"** — valid heading structure: one h1, paragraphs, no
+   sections. Cleared.
+
+## C. Real issues NOT fixed in this PR — roadmapped or awaiting rulings
+
+- **Tide fixture window expires 2026-09-04 (3 days).** After that the tide screen shows
+  its (honest) "No tide predictions loaded" empty state until live data lands. This is
+  owner decision #1 from the meeting; implementing live NOAA fetch without the ruling
+  would put words in the owner's mouth. **Urgent.**
+- **`docs/legal/` does not exist** (counsel's item: privacy policy & terms before any
+  public demo). Out of engineer scope.
+- **Sync flusher + `src/core/sync/store.ts` remain unbuilt** — head-dev lane, in
+  flight per meeting action items. E1 keeps the glass honest until it lands.
+- Two unrelated types are both named `BackupState` (`core/sync/outbox.ts` with
+  `backed_up` vs `features/shell/queries/backup-state.ts` with `settled`). Not wrong —
+  different layers — but worth renaming one before the flusher wires them together.
+- Learn-page "Diagnostics" and the notification-broom TODOs are real TODOs, honestly
+  marked, low priority.
+
+## D. Review of the morning staff meeting (the document itself)
+
+- **Accurate where verifiable.** The two headline claims we could test — the "Backed
+  up" lie and the stale HANDOFF — were both real and both reproduced exactly. The
+  minutes' own correction commit (`f191d46`, CI/Vercel claim) exists in history.
+- **Honest about uncertainty.** Roles flagged their own unverified claims rather than
+  bluffing; nothing in the doc asserts what it can't show.
+- **Action items listed today were indeed "not started"** when stated; this review took
+  the two doc/honesty items (E1, E4) as part of the fix scope, and the a11y sweep (E2,
+  E3) confirms the meeting's Medium a11y item was well-founded.
+- **One gap worth noting for future minutes:** the meeting's architecture section
+  proposes a "backup indicator shows three states" audit — with E1 fixed, the *real*
+  three-state audit now blocks on the flusher, not on the badge.
+
+## E. What reviewed clean (worth emulating)
+
+- `uuidv7`: monotonic sequence with same-ms and *backwards-clock* borrow-forward
+  handling; test-seam reset. Load-bearing and correct.
+- `outbox.ts`: the outcome→state machine is **total** over its union (no undefined
+  branch); full-jitter backoff with injected randomness; vocabulary in the type system.
+- Quick mark: Undo acts on the in-flight write's **promise** so the button never blocks;
+  `aria-live` announcement is deliberately separate from the timed-out visual toast;
+  storage-blocked state is surfaced instead of silently failing.
+- `preference.ts`: the hydration-hazard handling (server snapshot + subscribe-gated
+  ref) is documented next to the code, and Safari-private-mode `localStorage` throws are
+  caught. Careful code.
+- Zero console errors / page errors across all 14 smoked routes; all stubs are honest
+  stubs ("The month grid lands next", "Prototype: changes stay in this session…").
+
+## F. Verification of this PR
+
+- `npm run verify`: tokens ✓ · tripwires ✓ · lint ✓ · tsc 0 errors ✓ · **304/304 tests ✓**
+  (303 + the new local-only vocabulary test).
+- Live DOM after fix: badge = `Saved on this device` + grey dot; `/tides` h1 = `Tide`
+  (sr-only); `/tackle/hooks` outline = `H1:Hooks → H2(sr):All hooks`.
+- Screenshots (390px): badge, tide screen (visually unchanged), hooks page,
+  `/log` at 320px, `/setup`.

--- a/docs/team/worklog/2026-09-01-04-architect.md
+++ b/docs/team/worklog/2026-09-01-04-architect.md
@@ -1,0 +1,27 @@
+### 2026-09-01 | architect | Joint code review + backup-badge honesty fix (with ux-ui)
+
+Founder asked for an architect + ux-ui review of post-merge `main` and of the morning
+staff meeting, the errors written down, then one fix PR. Full findings:
+`docs/team/reviews/2026-09-01-architect-ux-ui-review.md`.
+
+- **E1 (owned this commit): the backup badge lied.** `readBackupState()` returned
+  `settled` unconditionally → green dot + "Backed up" on every screen while zero bytes
+  have ever left the device. ADR 004 §6 reserves those words for server-confirmed data.
+  Mechanical temptation was to leave a TODO and ship; the honest minimal change is a new
+  `local-only` state rendered **"Saved on this device"**, grey dot, with a test pinning
+  the words and the seam's current answer. The vocabulary contract tests stay — `settled`
+  still means "Backed up" for the day the flusher earns it.
+- **E4: HANDOFF.md's opening line** ("no application code written yet… starter skeleton")
+  was two false sentences in the doc every new agent reads first. Rewrote the header to
+  the actual state, including the two pending owner rulings and the fixture deadline.
+- **What I checked and did NOT touch:** `uuidv7` (backwards-clock handling is correct),
+  `outbox.ts` (state machine total over `SendOutcome`), fish-log/quick-log writes
+  (fire-and-forget by design, undo keyed off the write's promise), `preference.ts`
+  hydration handling. Zero console errors on 14 smoked routes.
+- **Noted, not fixed (other lanes / owner rulings):** tide fixture expires 2026-09-04;
+  `docs/legal/` missing; flusher + sync store still to build; two types named
+  `BackupState` (outbox vs shell query) — rename one when the flusher wires them.
+- **Meeting minutes review:** accurate and honest wherever verifiable; the one correction
+  commit exists; both "not started" items under my remit are done here.
+- **Verification:** `npm ci` fresh, `npm run verify` green (tsc 0, 304/304 tests), DOM
+  probed live for the badge text and heading outline, screenshots taken at 390/320px.

--- a/docs/team/worklog/2026-09-01-05-ux-ui.md
+++ b/docs/team/worklog/2026-09-01-05-ux-ui.md
@@ -1,0 +1,21 @@
+### 2026-09-01 | ux-ui | Joint code review + heading-order fixes (with architect)
+
+Same review as the architect's entry; findings in
+`docs/team/reviews/2026-09-01-architect-ux-ui-review.md`. The ux-ui-owned repairs:
+
+- **E2: `/tides` had no `h1`.** The immersive canvas is buttons and readouts; the only
+  headings in the DOM lived inside the four dormant sheets. Added an sr-only
+  `h1 "Tide"` in both render branches. Screenshot-diff: zero pixels moved.
+- **E3: category pages skipped h2.** `h1 "Hooks"` → card/empty-state `h3`s, nothing
+  between. The shared inventory list is correct on the main box (visible "All gear" h2),
+  so the fix lives in the shared component: an sr-only `h2 "All hooks"` exists only when
+  the list is category-scoped. Outline now walks h1 → h2 → h3 on both surfaces.
+- **Cleared after honest investigation (probe bugs, not app bugs):** the "Marksaved"
+  jammed space is a rendering artifact (DOM string is correct); the Quick Log sheet *is*
+  a native modal `<dialog>` with `aria-labelledby` and Escape — my first probe tested an
+  attribute selector against an implicit role.
+- **Confirmed good, kept:** quick mark placement/size/undo + separate aria-live line;
+  tackle back-link and header anatomy; `/log` and `/setup` new screens read clean at
+  390px and `/log` at 320px; tide screen visual unchanged.
+- **Verification:** verify green (304/304), ARIA probes on live DOM, screenshots at
+  390/320px attached to the PR.

--- a/src/features/conditions/tide-screen.tsx
+++ b/src/features/conditions/tide-screen.tsx
@@ -172,6 +172,8 @@ export function TideScreen() {
   if (!hasSamples) {
     return (
       <section className="tide-screen">
+        {/* The immersive canvas has no visible title; keep the page named for outline and screen readers. */}
+        <h1 className="sr-only">Tide</h1>
         <div className="tide-empty">
           <p className="tide-empty-title">No tide predictions loaded</p>
           <p className="tide-empty-note">
@@ -192,6 +194,8 @@ export function TideScreen() {
 
   return (
     <section className="tide-screen">
+      {/* The immersive canvas has no visible title; keep the page named for outline and screen readers. */}
+      <h1 className="sr-only">Tide</h1>
       <header className="tide-header">
         <div className="tide-header-top">
           <button type="button" className="tide-station-button" aria-haspopup="dialog" onClick={() => setSheet("station")}>

--- a/src/features/shell/components/backup-badge.tsx
+++ b/src/features/shell/components/backup-badge.tsx
@@ -10,12 +10,14 @@ export function BackupBadge() {
   const state = readBackupState();
   const label = describeBackupState(state);
 
+  // Green is earned only by `settled` — the server actually has the data. Local-only is
+  // deliberately the same quiet grey as "waiting": a small dot, never a success signal.
   const dot =
     state.kind === "needs-attention"
       ? "bg-amber-flag"
-      : state.kind === "waiting"
-        ? "bg-text-muted"
-        : "bg-success-green";
+      : state.kind === "settled"
+        ? "bg-success-green"
+        : "bg-text-muted";
 
   return (
     <p className="flex items-center gap-2 text-caption text-text-muted">

--- a/src/features/shell/queries/backup-state.test.ts
+++ b/src/features/shell/queries/backup-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { describeBackupState } from "./backup-state";
+import { describeBackupState, readBackupState } from "./backup-state";
 
 /*
  * ADR 004 §6 fixes this vocabulary deliberately: "Saved" and "Backed up" are different
@@ -17,6 +17,12 @@ describe("backup state vocabulary", () => {
 
   it("says backed up only when it is on the server", () => {
     expect(describeBackupState({ kind: "settled" })).toBe("Backed up");
+  });
+
+  it("says saved on this device — never backed up — before anything has synced", () => {
+    expect(describeBackupState({ kind: "local-only" })).toBe("Saved on this device");
+    // What the seam reports until the outbox store exists (ADR 004 §1): local-only.
+    expect(readBackupState().kind).toBe("local-only");
   });
 
   it("uses the agreed words for the one state allowed to interrupt", () => {

--- a/src/features/shell/queries/backup-state.ts
+++ b/src/features/shell/queries/backup-state.ts
@@ -10,19 +10,24 @@
  * There is no red banner here and there never will be.
  *
  * TODO(ADR 004 §1): read the real count from the outbox store once src/core/sync/store.ts
- * exists. Until then this reports a settled state rather than inventing a number.
+ * exists. Until then the only honest answer is `local-only`: every write lives on this
+ * device and nothing has ever reached a server, so the glass says "Saved on this device"
+ * — never "Backed up" next to a green dot while zero bytes have been backed up.
  */
 export type BackupState =
+  | { kind: "local-only" }
   | { kind: "settled" }
   | { kind: "waiting"; count: number }
   | { kind: "needs-attention"; count: number };
 
 export function readBackupState(): BackupState {
-  return { kind: "settled" };
+  return { kind: "local-only" };
 }
 
 export function describeBackupState(state: BackupState): string {
   switch (state.kind) {
+    case "local-only":
+      return "Saved on this device";
     case "settled":
       return "Backed up";
     case "waiting":

--- a/src/features/tackle/components/tackle-inventory-list.tsx
+++ b/src/features/tackle/components/tackle-inventory-list.tsx
@@ -124,6 +124,13 @@ export function TackleInventoryList({
       </label>
 
       <section aria-labelledby={headingId} className="flex flex-col gap-3">
+        {/*
+          On the main box this section is named by the visible "All gear" h2 above it.
+          On a category page the section name is the page h1 itself, and the card
+          titles (h3) would leap a level — so the outline keeps an unseen h2 here
+          rather than skipping from h1 to h3 (WCAG 1.3.1 heading order).
+        */}
+        {scopeLabel ? <h2 className="sr-only">All {scopeLabel.toLowerCase()}</h2> : null}
         {scopedItems.length === 0 ? (
           <div className="rounded-lg border border-hairline bg-surface p-6">
             <h3 className="text-h3">


### PR DESCRIPTION
## What this is
Joint architect + ux-ui review of today's post-merge `main` (PRs #10–#16) and of this morning's staff-meeting minutes. **Full findings document: `docs/team/reviews/2026-09-01-architect-ux-ui-review.md`.**

## Errors found & fixed (4)

| # | Error | Fix |
|---|---|---|
| **E1** (severe) | Every screen claimed green-dot **"Backed up"** while zero rows have ever synced — ADR 004 §6 reserves those words for server-confirmed state; meeting's #1 defect | New `local-only` state → **"Saved on this device"** + quiet grey dot; green is earned only by `settled`. Contract tests kept + 1 new test |
| **E2** | `/tides` had no `h1` at all (WCAG 1.3.1) | sr-only `h1 "Tide"` in both render branches — zero visual change |
| **E3** | Tackle category pages skipped a heading level (h1→h3); correct on the main box, wrong when scoped | Shared inventory list emits sr-only `h2 "All {category}"` when category-scoped — outline now walks h1→h2→h3 on both surfaces, zero visual change |
| **E4** | `docs/team/HANDOFF.md` opening line was false ("No application code written yet… starter skeleton") | Header rewritten to today's real state, incl. pending owner rulings + the **2026-09-04 fixture expiry** |

## Suspected, investigated, cleared (written down in the review doc)
"Marksaved" toast typo (rendering artifact; DOM string correct) · Quick Log sheet "missing dialog" (it IS a native `<dialog>` with `aria-labelledby`; probe tested an attribute selector) · tsc `idb` errors (stale node_modules) · meeting's 281 vs current 303 tests (both true at their times).

## Real issues NOT fixed here (roadmap / owner rulings)
- ⚠️ **Tide fixture window expires 2026-09-04** — owner decision #1 (live tide data) is the gate
- `docs/legal/` missing (counsel item, before any public demo)
- Flusher + `src/core/sync/store.ts` still to build (head-dev); E1's badge keeps the glass honest until then
- Minor: two unrelated types both named `BackupState` — rename one when the flusher wires them

## Verification
`npm run verify` green: tokens ✓ tripwires ✓ lint ✓ tsc 0 errors ✓ **304/304 tests** (303 + 1 new). 14-route headless smoke: 0 console/page errors. Live DOM: badge = "Saved on this device" + grey dot · `/tides` h1 = Tide (sr-only) · `/tackle/hooks` = H1 → sr-only H2 → H3. Visual sweeps at 390px & 320px: no pixel changes except the badge text.