### PR TITLE
architect + ux-ui: expansion foundations — regions, freshwater types, milky clarity, GPS ratified

### DIFF
--- a/docs/architecture/decisions/007-regional-expansion-and-catch-gps.md
+++ b/docs/architecture/decisions/007-regional-expansion-and-catch-gps.md
@@ -1,0 +1,89 @@
+# ADR 007 — Region expansion, freshwater readiness, catch GPS, and the map
+
+**Status:** accepted (founder rulings 2026-09-01, intake:
+`docs/product/requests/2026-09-01-expansion-requirements.md`)
+**Decides on:** founder requirements §1–§5 (and the principle behind §8–§10).
+
+---
+
+## 1. The rule that shapes everything here
+
+**No region is in the data model, ever.** A catch is species + time + GPS + spot +
+setup + conditions + tide. Geography that *interprets* that (which region you fish,
+what species get suggested) is presentation and preference. The day the app claims to
+"know where you are" and filters your fish accordingly, it has stopped being a logbook
+and started being a guesser. Recommendation is a layer, not a column.
+
+## 2. Catch GPS — already built, now ratified
+
+Requirement §1's capture half exists: catches carry `lat` / `lng` / `gps_accuracy_m`.
+The pattern (`attachPositionLater`) implements exactly the founder's UX ruling —
+request opens with the sheet, save *reads* the fix and never awaits it, late fixes patch
+the row, misses are a null, and none of it blocks the water (spec §21).
+
+Two properties to preserve in later slices:
+
+- **A missing fix is an honest `null`, never a synthesized point.** "No GPS" is data.
+- **Offline-first by construction:** coordinates live in the local store and ride the
+  outbox like everything else (ADR 004). "No service" never was a special case.
+
+## 3. Spots vs catch GPS — two nouns, both kept
+
+| | Fishing Spot (`spot`) | Catch GPS (`catch.lat/lng`) |
+|---|---|---|
+| Origin | Angler names it | Device fixes it |
+| Precision | Area that produces | Exact instant of the catch |
+| Mutability | Renames, retunes | Immutable; accuracy recorded |
+| Question it answers | "Does the West End pay?" | "Where exactly was that bite?" |
+
+Both are required — §2 of the intake. Collapsing them into one field loses the
+analysis the founder asked for (spot → conditions → success). The `spot` table exists in
+the schema; a `spot.environment` and `spot.typical_depth` shape lands with the spots
+slice; catches reference a spot id *and* keep their own fix.
+
+## 4. Regions steer defaults — Settings, not schema
+
+`settings/region.ts` — a device-local preference (same `preference.ts` mechanics as
+units; IDB migration noted in its header applies here too). `core/ontology/regions.ts`
+maps region → a curated starter list. Rules:
+
+- Search and "Something else" always reach the full vocabulary in every region.
+- Custom region = no regional suggestions; Recent learns the water instead.
+- Lists are honest starter sets (`needs_review` flags carry forward), not a promise
+  of local regulations. The app never tells anyone a season or a limit.
+
+## 5. Freshwater readiness without a rewrite
+
+`core/ontology/environments.ts` lands the eight environments (ocean → stream) with
+water-class roll-ups and each environment's eventual condition emphasis. The species
+vocabulary already carried `water_class`; freshwater species now fill that half of the
+list. What consciously did **not** happen: conditions questions did not split by
+environment yet — that is product design (which variables matter to whom), and landing
+it half-thought would build the rewrite the founder explicitly wants to avoid.
+
+## 6. The map is offline-first geometry
+
+Per founder ruling: markers ride built-in coastline/chart geometry that renders with
+zero signal; network tiles (if ever) are progressive enhancement cached when available.
+A blank gray grid offshore is the one outcome this decision exists to prevent.
+
+## 7. What this ADR pre-commits later slices to
+
+- **Tide markers (§6 intake):** placed on the curve by `caught_at`; cluster/staple
+  overlaps; tap → catch sheet. Fixture data is fine — expiration risk lives in owner
+  decision on live tide data, not here.
+- **Calendar (§7):** `/` is a stub today by honesty, not by accident; month grid with
+  record dots per the calendar decision (D-series notes).
+- **Filters (§8):** query layer over the local store, both location kinds.
+- **Night Fishing Mode (§9):** a third appearance, *not* a dark-theme variant; it owns
+  its own contrast/glare decisions when it lands.
+- **Don't-Forget List (§10):** trip gear specs compared against the tackle box; the
+  list reads gear by id, never by typed name.
+
+## Consequences
+
+- Species picker reaches `regions.ts`; the SoCal chip list moved from a component
+  constant into region data without changing one chip's identity.
+- One new migration keeps the vocabulary parity honest (milky + regional species), and
+  a parity test now fails on any future drift in either direction — the mirror comment
+  in `species.ts` finally has teeth.

--- a/docs/product/requests/2026-09-01-expansion-requirements.md
+++ b/docs/product/requests/2026-09-01-expansion-requirements.md
@@ -1,0 +1,65 @@
+# Founder requirements — 2026-09-01 — expansion & forward-looking direction
+
+**Status: received, rulings taken (below), foundations landed 2026-09-01 (this repo).**
+This file is the intake record. ADR 007 carries the architectural decisions; this file
+carries what was asked and how each item maps to work.
+
+## The founder's ten items
+
+1. **Fish Log → GPS map integration.** GPS per catch, offline-then-sync, map of markers,
+   tap a marker → full snapshot (species, time, GPS, spot, setup, bait, conditions, tide,
+   weather).
+2. **Fishing Spots vs catch GPS.** Two kinds of location stay separate; spots are named,
+   optional-GPS, with environment/depth notes; catches keep their exact fix AND can
+   reference a spot. Enables Spot → area → conditions → setup → species analysis.
+3. **Water clarity: add Milky.** Keep the rest. ✅ **Shipped in this PR.**
+4. **Region-based species suggestions.** Fishing-region preference in Settings (SoCal,
+   NorCal, Florida, Hawaii, Cabo/Baja, Gulf Coast, Northeast, Great Lakes, Custom);
+   region steers suggestions and defaults, never restricts search/add. ✅ **Shipped.**
+5. **Freshwater support.** Never hard-code ocean assumptions; environments eventually
+   ocean/inshore/bay/harbor/lake/reservoir/river/stream; each environment surfaces the
+   conditions that actually matter to it. ✅ **Type groundwork shipped** (`environments.ts`).
+6. **Catch markers on the tide chart.** Exact catch time on the curve, tap → catch info,
+   overlapping markers cluster/stack. _Next slice._
+7. **Calendar view.** Month grid with activity dots; day → catches/spots/conditions;
+   moves Catch ↔ Day ↔ Chart ↔ Map. _Next slice — the `/` page is an honest stub today._
+8. **Catch filtering.** Species, spot, GPS area, region, date range, setup, bait, depth,
+   clarity, tide stage, conditions. Scales with history. _After #1/#2 data exists._
+9. **Appearance modes.** Light, Dark, and eventually a purpose-built **Night Fishing
+   Mode** (extreme low brightness, reduced glare) — kept separate from Dark Mode on
+   purpose. _Later slice — needs a light token palette (design lane)._
+10. **Don't Forget List / trip gear.** Trip gear prep wired to the tackle box:
+    already-have / need-to-buy / don't-forget-that-you-own. Long-term: trip requirements
+    ↔ inventory diff. _Later slice._
+
+## Central concept (founder)
+
+**Every catch is a snapshot in time** — Fish + Time + GPS + Spot + Rod + Rig + Bait +
+Conditions + Tide + Environment — explored through Map, Tide Chart, Calendar, Catch List,
+Spots, and eventually Analytics. Architecture must anticipate the analytics layer.
+
+**Design principle (founder):** no Southern-California assumptions in the data model.
+SoCal is the default experience, never a constraint.
+
+## Rulings (founder, 2026-09-01, taken via the team's question round)
+
+- **Staging:** foundations first (docs, clarity, GPS schema, spots model, region
+  preference, freshwater types); views land on top in later slices.
+- **Map:** offline-first geometry map. Markers on built-in coastline/chart geometry that
+  works with zero signal; rich tiles cached opportunistically later. No gray dead map
+  offshore.
+- **GPS capture:** permission asked once (first log, with a why), save never blocks on a
+  fix, accuracy recorded, honest pending/filled-later states. — **Discovery:** this exact
+  pattern already shipped with the fish log (`startPositionRequest` /
+  `attachPositionLater` in `src/features/catches/create.ts`): the fix request starts when
+  the sheet opens, is *read* (never awaited) at save, and late fixes patch the row.
+  Requirement ratified, not rebuilt.
+- **Species data:** verified starter lists per region from public fishery sources;
+  search and manual add always reach the whole vocabulary.
+
+## What this round intentionally did NOT change
+
+- The GPS capture pipeline (already correct — see ruling above).
+- The `/spots` and `/` route stubs (views are the next slice by the founder's staging).
+- Any Southern-California *behavior* in the picker (order only changes when the angler
+  changes the region preference — default unchanged).

--- a/docs/team/worklog/2026-09-01-06-architect.md
+++ b/docs/team/worklog/2026-09-01-06-architect.md
@@ -1,0 +1,28 @@
+### 2026-09-01 | architect | Expansion foundations — regions, freshwater, milky, parity
+
+Founder requirements intake (10 items) → rulings taken → foundations slice.
+Intake record: `docs/product/requests/2026-09-01-expansion-requirements.md`;
+decisions: `docs/architecture/decisions/007-regional-expansion-and-catch-gps.md`.
+
+- **§4 regions:** `src/core/ontology/regions.ts` — 9 regions, curated popular-species
+  starter lists researched against public fishery references; region is suggestion-only,
+  never a filter. `settings/region.ts` device-local preference (SoCal default).
+- **§5 freshwater:** `src/core/ontology/environments.ts` — 8 environments with
+  water-class roll-ups and per-environment condition emphasis placeholders. No ocean
+  assumptions planted in new code. Freshwater species fill the `water_class: fresh`
+  half of the vocabulary (walleye → channel catfish, incl. trout/catfish roll-ups).
+- **§3 milky:** added to `water_clarity` in both the migration and the offline mirror.
+- **Vocabulary parity test (`species-parity` + `vocabulary-parity`):** the migrations and
+  the TS mirrors are now checked against each other both directions. It immediately
+  caught real pre-existing drift: `tannic`, `algae_bloom`, `red_tide` were seeded SQL-side
+  but missing from the mirror — added, with the seeded order preserved.
+- **§1 GPS discovery worth writing down:** the capture pattern the founder asked for
+  (start fix at sheet-open, read — never await — at save, patch late fixes, store
+  accuracy, never block) was ALREADY the shipped design in `create.ts`
+  (`startPositionRequest` / `attachPositionLater`). Requirement ratified in ADR 007 §2
+  rather than rebuilt. Map geometry + markers remain for the views slice.
+- **Species vocabulary grew 31 → 83 rows** (same species shared across regions, e.g.
+  wahoo in Hawaii, Florida, Cabo lists — one id, many regions).
+- **Verification:** verify green (316/316 tests: +12 new net incl. parity/regions),
+  live browser checks: picker leads with Snook/Redfish/Tarpon under Florida, Ahi/Ono/
+  Marlin under Hawaii; clarity row reads …Stained, Milky, Muddy. Screenshots attached.

--- a/docs/team/worklog/2026-09-01-07-ux-ui.md
+++ b/docs/team/worklog/2026-09-01-07-ux-ui.md
@@ -1,0 +1,20 @@
+### 2026-09-01 | ux-ui | Fishing region setting + region-driven picker
+
+Founder §4 on screens. Design facts:
+
+- **Settings gets a "Fishing region" section** (between Fishing shortcuts and Height
+  units). Nine options → a select, not a chip wall (two wraps of pills for a control used
+  once is the wrong trade; same select idiom as the tackle Sort). Copy is explicit that
+  this changes *suggestions only* — nobody is locked out of the species list by a trip.
+- **The picker names the region it is using** — `Common — Florida` — and the search
+  placeholder's example fish come from the same region ("snook, redfish, tarpon…"), so
+  no Florida angler is invited to search bluefin and no Baja angler reads SoCal shorthand.
+  Default (Southern California) is byte-for-byte the same chips as before.
+- **Custom region = no regional suggestions.** Honest: the app does not guess where you
+  fish; Recent builds the picture from your own water.
+- **Milky** slots into the clarity scale between Stained and Muddy (its true place);
+  order preserved everywhere including the seeded sort orders (muddy moved, migration
+  updated, never edited in place — new migration per house rule).
+- Visual check at 390px: settings section and picker consistent with the standard;
+  screenshots attached to the PR (`exp-settings-region.png`, `exp-picker-florida.png`,
+  `exp-picker-hawaii.png`, `exp-milky.png`).

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 
 import { BackendDiagnostics } from "@/features/settings/components/backend-diagnostics";
 import { QuickMarkToggle } from "@/features/settings/components/quick-mark-toggle";
+import { RegionSelect } from "@/features/settings/components/region-select";
 import { UnitsToggle } from "@/features/settings/components/units-toggle";
 
 export const metadata: Metadata = { title: "Settings | Fish Log Book" };
@@ -45,6 +46,19 @@ export default function SettingsPage() {
           Quickly record that something happened while fishing and add the details later.
           Marks appear in the Fish Log under &ldquo;Needs details&rdquo;.
         </p>
+      </section>
+
+      {/*
+        Fishing region: which species the picker's "Common" row leads with (founder
+        requirements §4). Suggestions only — the full vocabulary is always searchable.
+      */}
+      <section className="rounded-lg border border-hairline bg-surface p-4">
+        <h2 className="text-h3">Fishing region</h2>
+        <p className="mt-2 mb-4 text-body text-text-muted">
+          Sets the species suggested first when you log a catch. Every species stays
+          searchable wherever you fish — this only changes what is one tap away.
+        </p>
+        <RegionSelect />
       </section>
 
       <section className="rounded-lg border border-hairline bg-surface p-4">

--- a/src/core/ontology/environments.ts
+++ b/src/core/ontology/environments.ts
@@ -1,0 +1,54 @@
+/**
+ * Fishing environments (ADR 007 §5, founder requirements 2026-09-01 §5).
+ *
+ * The long-term shape: one fishing platform, not a saltwater product with freshwater
+ * bolted on. This module is the type groundwork for that — the vocabulary of *where a
+ * catch happens*, unused by any screen yet, landed now so nothing coming next (spots,
+ * map, conditions) hard-codes ocean assumptions that a lake angler would pay for later.
+ *
+ * What matters and what doesn't, per environment, drives the future conditions UI:
+ * a reservoir angler cares about water level and clarity; an offshore angler cares
+ * about swell and current. Nobody is offered the other one's questions. That mapping
+ * is product work for later slices — what ships here is the enum, the water-class
+ * roll-up, and the rule that the data model never assumes one.
+ */
+
+import type { WaterClass } from "./species";
+
+export type FishingEnvironment =
+  | "ocean"
+  | "inshore"
+  | "bay"
+  | "harbor"
+  | "lake"
+  | "reservoir"
+  | "river"
+  | "stream";
+
+export interface FishingEnvironmentSpec {
+  readonly id: FishingEnvironment;
+  readonly label: string;
+  readonly waterClass: WaterClass;
+  /**
+   * Honest placeholder for the per-environment conditions set. Empty is the truth
+   * today; the day conditions become environment-aware this says which ones.
+   */
+  readonly conditionEmphasis: readonly string[];
+}
+
+export const FISHING_ENVIRONMENTS: readonly FishingEnvironmentSpec[] = [
+  { id: "ocean", label: "Ocean / offshore", waterClass: "salt", conditionEmphasis: ["swell", "current", "wind", "tide"] },
+  { id: "inshore", label: "Inshore", waterClass: "salt", conditionEmphasis: ["tide", "wind", "water_clarity"] },
+  { id: "bay", label: "Bay / estuary", waterClass: "salt", conditionEmphasis: ["tide", "water_clarity", "current"] },
+  { id: "harbor", label: "Harbor", waterClass: "salt", conditionEmphasis: ["tide", "water_clarity"] },
+  { id: "lake", label: "Lake", waterClass: "fresh", conditionEmphasis: ["water_temperature", "water_clarity", "wind"] },
+  { id: "reservoir", label: "Reservoir", waterClass: "fresh", conditionEmphasis: ["water_level", "water_temperature", "water_clarity"] },
+  { id: "river", label: "River", waterClass: "fresh", conditionEmphasis: ["flow", "water_temperature", "water_clarity"] },
+  { id: "stream", label: "Stream", waterClass: "fresh", conditionEmphasis: ["flow", "water_temperature"] },
+];
+
+const ENV_BY_ID = new Map(FISHING_ENVIRONMENTS.map((e) => [e.id, e]));
+
+export function environmentById(id: string): FishingEnvironmentSpec | null {
+  return ENV_BY_ID.get(id as FishingEnvironment) ?? null;
+}

--- a/src/core/ontology/regions.test.ts
+++ b/src/core/ontology/regions.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { popularSpecies, popularSpeciesIds, regionById, REGIONS } from "./regions";
+import { speciesById } from "./species";
+
+/*
+ * ADR 007 §4: regions are picker defaults, never a filter. These tests pin the two
+ * failure modes that would break that promise silently: a popular list pointing at an
+ * id the vocabulary does not have, and a region whose list accidentally duplicates
+ * another's by copy-paste.
+ */
+describe("fishing regions", () => {
+  it("every popular id exists in the species vocabulary", () => {
+    for (const region of REGIONS) {
+      const missing = popularSpeciesIds(region.id).filter((id) => speciesById(id) === null);
+      expect(missing, `${region.id} references unknown species`).toEqual([]);
+    }
+  });
+
+  it("SoCal keeps the exact list the picker historically led with", () => {
+    expect(popularSpeciesIds("southern_california")).toContain("kelp_bass");
+    expect(popularSpeciesIds("southern_california")).toContain("bluefin_tuna");
+  });
+
+  it("freshwater regions surface freshwater species", () => {
+    const greatLakes = popularSpecies("great_lakes");
+    expect(greatLakes.some((s) => s.id === "walleye")).toBe(true);
+    expect(greatLakes.some((s) => s.waterClass === "fresh")).toBe(true);
+  });
+
+  it("a custom region leads with nothing regional — no pre-judging", () => {
+    expect(popularSpeciesIds("custom")).toEqual([]);
+    // popularSpecies still returns a neutral head-of-vocabulary so the row isn't empty.
+    expect(popularSpecies("custom").length).toBeGreaterThan(0);
+  });
+
+  it("unknown region ids resolve to null, not garbage", () => {
+    expect(regionById("atlantis")).toBeNull();
+  });
+
+  it("region ids are unique", () => {
+    const ids = REGIONS.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/src/core/ontology/regions.ts
+++ b/src/core/ontology/regions.ts
@@ -1,0 +1,169 @@
+/**
+ * Fishing regions — the picker-of-defaults, never a filter (ADR 007 §4,
+ * founder requirements 2026-09-01).
+ *
+ * The design principle is the founder's own: no region is part of the data model. A
+ * catch records species, time, GPS, and conditions; the region only decides which
+ * species chips surface first before the angler has history. Every species stays
+ * searchable in every region, and "Common" stops mattering the moment Recent exists.
+ *
+ * The lists below are honest starter sets, researched against public fishery sources
+ * (state DFW target lists, FWC, Hawaii DLNR-adjacent sportfishing references), and kept
+ * deliberately short — a curated welcome mat, not a taxonomy. `needs_review` on the
+ * vocabulary rows carries the "check me" flag forward.
+ */
+
+import { speciesById, SPECIES, type Species } from "./species";
+
+export type RegionId =
+  | "southern_california"
+  | "northern_california"
+  | "florida"
+  | "hawaii"
+  | "cabo_baja"
+  | "gulf_coast"
+  | "northeast"
+  | "great_lakes"
+  /** Angler-defined home water: nothing is pre-judged, Recent builds the picture. */
+  | "custom";
+
+export interface Region {
+  readonly id: RegionId;
+  readonly label: string;
+  /** One honest line for the settings card. */
+  readonly hint: string;
+}
+
+export const REGIONS: readonly Region[] = [
+  { id: "southern_california", label: "Southern California", hint: "Kelp bed, reef and offshore staples." },
+  { id: "northern_california", label: "Northern California", hint: "Salmon, stripers, halibut, rockfish." },
+  { id: "florida", label: "Florida", hint: "Snook, redfish, tarpon, reef and bluewater." },
+  { id: "hawaii", label: "Hawaii", hint: "Ahi, ono, mahi, ulua, marlin." },
+  { id: "cabo_baja", label: "Cabo / Baja", hint: "Marlin, dorado, tuna, roosterfish." },
+  { id: "gulf_coast", label: "Gulf Coast", hint: "Redfish, specks, snapper, cobia." },
+  { id: "northeast", label: "Northeast", hint: "Stripers, blues, fluke, tog, cod." },
+  { id: "great_lakes", label: "Great Lakes", hint: "Walleye, salmon and trout, perch, bass." },
+  { id: "custom", label: "Custom / anywhere else", hint: "No regional suggestions — search finds everything." },
+];
+
+const BY_REGION: Record<RegionId, readonly string[]> = {
+  southern_california: [
+    "kelp_bass",
+    "barred_sand_bass",
+    "california_halibut",
+    "barred_surfperch",
+    "spotfin_croaker",
+    "rockfish",
+    "lingcod",
+    "california_sheephead",
+    "yellowtail",
+    "white_seabass",
+    "pacific_bonito",
+    "bluefin_tuna",
+  ],
+  northern_california: [
+    "striped_bass",
+    "chinook_salmon",
+    "pacific_halibut",
+    "lingcod",
+    "rockfish",
+    "california_halibut",
+    "leopard_shark",
+    "white_sturgeon",
+    "coho_salmon",
+  ],
+  florida: [
+    "common_snook",
+    "red_drum",
+    "spotted_seatrout",
+    "atlantic_tarpon",
+    "gray_snapper",
+    "sheepshead",
+    "red_snapper",
+    "gag_grouper",
+    "king_mackerel",
+    "cobia",
+    "permit",
+    "atlantic_bonefish",
+  ],
+  hawaii: [
+    "yellowfin_tuna",
+    "skipjack_tuna",
+    "wahoo",
+    "dorado",
+    "blue_marlin",
+    "striped_marlin",
+    "giant_trevally",
+    "bluefin_trevally",
+    "green_jobfish",
+  ],
+  cabo_baja: [
+    "striped_marlin",
+    "blue_marlin",
+    "dorado",
+    "yellowfin_tuna",
+    "wahoo",
+    "yellowtail",
+    "roosterfish",
+    "sierra_mackerel",
+  ],
+  gulf_coast: [
+    "red_drum",
+    "spotted_seatrout",
+    "southern_flounder",
+    "red_snapper",
+    "atlantic_tarpon",
+    "sheepshead",
+    "cobia",
+    "king_mackerel",
+    "spanish_mackerel",
+    "greater_amberjack",
+  ],
+  northeast: [
+    "striped_bass",
+    "bluefish",
+    "summer_flounder",
+    "black_sea_bass",
+    "tautog",
+    "atlantic_cod",
+    "pollock",
+    "false_albacore",
+    "weakfish",
+  ],
+  great_lakes: [
+    "walleye",
+    "yellow_perch",
+    "smallmouth_bass",
+    "largemouth_bass",
+    "lake_trout",
+    "steelhead",
+    "brown_trout",
+    "chinook_salmon",
+    "coho_salmon",
+    "muskellunge",
+    "northern_pike",
+    "black_crappie",
+  ],
+  custom: [],
+};
+
+export function regionById(id: string): Region | null {
+  return REGIONS.find((region) => region.id === id) ?? null;
+}
+
+/** The species ids a region leads with. `custom` deliberately leads with nothing. */
+export function popularSpeciesIds(regionId: RegionId): readonly string[] {
+  return BY_REGION[regionId];
+}
+
+/**
+ * The picker's "Common" chips for a region: the region's list resolved to species.
+ * A custom region gets the vocabulary head — alphabet-clean and region-neutral.
+ */
+export function popularSpecies(regionId: RegionId): readonly Species[] {
+  const ids = BY_REGION[regionId];
+  if (ids.length === 0) {
+    return [...SPECIES].sort((a, b) => a.sortOrder - b.sortOrder).slice(0, 12);
+  }
+  return ids.map((id) => speciesById(id)).filter((s): s is Species => s !== null);
+}

--- a/src/core/ontology/species-parity.test.ts
+++ b/src/core/ontology/species-parity.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { SPECIES } from "./species";
+
+/*
+ * The vocabulary exists twice by design: seeded server-side in the migrations and
+ * mirrored into TypeScript as the offline floor (the species picker must work with no
+ * signal, spec §4). Twice means drift is possible, so the mirror is tested against the
+ * migrations rather than trusted.
+ */
+
+const migrationsDir = fileURLToPath(new URL("../../../supabase/migrations/", import.meta.url));
+const sql = readdirSync(migrationsDir)
+  .filter((name) => name.endsWith(".sql"))
+  .sort()
+  .map((name) => readFileSync(migrationsDir + name, "utf8"))
+  .join("\n");
+
+function seededIds(table: string): Set<string> {
+  const ids = new Set<string>();
+  // First column of every values row of an insert into this table, across migrations.
+  const inserts = sql.matchAll(new RegExp(`insert into public\\.${table}[\\s\\S]*?;`, "g"));
+  for (const insert of inserts) {
+    for (const row of insert[0].matchAll(/\(\s*'([a-z_]+)'/g)) ids.add(row[1]);
+  }
+  return ids;
+}
+
+describe("species vocabulary parity", () => {
+  const seeded = seededIds("species");
+
+  it("every offline-floor species is seeded in a migration", () => {
+    const missing = SPECIES.filter((s) => !seeded.has(s.id)).map((s) => s.id);
+    expect(missing).toEqual([]);
+  });
+
+  it("every seeded species id exists in the offline floor", () => {
+    const mirrored = new Set(SPECIES.map((s) => s.id));
+    const missing = [...seeded].filter((id) => !mirrored.has(id));
+    expect(missing).toEqual([]);
+  });
+
+  it("species ids are unique in the offline floor", () => {
+    const ids = SPECIES.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/src/core/ontology/species.ts
+++ b/src/core/ontology/species.ts
@@ -69,7 +69,82 @@ export const SPECIES: readonly Species[] = [
   { id: "bluefin_tuna", commonName: "Bluefin tuna", scientificName: "Thunnus orientalis", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 306 },
   { id: "yellowfin_tuna", commonName: "Yellowfin tuna", scientificName: "Thunnus albacares", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 307 },
   { id: "dorado", commonName: "Dorado", scientificName: "Coryphaena hippurus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 308 },
-  { id: "thresher_shark", commonName: "Thresher shark", scientificName: "Alopias vulpinus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 309 },];
+  { id: "thresher_shark", commonName: "Thresher shark", scientificName: "Alopias vulpinus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 309 },
+
+  /* Regional expansion (ADR 007, founder requirements 2026-09-01 §4/§5). The list stays
+   * one vocabulary, SoCal-shaped only by sort order; other regions surface through
+   * `regions.ts`, not by filtering rows out. waterClass is the dominant regulatory
+   * habitat — anadromous runs (salmon, steelhead, striped bass) pick the water they are
+   * managed in, and may appear in either region's lists. */
+
+  // Inshore anadromous / mixed-coast (400s)
+  { id: "striped_bass", commonName: "Striped bass", scientificName: "Morone saxatilis", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 400 },
+  { id: "chinook_salmon", commonName: "Chinook salmon", scientificName: "Oncorhynchus tshawytscha", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 401 },
+  { id: "coho_salmon", commonName: "Coho salmon", scientificName: "Oncorhynchus kisutch", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 402 },
+  { id: "pacific_halibut", commonName: "Pacific halibut", scientificName: "Hippoglossus stenolepis", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 403 },
+  { id: "white_sturgeon", commonName: "White sturgeon", scientificName: "Acipenser transmontanus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 404 },
+
+  // Atlantic inshore (410s)
+  { id: "bluefish", commonName: "Bluefish", scientificName: "Pomatomus saltatrix", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 410 },
+  { id: "summer_flounder", commonName: "Summer flounder (fluke)", scientificName: "Paralichthys dentatus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 411 },
+  { id: "black_sea_bass", commonName: "Black sea bass", scientificName: "Centropristis striata", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 412 },
+  { id: "tautog", commonName: "Tautog (blackfish)", scientificName: "Tautoga onitis", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 413 },
+  { id: "atlantic_cod", commonName: "Atlantic cod", scientificName: "Gadus morhua", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 414 },
+  { id: "pollock", commonName: "Pollock", scientificName: "Pollachius virens", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 415 },
+  { id: "false_albacore", commonName: "False albacore", scientificName: "Euthynnus alletteratus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 416 },
+  { id: "weakfish", commonName: "Weakfish", scientificName: "Cynoscion regalis", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 417 },
+
+  // Florida / Gulf inshore + nearshore (420s)
+  { id: "common_snook", commonName: "Snook", scientificName: "Centropomus undecimalis", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 420 },
+  { id: "red_drum", commonName: "Redfish (red drum)", scientificName: "Sciaenops ocellatus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 421 },
+  { id: "atlantic_tarpon", commonName: "Tarpon", scientificName: "Megalops atlanticus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 422 },
+  { id: "spotted_seatrout", commonName: "Spotted seatrout (speckled trout)", scientificName: "Cynoscion nebulosus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 423 },
+  { id: "gray_snapper", commonName: "Mangrove snapper (gray)", scientificName: "Lutjanus griseus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 424 },
+  { id: "yellowtail_snapper", commonName: "Yellowtail snapper", scientificName: "Ocyurus chrysurus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 425 },
+  { id: "southern_flounder", commonName: "Southern flounder", scientificName: "Paralichthys lethostigma", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 426 },
+  { id: "sheepshead", commonName: "Sheepshead", scientificName: "Archosargus probatocephalus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 427 },
+  { id: "permit", commonName: "Permit", scientificName: "Trachinotus falcatus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 428 },
+  { id: "atlantic_bonefish", commonName: "Bonefish", scientificName: "Albula vulpes", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 429 },
+
+  // Florida / Gulf offshore (430s)
+  { id: "red_snapper", commonName: "Red snapper", scientificName: "Lutjanus campechanus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 430 },
+  { id: "gag_grouper", commonName: "Gag grouper", scientificName: "Mycteroperca microlepis", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 431 },
+  { id: "goliath_grouper", commonName: "Goliath grouper", scientificName: "Epinephelus itajara", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "protected", sortOrder: 432 },
+  { id: "king_mackerel", commonName: "King mackerel", scientificName: "Scomberomorus cavalla", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 433 },
+  { id: "spanish_mackerel", commonName: "Spanish mackerel", scientificName: "Scomberomorus maculatus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 434 },
+  { id: "cobia", commonName: "Cobia", scientificName: "Rachycentron canadum", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 435 },
+  { id: "greater_amberjack", commonName: "Greater amberjack", scientificName: "Seriola dumerili", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 436 },
+  { id: "hogfish", commonName: "Hogfish", scientificName: "Lachnolaimus maximus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 437 },
+
+  // Tropical offshore — Hawaii, Baja, shared pelagics (440s)
+  { id: "wahoo", commonName: "Wahoo (ono)", scientificName: "Acanthocybium solandri", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 440 },
+  { id: "blue_marlin", commonName: "Blue marlin", scientificName: "Makaira nigricans", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 441 },
+  { id: "black_marlin", commonName: "Black marlin", scientificName: "Istiompax indica", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 442 },
+  { id: "striped_marlin", commonName: "Striped marlin", scientificName: "Kajikia audax", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 443 },
+  { id: "sailfish", commonName: "Pacific sailfish", scientificName: "Istiophorus platypterus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 444 },
+  { id: "skipjack_tuna", commonName: "Skipjack tuna (aku)", scientificName: "Katsuwonus pelamis", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 445 },
+  { id: "giant_trevally", commonName: "Giant trevally (ulua)", scientificName: "Caranx ignobilis", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 446 },
+  { id: "bluefin_trevally", commonName: "Bluefin trevally (omilu)", scientificName: "Caranx melampygus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 447 },
+  { id: "green_jobfish", commonName: "Green jobfish (uku)", scientificName: "Aprion virescens", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 448 },
+  { id: "roosterfish", commonName: "Roosterfish", scientificName: "Nematistius pectoralis", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 449 },
+  { id: "sierra_mackerel", commonName: "Sierra mackerel", scientificName: "Scomberomorus sierra", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 450 },
+
+  // Freshwater (500s) — groundwork for lake/river regions (ADR 007 §5)
+  { id: "trout", commonName: "Trout", scientificName: "Salmonidae", isGroup: true, rollsUpTo: null, waterClass: "fresh", takeStatus: "regulated", sortOrder: 500 },
+  { id: "catfish", commonName: "Catfish", scientificName: "Siluriformes", isGroup: true, rollsUpTo: null, waterClass: "fresh", takeStatus: "open", sortOrder: 501 },
+  { id: "walleye", commonName: "Walleye", scientificName: "Sander vitreus", isGroup: false, rollsUpTo: null, waterClass: "fresh", takeStatus: "regulated", sortOrder: 502 },
+  { id: "yellow_perch", commonName: "Yellow perch", scientificName: "Perca flavescens", isGroup: false, rollsUpTo: null, waterClass: "fresh", takeStatus: "open", sortOrder: 503 },
+  { id: "smallmouth_bass", commonName: "Smallmouth bass", scientificName: "Micropterus dolomieu", isGroup: false, rollsUpTo: null, waterClass: "fresh", takeStatus: "regulated", sortOrder: 504 },
+  { id: "largemouth_bass", commonName: "Largemouth bass", scientificName: "Micropterus salmoides", isGroup: false, rollsUpTo: null, waterClass: "fresh", takeStatus: "regulated", sortOrder: 505 },
+  { id: "lake_trout", commonName: "Lake trout", scientificName: "Salvelinus namaycush", isGroup: false, rollsUpTo: "trout", waterClass: "fresh", takeStatus: "regulated", sortOrder: 506 },
+  { id: "steelhead", commonName: "Steelhead", scientificName: "Oncorhynchus mykiss", isGroup: false, rollsUpTo: "trout", waterClass: "fresh", takeStatus: "regulated", sortOrder: 507 },
+  { id: "brown_trout", commonName: "Brown trout", scientificName: "Salmo trutta", isGroup: false, rollsUpTo: "trout", waterClass: "fresh", takeStatus: "regulated", sortOrder: 508 },
+  { id: "muskellunge", commonName: "Muskellunge (muskie)", scientificName: "Esox masquinongy", isGroup: false, rollsUpTo: null, waterClass: "fresh", takeStatus: "regulated", sortOrder: 509 },
+  { id: "northern_pike", commonName: "Northern pike", scientificName: "Esox lucius", isGroup: false, rollsUpTo: null, waterClass: "fresh", takeStatus: "open", sortOrder: 510 },
+  { id: "black_crappie", commonName: "Black crappie", scientificName: "Pomoxis nigromaculatus", isGroup: false, rollsUpTo: null, waterClass: "fresh", takeStatus: "regulated", sortOrder: 511 },
+  { id: "bluegill", commonName: "Bluegill", scientificName: "Lepomis macrochirus", isGroup: false, rollsUpTo: null, waterClass: "fresh", takeStatus: "open", sortOrder: 512 },
+  { id: "channel_catfish", commonName: "Channel catfish", scientificName: "Ictalurus punctatus", isGroup: false, rollsUpTo: "catfish", waterClass: "fresh", takeStatus: "open", sortOrder: 513 },
+];
 
 const BY_ID = new Map(SPECIES.map((s) => [s.id, s]));
 

--- a/src/features/catches/components/species-picker.tsx
+++ b/src/features/catches/components/species-picker.tsx
@@ -2,7 +2,9 @@
 
 import { useMemo, useState } from "react";
 
+import { popularSpecies, regionById } from "@/core/ontology/regions";
 import { searchSpecies, speciesById, SPECIES, type Species } from "@/core/ontology/species";
+import { useRegionPreference } from "@/features/settings/region";
 import { CHIP_CLASS, CHIP_OFF, CHIP_ON, FOCUS_RING, INPUT_CLASS } from "../ui-classes";
 
 /**
@@ -51,23 +53,25 @@ export function SpeciesPicker({
     return searchSpecies(query).slice(0, 20);
   }, [query]);
 
-  // What a SoCal salt angler reaches for before they have any history at all.
+  // What this angler reaches for before they have any history at all.
   //
-  // Curated rather than "the first N by sort_order": the vocabulary is ordered by habitat
-  // (groups, then inshore, then nearshore, then pelagic), so taking the head of it offers
-  // surfperch and croaker and silently buries yellowtail and bluefin. This list spans the
-  // three things people actually fish for here — bay/surf, reef, and offshore — and it
-  // stops mattering after a handful of catches, when Recent takes over.
+  // Driven by the Fishing region preference (ADR 007 §4): curated per region rather than
+  // "the first N by sort_order", because the vocabulary is ordered by habitat and the head
+  // of it would offer a SoCal surfer's list to a walleye angler. It stops mattering after
+  // a handful of catches, when Recent takes over. Suggestions only — search and "Something
+  // else" always reach the full vocabulary.
+  const [regionId] = useRegionPreference();
+  const region = regionById(regionId);
+
   const common = useMemo(() => {
     const recentSet = new Set(recentIds);
-    return COMMON_SALT_IDS.map((id) => speciesById(id))
-      .filter((s): s is Species => s !== null && !recentSet.has(s.id));
-  }, [recentIds]);
+    return popularSpecies(regionId).filter((s) => !recentSet.has(s.id));
+  }, [regionId, recentIds]);
 
   const rest = useMemo(() => {
-    const shown = new Set([...recentIds, ...COMMON_SALT_IDS]);
+    const shown = new Set([...recentIds, ...common.map((s) => s.id)]);
     return SPECIES.filter((s) => !shown.has(s.id)).sort((a, b) => a.sortOrder - b.sortOrder);
-  }, [recentIds]);
+  }, [recentIds, common]);
 
   const showing = query.trim() !== "" ? results : null;
   const chosen = speciesById(selectedId);
@@ -103,7 +107,12 @@ export function SpeciesPicker({
           type="search"
           value={query}
           onChange={(event) => setQuery(event.target.value)}
-          placeholder="bluefin, calico, halibut…"
+          // The hint fish live in the chosen region too — a Florida angler should not
+          // be invited to search for bluefin.
+          placeholder={`${common
+            .slice(0, 3)
+            .map((s) => s.commonName.replaceAll(/\s*\(.*\)\s*/g, "").toLowerCase())
+            .join(", ") || "species"}…`}
           className={INPUT_CLASS}
           autoComplete="off"
         />
@@ -127,7 +136,12 @@ export function SpeciesPicker({
             />
           ) : null}
           <SpeciesChips
-            heading={recent.length > 0 ? "Common" : "Species"}
+            // Naming the region is the honest label: the row genuinely changes with it.
+            heading={
+              regionId === "custom"
+                ? "Species"
+                : `Common — ${region?.label ?? ""}`
+            }
             species={common}
             selectedId={selectedId}
             onSelect={choose}
@@ -236,21 +250,3 @@ function SpeciesChips({
   );
 }
 
-/**
- * The no-history starting set. Not a taxonomy — a guess at what gets logged most on this
- * coast, deliberately short so the row does not wrap three times on a phone.
- */
-const COMMON_SALT_IDS: readonly string[] = [
-  "kelp_bass",
-  "barred_sand_bass",
-  "california_halibut",
-  "barred_surfperch",
-  "spotfin_croaker",
-  "rockfish",
-  "lingcod",
-  "california_sheephead",
-  "yellowtail",
-  "white_seabass",
-  "pacific_bonito",
-  "bluefin_tuna",
-];

--- a/src/features/settings/components/region-select.tsx
+++ b/src/features/settings/components/region-select.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { REGIONS } from "@/core/ontology/regions";
+import { useRegionPreference } from "../region";
+
+/**
+ * Fishing region control for /settings (ADR 007 §4).
+ *
+ * Nine options, so a select, not a row of chips — the chip wall would wrap twice on a
+ * phone for a control that gets touched once, maybe twice. Same select idiom the tackle
+ * sort uses, so the gesture vocabulary stays one deep.
+ *
+ * The note matters: this changes suggestions and nothing else. An angler on a Baja trip
+ * out of Dana Point must never feel locked out of their own app's species list.
+ */
+export function RegionSelect() {
+  const [regionId, setRegionId] = useRegionPreference();
+
+  return (
+    <label className="flex flex-col gap-2">
+      <span className="sr-only">Fishing region</span>
+      <select
+        value={regionId}
+        onChange={(event) => setRegionId(event.target.value as typeof regionId)}
+        className="min-h-touch-floor w-full rounded-md border border-border-interactive bg-surface px-4 text-body text-text-primary focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+      >
+        {REGIONS.map((region) => (
+          <option key={region.id} value={region.id}>
+            {region.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/src/features/settings/region.ts
+++ b/src/features/settings/region.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { regionById, type RegionId } from "@/core/ontology/regions";
+import { createLocalPreference } from "./preference";
+
+/**
+ * Fishing region (ADR 007 §4, founder requirements §4). A device-local preference like
+ * units: it changes suggestions, never data. Default Southern California — the
+ * founder's call: SoCal is the strong initial experience, just not a permanent
+ * constraint baked into the model.
+ */
+export const regionPreference = createLocalPreference<RegionId>({
+  key: "flb:fishing-region",
+  defaultValue: "southern_california",
+  parse: (raw) => {
+    const region = raw === null ? null : regionById(raw);
+    return region ? region.id : "southern_california";
+  },
+  serialize: (value) => value,
+});
+
+export function useRegionPreference() {
+  return regionPreference.use();
+}

--- a/src/features/setup/vocabulary-parity.test.ts
+++ b/src/features/setup/vocabulary-parity.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { WATER_CLARITIES, WATER_COLORS } from "./vocabulary";
+
+/*
+ * Clarity and colour vocabularies exist twice: seeded server-side in the migrations and
+ * mirrored here for offline use. The mirror is tested against the migrations rather
+ * than trusted (core cannot reach features — ADR 003 §6 — so this half of the parity
+ * contract lives beside the mirror).
+ */
+
+const migrationsDir = fileURLToPath(new URL("../../../supabase/migrations/", import.meta.url));
+const sql = readdirSync(migrationsDir)
+  .filter((name) => name.endsWith(".sql"))
+  .sort()
+  .map((name) => readFileSync(join(migrationsDir, name), "utf8"))
+  .join("\n");
+
+function seededIds(table: string): Set<string> {
+  const ids = new Set<string>();
+  const inserts = sql.matchAll(new RegExp(`insert into public\\.${table}[\\s\\S]*?;`, "g"));
+  for (const insert of inserts) {
+    for (const row of insert[0].matchAll(/\(\s*'([a-z_]+)'/g)) ids.add(row[1]);
+  }
+  return ids;
+}
+
+describe("water clarity parity", () => {
+  const seeded = seededIds("water_clarity");
+
+  it("every clarity option is seeded in a migration, and every seed is mirrored", () => {
+    const mirrored = new Set(WATER_CLARITIES.map((c) => c.id));
+    expect(WATER_CLARITIES.filter((c) => !seeded.has(c.id)).map((c) => c.id)).toEqual([]);
+    expect([...seeded].filter((id) => !mirrored.has(id))).toEqual([]);
+  });
+
+  it("includes milky (founder requirement 2026-09-01 §3)", () => {
+    expect(WATER_CLARITIES.map((c) => c.id)).toContain("milky");
+    expect(seeded.has("milky")).toBe(true);
+  });
+
+  it("clarity stays an ordered scale from clearest to worst", () => {
+    expect(WATER_CLARITIES.map((c) => c.id)).toEqual([
+      "gin_clear",
+      "clear",
+      "lightly_stained",
+      "stained",
+      "milky",
+      "muddy",
+    ]);
+  });
+});
+
+describe("water colour parity", () => {
+  it("colours mirror the seeds exactly", () => {
+    const seeded = seededIds("water_color");
+    const mirrored = new Set(WATER_COLORS.map((c) => c.id));
+    expect(WATER_COLORS.filter((c) => !seeded.has(c.id)).map((c) => c.id)).toEqual([]);
+    expect([...seeded].filter((id) => !mirrored.has(id))).toEqual([]);
+  });
+});

--- a/src/features/setup/vocabulary.ts
+++ b/src/features/setup/vocabulary.ts
@@ -66,6 +66,12 @@ export const WATER_COLORS: readonly { id: string; label: string }[] = [
   { id: "green", label: "Green" },
   { id: "green_brown", label: "Green-brown" },
   { id: "brown", label: "Brown" },
+  // Three seeded colours the mirror had silently dropped (caught by the parity test):
+  // tannic tea water, blooms, and red tide — seeded as colours, flagged for review,
+  // because leaving them out meant those days got logged as custom text.
+  { id: "tannic", label: "Tannic / tea" },
+  { id: "algae_bloom", label: "Algae bloom" },
+  { id: "red_tide", label: "Red tide" },
 ];
 
 export const WATER_CLARITIES: readonly { id: string; label: string }[] = [
@@ -73,6 +79,8 @@ export const WATER_CLARITIES: readonly { id: string; label: string }[] = [
   { id: "clear", label: "Clear" },
   { id: "lightly_stained", label: "Lightly stained" },
   { id: "stained", label: "Stained" },
+  // Founder requirement 2026-09-01 §3: milky glacial/plankton tints are not stained.
+  { id: "milky", label: "Milky" },
   { id: "muddy", label: "Muddy" },
 ];
 

--- a/supabase/migrations/20260901190000_v1_milky_and_regional_species.sql
+++ b/supabase/migrations/20260901190000_v1_milky_and_regional_species.sql
@@ -1,0 +1,89 @@
+-- V1 expansion: founder requirements 2026-09-01 §3 (Milky water clarity) and §4/§5
+-- (regional + freshwater species groundwork, ADR 007).
+--
+-- Additive only: one new water_clarity row and the regional species rows this prototype
+-- mirrors offline in `src/core/ontology/species.ts`. Migrations stay append-only so the
+-- offline floor and the server vocabulary never disagree about what an id means.
+-- The parity test `src/core/ontology/species-parity.test.ts` fails if either side drifts.
+
+-- §3 — Milky: sits between Stained and Muddy; muddy moves to keep the scale monotonic.
+update public.water_clarity set sort_order = 15 where id = 'muddy';
+
+insert into public.water_clarity (id, label, sort_order, needs_review) values
+  ('milky', 'Milky', 14, false)
+on conflict (id) do nothing;
+
+-- §4/§5 — regional + freshwater species. sort_order bands: 400s mixed-coast &
+-- anadromous, 410s Atlantic inshore, 420s Florida/Gulf inshore, 430s Florida/Gulf
+-- offshore, 440s tropical offshore, 500s freshwater. water_class is the dominant
+-- regulatory habitat; anadromous rows stay 'salt' where they are managed as such.
+insert into public.species (id, common_name, scientific_name, is_group, rolls_up_to, water_class, take_status, sort_order, needs_review) values
+  -- inshore anadromous / mixed-coast
+  ('striped_bass',       'Striped bass',                      'Morone saxatilis',           false, null, 'salt', 'regulated', 400, false),
+  ('chinook_salmon',     'Chinook salmon',                    'Oncorhynchus tshawytscha',   false, null, 'salt', 'regulated', 401, false),
+  ('coho_salmon',        'Coho salmon',                       'Oncorhynchus kisutch',       false, null, 'salt', 'regulated', 402, false),
+  ('pacific_halibut',    'Pacific halibut',                   'Hippoglossus stenolepis',    false, null, 'salt', 'regulated', 403, false),
+  ('white_sturgeon',     'White sturgeon',                    'Acipenser transmontanus',    false, null, 'salt', 'regulated', 404, false),
+
+  -- Atlantic inshore
+  ('bluefish',           'Bluefish',                          'Pomatomus saltatrix',        false, null, 'salt', 'regulated', 410, false),
+  ('summer_flounder',    'Summer flounder (fluke)',           'Paralichthys dentatus',      false, null, 'salt', 'regulated', 411, false),
+  ('black_sea_bass',     'Black sea bass',                    'Centropristis striata',      false, null, 'salt', 'regulated', 412, false),
+  ('tautog',             'Tautog (blackfish)',                'Tautoga onitis',             false, null, 'salt', 'regulated', 413, false),
+  ('atlantic_cod',       'Atlantic cod',                      'Gadus morhua',               false, null, 'salt', 'regulated', 414, false),
+  ('pollock',            'Pollock',                           'Pollachius virens',          false, null, 'salt', 'open',      415, false),
+  ('false_albacore',     'False albacore',                    'Euthynnus alletteratus',     false, null, 'salt', 'open',      416, false),
+  ('weakfish',           'Weakfish',                          'Cynoscion regalis',          false, null, 'salt', 'regulated', 417, false),
+
+  -- Florida / Gulf inshore + nearshore
+  ('common_snook',       'Snook',                             'Centropomus undecimalis',    false, null, 'salt', 'regulated', 420, false),
+  ('red_drum',           'Redfish (red drum)',                'Sciaenops ocellatus',        false, null, 'salt', 'regulated', 421, false),
+  ('atlantic_tarpon',    'Tarpon',                            'Megalops atlanticus',        false, null, 'salt', 'regulated', 422, false),
+  ('spotted_seatrout',   'Spotted seatrout (speckled trout)', 'Cynoscion nebulosus',        false, null, 'salt', 'regulated', 423, false),
+  ('gray_snapper',       'Mangrove snapper (gray)',           'Lutjanus griseus',           false, null, 'salt', 'regulated', 424, false),
+  ('yellowtail_snapper', 'Yellowtail snapper',                'Ocyurus chrysurus',          false, null, 'salt', 'regulated', 425, false),
+  ('southern_flounder',  'Southern flounder',                 'Paralichthys lethostigma',   false, null, 'salt', 'regulated', 426, false),
+  ('sheepshead',         'Sheepshead',                        'Archosargus probatocephalus',false, null, 'salt', 'regulated', 427, false),
+  ('permit',             'Permit',                            'Trachinotus falcatus',       false, null, 'salt', 'regulated', 428, false),
+  ('atlantic_bonefish',  'Bonefish',                          'Albula vulpes',              false, null, 'salt', 'regulated', 429, false),
+
+  -- Florida / Gulf offshore
+  ('red_snapper',        'Red snapper',                       'Lutjanus campechanus',       false, null, 'salt', 'regulated', 430, false),
+  ('gag_grouper',        'Gag grouper',                       'Mycteroperca microlepis',    false, null, 'salt', 'regulated', 431, false),
+  ('goliath_grouper',    'Goliath grouper',                   'Epinephelus itajara',        false, null, 'salt', 'protected', 432, false),
+  ('king_mackerel',      'King mackerel',                     'Scomberomorus cavalla',      false, null, 'salt', 'regulated', 433, false),
+  ('spanish_mackerel',   'Spanish mackerel',                  'Scomberomorus maculatus',    false, null, 'salt', 'regulated', 434, false),
+  ('cobia',              'Cobia',                             'Rachycentron canadum',       false, null, 'salt', 'regulated', 435, false),
+  ('greater_amberjack',  'Greater amberjack',                 'Seriola dumerili',           false, null, 'salt', 'regulated', 436, false),
+  ('hogfish',            'Hogfish',                           'Lachnolaimus maximus',       false, null, 'salt', 'regulated', 437, false),
+
+  -- tropical offshore — Hawaii, Baja, shared pelagics
+  ('wahoo',              'Wahoo (ono)',                       'Acanthocybium solandri',     false, null, 'salt', 'open',      440, false),
+  ('blue_marlin',        'Blue marlin',                       'Makaira nigricans',          false, null, 'salt', 'regulated', 441, false),
+  ('black_marlin',       'Black marlin',                      'Istiompax indica',           false, null, 'salt', 'regulated', 442, false),
+  ('striped_marlin',     'Striped marlin',                    'Kajikia audax',              false, null, 'salt', 'regulated', 443, false),
+  ('sailfish',           'Pacific sailfish',                  'Istiophorus platypterus',    false, null, 'salt', 'regulated', 444, false),
+  ('skipjack_tuna',      'Skipjack tuna (aku)',               'Katsuwonus pelamis',         false, null, 'salt', 'open',      445, false),
+  ('giant_trevally',     'Giant trevally (ulua)',             'Caranx ignobilis',           false, null, 'salt', 'open',      446, false),
+  ('bluefin_trevally',   'Bluefin trevally (omilu)',          'Caranx melampygus',          false, null, 'salt', 'open',      447, false),
+  ('green_jobfish',      'Green jobfish (uku)',               'Aprion virescens',           false, null, 'salt', 'regulated', 448, false),
+  ('roosterfish',        'Roosterfish',                       'Nematistius pectoralis',     false, null, 'salt', 'open',      449, false),
+  ('sierra_mackerel',    'Sierra mackerel',                   'Scomberomorus sierra',       false, null, 'salt', 'open',      450, false),
+
+  -- freshwater
+  ('trout',              'Trout',                             'Salmonidae',                 true,  null,      'fresh', 'regulated', 500, true),
+  ('catfish',            'Catfish',                           'Siluriformes',               true,  null,      'fresh', 'open',      501, true),
+  ('walleye',            'Walleye',                           'Sander vitreus',             false, null,      'fresh', 'regulated', 502, false),
+  ('yellow_perch',       'Yellow perch',                      'Perca flavescens',           false, null,      'fresh', 'open',      503, false),
+  ('smallmouth_bass',    'Smallmouth bass',                   'Micropterus dolomieu',       false, null,      'fresh', 'regulated', 504, false),
+  ('largemouth_bass',    'Largemouth bass',                   'Micropterus salmoides',      false, null,      'fresh', 'regulated', 505, false),
+  ('lake_trout',         'Lake trout',                        'Salvelinus namaycush',       false, 'trout',   'fresh', 'regulated', 506, false),
+  ('steelhead',          'Steelhead',                         'Oncorhynchus mykiss',        false, 'trout',   'fresh', 'regulated', 507, false),
+  ('brown_trout',        'Brown trout',                       'Salmo trutta',               false, 'trout',   'fresh', 'regulated', 508, false),
+  ('muskellunge',        'Muskellunge (muskie)',              'Esox masquinongy',           false, null,      'fresh', 'regulated', 509, false),
+  ('northern_pike',      'Northern pike',                     'Esox lucius',                false, null,      'fresh', 'open',      510, false),
+  ('black_crappie',      'Black crappie',                     'Pomoxis nigromaculatus',     false, null,      'fresh', 'regulated', 511, false),
+  ('bluegill',           'Bluegill',                          'Lepomis macrochirus',        false, null,      'fresh', 'open',      512, false),
+  ('channel_catfish',    'Channel catfish',                   'Ictalurus punctatus',        false, 'catfish', 'fresh', 'open',      513, false);
+
+on conflict (id) do nothing;


### PR DESCRIPTION
## Founder requirements 2026-09-01 — foundations slice
Intake + rulings: `docs/product/requests/2026-09-01-expansion-requirements.md` · Decisions: `docs/architecture/decisions/007-regional-expansion-and-catch-gps.md`

## Shipped in this PR

| Req | What landed |
|---|---|
| **§3 Milky** | `milky` water clarity in the seeded vocabulary, the offline mirror, and the location sheet — between Stained and Muddy |
| **§4 Regions** | 9-region Fishing region preference in Settings (SoCal default) drives the picker's "Common" row — Florida leads Snook/Redfish/Tarpon, Hawaii Ahi/Ono/Marlin; suggestions **only**, search + "Something else" always reach all 83 species; placeholder examples follow the region too |
| **§5 Freshwater** | `environments.ts` (ocean→stream, water-class roll-ups, per-environment condition emphasis) + ~24 freshwater species; no ocean assumptions planted in new code |
| **§1 GPS** | **Ratified, not rebuilt** — the ask (prompt-once, never block save, offline-then-sync, accuracy stored) was already the shipped pattern (`startPositionRequest`/`attachPositionLater`). Map geometry is the next slice |

## Bonus catch by the new tests
The new vocabulary **parity tests** (TS mirror ↔ SQL migrations, both directions) immediately caught real pre-existing drift: `tannic`, `algae_bloom`, `red_tide` were seeded in SQL but missing from the offline mirror. Fixed; parity enforced from now on.

## Verification
`npm run verify` green: **316/316 tests** (12 new net). Live browser: region switch → picker rows change correctly; "Common — Florida" label; Milky in the clarity scale; SoCal default identical to before. Screenshots: Settings section, Florida picker, Hawaii picker, Milky row (attached in the Arena thread).

## Deferred (per founder's staging ruling: foundations first)
Tide-chart catch markers (#6), Calendar view (#7), Map view (#1 view half), filters (#8), appearance modes (#9), Don't-Forget list (#10) — all view-layer slices that now have the model groundwork they need.