### PR TITLE
architect + ux-ui: calendar home, day pages, catch markers on the tide curve (§6/§7)

### DIFF
--- a/docs/team/worklog/2026-09-01-08-architect.md
+++ b/docs/team/worklog/2026-09-01-08-architect.md
@@ -1,0 +1,24 @@
+### 2026-09-01 | architect | Calendar data + catch-marker clustering (§6/§7 views slice)
+
+Founder §6 and §7 landed as the views slice on top of PR #18's foundations (ADR 007 §7).
+
+- **`calendar-data.ts` (pure, tested):** month cells (Monday-first, 5–6 rows, trailing
+  all-grey week trimmed; local-noon Date construction so a DST hour can never slide a
+  cell into the wrong day), zone-correct local date keys via `Intl` (a 22:30-PDT catch
+  is a Tuesday catch while UTC says Wednesday — pinned in tests), honest day summaries
+  (resolved vs needs-details, deleted rows invisible, unparseable clocks not a day),
+  strict `YYYY-MM-DD` day params (leap-legal, junk 404s).
+- **Zone split, on purpose and documented:** the calendar is dated by the VIEWER's
+  calendar (a logbook is about a person); the tide chart stays anchored to the station's
+  calendar day (a tide table is about a place). Opposite rules, both right, both named.
+- **`catch-markers.ts` (pure, tested):** gap-clustering of catches by the chart's own
+  x-scale (~32 px thumb-width at the timeline's density), unresolved-mark flag
+  propagates to the cluster. Hot-bite chain merges into one marker; distant catches
+  never merge. 330/330 tests.
+- **Render-purity compliance:** `Date.now()` removed from component renders (the new
+  react-hooks purity rule rightly flagged it): day-summary "today" derives from
+  `useNow()`; calendar month cursor = navigation state only, current month derived, no
+  effect. Took the pattern the codebase already proved (`useNow`/`useLocalTimeZone`)
+  instead of inventing a third way.
+- **Caught by the tripwires:** one raw `text-[12px]` literal in my first pass — matched
+  the file's established single-line `<text>` idiom rather than adding an exception.

--- a/docs/team/worklog/2026-09-01-09-ux-ui.md
+++ b/docs/team/worklog/2026-09-01-09-ux-ui.md
@@ -1,0 +1,26 @@
+### 2026-09-01 | ux-ui | Month calendar home, day pages, catches on the tide curve
+
+Founder §6/§7 on screens.
+
+- **Calendar is now the real home surface** (D23): month title + prev/next + Today
+  (only when away), Mon-first week headers, every in-month day a 44px+ button. Dots:
+  orange = catches, amber = needs details — with a legend in words, and every day cell
+  speaks the truth to screen readers ("Tue, September 1 — 2 catches, 1 needs details").
+  Out-of-month spill cells stay to keep week rows stable but are dimmed and inert; a
+  wholly out-of-month week row is trimmed (first pass left a dead grey row — a polish
+  round caught it).
+- **Day pages** (`/day/YYYY-MM-DD`): heading "Today" / weekday format, count line, amber
+  *Needs details* section first (finish-it link into the Log), catch rows with time,
+  disposition, bait/lure/jig, and honest GPS ("±12 m" / "No GPS fix" — headless proves
+  the truth-telling path). Links: ← Calendar, Open tide chart. Empty day says so plainly
+  and points at the Log. Invalid dates 404.
+- **Catch markers on the tide curve:** each catch sits ON the curve at its exact instant
+  (clustered with a count under one thumb-width). Tap does two things: reveals species +
+  times in an opaque plate (same idiom as the sun markers, same pan-never-taps guard,
+  same Enter/Space contract) AND pins the read-head onto the catch — so the header
+  readout instantly reads height + movement AT the catch. Verified live: three catches
+  inside two minutes cluster to one marker, reveal lists all three, header readout
+  answered "-0.71 ft/hr, Falling" at 8:46pm.
+- Verified at 390px and 320px; zero page errors across the whole flow; worklog truth:
+  screenshots `v-calendar-dots.png`, `v-day.png`, `v-tide-markers.png`,
+  `v-tide-revealed.png`, `v2-calendar.png`, `v-calendar-320.png`.

--- a/src/app/(app)/day/[date]/page.tsx
+++ b/src/app/(app)/day/[date]/page.tsx
@@ -1,12 +1,25 @@
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 
-export const metadata: Metadata = { title: "Day | Fish Log Book" };
+import { parseDayParam } from "@/features/calendar/calendar-data";
+import { DayView } from "@/features/calendar/components/day-view";
 
-export default function Page() {
-  return (
-    <section className="rounded-lg border border-hairline bg-surface p-4">
-      <h1 className="text-h1">Day</h1>
-      <p className="mt-3 text-body text-text-muted">A day&rsquo;s journal, trips and marks. Today gets Start Fishing and the four verbs; a past day gets the backfill entry (D24).</p>
-    </section>
-  );
+type Params = Promise<{ date: string }>;
+
+export async function generateMetadata({ params }: { params: Params }): Promise<Metadata> {
+  const { date } = await params;
+  const valid = parseDayParam(date);
+  return { title: `${valid ?? "Day"} | Fish Log Book` };
+}
+
+/**
+ * One logged day (founder requirements §7). The date is data, not wall decoration:
+ * anything that is not a real `YYYY-MM-DD` calendar day 404s rather than rendering a
+ * page named after garbage.
+ */
+export default async function DayPage({ params }: { params: Params }) {
+  const { date } = await params;
+  const dateKey = parseDayParam(date);
+  if (!dateKey) notFound();
+  return <DayView dateKey={dateKey} />;
 }

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -1,34 +1,30 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
+import { MonthCalendar } from "@/features/calendar/components/month-calendar";
+
 export const metadata: Metadata = { title: "Calendar | Fish Log Book" };
 
 /**
  * / — the month calendar. D23 is unambiguous that the calendar is the home surface: not a
- * dashboard, not a feed, not a landing page.
+ * dashboard, not a feed, not a landing page (founder requirements 2026-09-01 §7 makes it
+ * the third leg of Calendar → Day → Catch navigation).
  *
- * The calendar itself is the next round's work (ADR 005 scope note: this round is the
- * design system and the shell, and nothing in features/* beyond shell/ should exist).
- *
- * The tide chart link carries over from the pre-shell homepage (see PR #4/#5). The Tide
- * tab in the primary nav also reaches it now, but this stays as a direct shortcut until
- * the month grid itself surfaces conditions inline.
+ * Dots are the day's truth: orange for catches, amber for anything still needing
+ * details. The tide chart link carries over from the shell round (PR #4/#5); the Tide
+ * tab reaches it too, and this stays as the direct shortcut until the grid itself
+ * surfaces conditions inline.
  */
 export default function CalendarPage() {
   return (
-    <section className="rounded-lg border border-hairline bg-surface p-4">
-      <h1 className="text-h1">Calendar</h1>
-      <p className="mt-3 text-body text-text-muted">
-        The month grid lands next, with a record dot on days that have one and a flag on
-        days that need a look.
-      </p>
-
+    <div className="flex flex-col gap-4">
+      <MonthCalendar />
       <Link
         href="/tides"
-        className="mt-4 inline-flex min-h-touch-floor items-center justify-center rounded-md border border-signal-orange bg-signal-orange px-6 py-3 text-label font-semibold text-ink-on-orange transition-colors hover:bg-signal-orange-pressed focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+        className="inline-flex min-h-touch-floor items-center justify-center self-start rounded-md border border-border-interactive px-4 text-label text-text-link transition-colors hover:border-tide-cyan focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
       >
         Open tide chart
       </Link>
-    </section>
+    </div>
   );
 }

--- a/src/features/calendar/calendar-data.test.ts
+++ b/src/features/calendar/calendar-data.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ariaForKey,
+  currentMonthCursor,
+  localDateKey,
+  monthCells,
+  monthCursorOfDayKey,
+  monthLabel,
+  parseDayParam,
+  shiftMonth,
+  summarizeDays,
+} from "./calendar-data";
+
+const catchRow = (iso: string, unresolved = false) => ({
+  caught_at: iso,
+  deleted_at: null as string | null,
+  species_id: unresolved ? null : "yellowtail",
+  species_other: null as string | null,
+});
+
+describe("month cells", () => {
+  it("renders full weeks only — a wholly out-of-month row is trimmed", () => {
+    const cells = monthCells({ year: 2026, month: 8 }, "America/Los_Angeles", 0); // September 2026
+    expect(cells).toHaveLength(35);
+    expect(cells[0].dayOfMonth).toBe(31); // Monday August 31
+    expect(cells[0].inCurrentMonth).toBe(false);
+    expect(cells[cells.length - 1].key).toBe("2026-10-04");
+    expect(cells.filter((c) => c.inCurrentMonth)).toHaveLength(30);
+    expect(cells.find((c) => c.key === "2026-09-01")?.inCurrentMonth).toBe(true);
+  });
+
+  it("handles February without a leap-year slip", () => {
+    const cells = monthCells({ year: 2025, month: 1 }, "America/Los_Angeles", 0);
+    expect(cells.filter((c) => c.inCurrentMonth)).toHaveLength(28);
+    expect(cells[0].key).toBe("2025-01-27");
+  });
+
+  it("survives a DST month inside the grid (March 2026 PDT, the 6-row month)", () => {
+    const cells = monthCells({ year: 2026, month: 2 }, "America/Los_Angeles", 0);
+    expect(cells).toHaveLength(42);
+    expect(cells.filter((c) => c.inCurrentMonth)).toHaveLength(31);
+    expect(cells.find((c) => c.key === "2026-03-15")).toBeTruthy();
+  });
+});
+
+describe("local date keys", () => {
+  it("assigns a catch to the VIEWER's day, not UTC's", () => {
+    // 05:30 UTC is 22:30 the previous day in PDT — the catch is a "Tuesday" catch here.
+    const at = Date.parse("2026-09-02T05:30:00.000Z");
+    expect(localDateKey(at, "UTC")).toBe("2026-09-02");
+    expect(localDateKey(at, "America/Los_Angeles")).toBe("2026-09-01");
+  });
+});
+
+describe("day summaries", () => {
+  it("counts resolved catches and unresolved marks separately; deleted rows never count", () => {
+    const zone = "America/Los_Angeles";
+    const map = summarizeDays(
+      [
+        catchRow("2026-09-01T15:00:00Z"),
+        catchRow("2026-09-01T16:00:00Z"),
+        catchRow("2026-09-01T17:00:00Z", true),
+        { ...catchRow("2026-09-01T18:00:00Z"), deleted_at: "2026-09-01T19:00:00Z" },
+        catchRow("2026-09-03T15:00:00Z"),
+      ],
+      zone,
+    );
+    expect(map.get("2026-09-01")).toEqual({ catches: 2, needsDetails: 1 });
+    expect(map.get("2026-09-03")).toEqual({ catches: 1, needsDetails: 0 });
+    expect(map.size).toBe(2);
+  });
+
+  it("a catch with an unparseable clock is not a day on the grid", () => {
+    const map = summarizeDays([{ ...catchRow("not-a-date") }], "UTC");
+    expect(map.size).toBe(0);
+  });
+});
+
+describe("day params and labels", () => {
+  it("accepts real days and rejects everything else", () => {
+    expect(parseDayParam("2026-09-14")).toBe("2026-09-14");
+    expect(parseDayParam("2026-02-29")).toBeNull();
+    expect(parseDayParam("2024-02-29")).toBe("2024-02-29");
+    expect(parseDayParam("09-14-2026")).toBeNull();
+    expect(parseDayParam("2026-9-4")).toBeNull();
+    expect(parseDayParam("../../etc/passwd")).toBeNull();
+  });
+
+  it("labels a day honestly, including empty", () => {
+    expect(ariaForKey("2026-09-14", { catches: 2, needsDetails: 1 })).toContain("2 catches, 1 needs details");
+    expect(ariaForKey("2026-09-14", undefined)).toContain("no fishing logged");
+  });
+
+  it("month cursors shift correctly across years", () => {
+    expect(shiftMonth({ year: 2026, month: 0 }, -1)).toEqual({ year: 2025, month: 11 });
+    expect(monthCursorOfDayKey("2026-09-14")).toEqual({ year: 2026, month: 8 });
+    expect(monthLabel({ year: 2026, month: 8 })).toContain("September 2026");
+    expect(currentMonthCursor("America/Los_Angeles", Date.parse("2026-09-01T20:00:00Z"))).toEqual({
+      year: 2026,
+      month: 8,
+    });
+  });
+});

--- a/src/features/calendar/calendar-data.ts
+++ b/src/features/calendar/calendar-data.ts
@@ -1,0 +1,159 @@
+/**
+ * Calendar data: the pure half of the month grid (founder requirements 2026-09-01 §7).
+ *
+ * The calendar is dated by the VIEWER's calendar (your days of fishing), not a tide
+ * station's — the opposite of the tide chart, on purpose and documented: a tide table is
+ * about a place; a logbook is about a person. All zone work goes through `Intl` with an
+ * explicit IANA zone so the grid is right in Pago Pago the same as in PDT, including on
+ * DST edges (a local day is 23 or 25 hours twice a year; Date arithmetic that ignores
+ * that drops a cell).
+ */
+
+export interface MonthCursor {
+  /** Four-digit year. */
+  readonly year: number;
+  /** 0-based month (Date convention: January = 0). */
+  readonly month: number;
+}
+
+export interface DayCell {
+  /** Local calendar key, `YYYY-MM-DD`, in the viewer's zone. */
+  readonly key: string;
+  readonly dayOfMonth: number;
+  readonly inCurrentMonth: boolean;
+  readonly isToday: boolean;
+}
+
+export interface DaySummary {
+  /** Resolved catches (species known) landed that day. */
+  readonly catches: number;
+  /** Marks/catches still waiting on "what happened" — the amber flag, never hidden. */
+  readonly needsDetails: number;
+}
+
+/** Monday-first, the way a fishing week actually runs into the weekend. */
+export const WEEKDAY_HEADERS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+
+const CELLS = 42; // six weeks — deep enough that the grid never reflows month to month
+
+/** Year/month/day in the given zone, via Intl. */
+export function zonedParts(atMs: number, timeZone: string): { y: number; m: number; d: number } {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date(atMs));
+  const map = Object.fromEntries(parts.map((p) => [p.type, p.value]));
+  return { y: Number(map.year), m: Number(map.month), d: Number(map.day) };
+}
+
+/** `YYYY-MM-DD` for the instant in the given zone — the day a catch belongs to. */
+export function localDateKey(atMs: number, timeZone: string): string {
+  const { y, m, d } = zonedParts(atMs, timeZone);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${y}-${pad(m)}-${pad(d)}`;
+}
+
+/** The zone's current month as a cursor. `nowMs` is explicit — the clock is the
+ *  caller's job (render-purity rule), which keeps every function here pure. */
+export function currentMonthCursor(timeZone: string, nowMs: number): MonthCursor {
+  const { y, m } = zonedParts(nowMs, timeZone);
+  return { year: y, month: m - 1 };
+}
+
+export function shiftMonth(cursor: MonthCursor, delta: number): MonthCursor {
+  const total = cursor.year * 12 + cursor.month + delta;
+  return { year: Math.floor(total / 12), month: ((total % 12) + 12) % 12 };
+}
+
+export function monthLabel(cursor: MonthCursor): string {
+  return new Intl.DateTimeFormat(undefined, { year: "numeric", month: "long" }).format(
+    new Date(cursor.year, cursor.month, 15),
+  );
+}
+
+/**
+ * The full week rows of one viewer-local month (5–6 rows; a wholly out-of-month row is
+ * trimmed rather than rendered as dead grey cells). Cell dates are built with local-noon
+ * Date values (never midnight) so a DST hour change inside a cell can never slide it
+ * into the wrong day — noon survives the worst one-hour jump either way.
+ */
+export function monthCells(cursor: MonthCursor, timeZone: string, nowMs: number): readonly DayCell[] {
+  const first = new Date(cursor.year, cursor.month, 1, 12);
+  const mondayOffset = (first.getDay() + 6) % 7;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const todayKey = localDateKey(nowMs, timeZone);
+
+  const all = Array.from({ length: CELLS }, (_, i) => {
+    const cell = new Date(cursor.year, cursor.month, 1 - mondayOffset + i, 12);
+    const key = `${cell.getFullYear()}-${pad(cell.getMonth() + 1)}-${pad(cell.getDate())}`;
+    return {
+      key,
+      dayOfMonth: cell.getDate(),
+      inCurrentMonth: cell.getMonth() === cursor.month,
+      isToday: key === todayKey,
+    };
+  });
+  let rows = CELLS / 7;
+  while (rows > 1 && all.slice((rows - 1) * 7).every((cell) => !cell.inCurrentMonth)) rows -= 1;
+  return all.slice(0, rows * 7);
+}
+
+/** Roll the store's catches into per-day counts. Deleted rows never reach the glass. */
+export function summarizeDays(
+  catches: readonly { caught_at: string; deleted_at: string | null; species_id: string | null; species_other: string | null }[],
+  timeZone: string,
+): ReadonlyMap<string, DaySummary> {
+  const byDay = new Map<string, DaySummary>();
+  for (const c of catches) {
+    if (c.deleted_at !== null) continue;
+    const at = Date.parse(c.caught_at);
+    if (Number.isNaN(at)) continue; // a bad clock is not a day on the grid
+    const key = localDateKey(at, timeZone);
+    const needsDetails = c.species_id === null && c.species_other === null;
+    const current = byDay.get(key) ?? { catches: 0, needsDetails: 0 };
+    byDay.set(key, {
+      catches: current.catches + (needsDetails ? 0 : 1),
+      needsDetails: current.needsDetails + (needsDetails ? 1 : 0),
+    });
+  }
+  return byDay;
+}
+
+/** Full spoken date + honest counts ("Tue, September 5 — 2 catches, 1 needs details"). */
+export function ariaForKey(key: string, summary: DaySummary | undefined): string {
+  const [y, m, d] = key.split("-").map(Number);
+  const pretty = new Intl.DateTimeFormat(undefined, {
+    weekday: "short",
+    month: "long",
+    day: "numeric",
+  }).format(new Date(y, m - 1, d, 12));
+  if (!summary || (summary.catches === 0 && summary.needsDetails === 0)) {
+    return `${pretty} — no fishing logged`;
+  }
+  const parts: string[] = [];
+  if (summary.catches > 0) parts.push(`${summary.catches} ${summary.catches === 1 ? "catch" : "catches"}`);
+  if (summary.needsDetails > 0) parts.push(`${summary.needsDetails} needs details`);
+  return `${pretty} — ${parts.join(", ")}`;
+}
+
+/** Strict `YYYY-MM-DD` that points at a real calendar day, or null. */
+export function parseDayParam(raw: string): string | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw);
+  if (!match) return null;
+  const [, ys, ms, ds] = match;
+  const y = Number(ys);
+  const m = Number(ms);
+  const d = Number(ds);
+  if (y < 2000 || y > 2200) return null;
+  const probe = new Date(Date.UTC(y, m - 1, d));
+  if (probe.getUTCFullYear() !== y || probe.getUTCMonth() + 1 !== m || probe.getUTCDate() !== d) return null;
+  return `${ys}-${ms}-${ds}`;
+}
+
+/** Strict key → the month its day page belongs to (for "view this month" links). */
+export function monthCursorOfDayKey(key: string): MonthCursor {
+  const [y, m] = key.split("-").map(Number);
+  return { year: y, month: m - 1 };
+}

--- a/src/features/calendar/components/day-view.tsx
+++ b/src/features/calendar/components/day-view.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo } from "react";
+
+import { searchable, useLog } from "@/features/catches/store";
+import { GEAR_ROLE_LABEL, formatClock, formatDayHeading } from "@/features/catches/format";
+import { useLocalTimeZone } from "@/features/conditions/use-local-time-zone";
+import { useNow } from "@/lib/time/use-now";
+import { localDateKey } from "../calendar-data";
+
+/**
+ * One logged day (founder requirements §7: Calendar → Day → Catch).
+ *
+ * Shows exactly what the log knows: catch times, species (or the amber "needs details"
+ * state), the gear attached to each, GPS honesty (real accuracy or "no fix"), and kept /
+ * released. It does NOT promise tide or weather it cannot show yet — those join when the
+ * conditions snapshot link-up lands. D24's backfill verbs land with the day-flow slice;
+ * today a day page is a window into history, plus a door to the tide chart.
+ */
+export function DayView({ dateKey }: { dateKey: string }) {
+  const state = useLog();
+  const zone = useLocalTimeZone() ?? "UTC";
+
+  const items = useMemo(() => {
+    if (!state.hydrated) return [];
+    return searchable(state)
+      .filter(({ record }) => localDateKey(Date.parse(record.caught_at), zone) === dateKey)
+      .sort((a, b) => Date.parse(a.record.caught_at) - Date.parse(b.record.caught_at));
+  }, [state, zone, dateKey]);
+
+  const now = useNow();
+  // No clock yet (SSR/first paint): no day is "today". The long-format heading still shows.
+  const today = now === null ? "" : localDateKey(Number(now), zone);
+  const heading = formatDayHeading(dateKey, today);
+  const resolved = items.filter((i) => i.speciesName !== null);
+  const pending = items.filter((i) => i.speciesName === null);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Link
+        href="/"
+        className="inline-flex min-h-touch-floor items-center gap-2 self-start rounded-md text-label text-text-link focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+      >
+        ‹ Calendar
+      </Link>
+
+      <section className="rounded-lg border border-hairline bg-surface p-4">
+        <h1 className="text-h1">{heading}</h1>
+        <p className="mt-2 text-caption text-text-muted">
+          {dateKey}
+          {state.hydrated
+            ? items.length === 0
+              ? " — no fishing logged"
+              : ` — ${resolved.length} ${resolved.length === 1 ? "catch" : "catches"}${
+                  pending.length > 0 ? `, ${pending.length} needs details` : ""
+                }`
+            : ""}
+        </p>
+      </section>
+
+      {!state.hydrated ? (
+        <section className="rounded-lg border border-hairline bg-surface p-4">
+          <p className="text-body text-text-muted">Opening your log…</p>
+        </section>
+      ) : items.length === 0 ? (
+        <section className="rounded-lg border border-hairline bg-surface p-4">
+          <h2 className="text-h3">Nothing on this day yet.</h2>
+          <p className="mt-2 text-body text-text-muted">
+            When you log a catch on {formatDayHeading(dateKey, "") === "Today" ? "today" : "this day"}, it lands here
+            — time, species, gear, and where you were.
+          </p>
+          <Link
+            href="/log"
+            className="mt-4 inline-flex min-h-touch-floor items-center justify-center rounded-md border border-border-interactive px-4 text-label text-text-link focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+          >
+            Open the Fish Log
+          </Link>
+        </section>
+      ) : (
+        <>
+          {pending.length > 0 ? (
+            <section className="flex flex-col gap-3" aria-labelledby="day-needs-details">
+              <h2 id="day-needs-details" className="text-h3 text-amber-flag">
+                Needs details
+              </h2>
+              {pending.map(({ record }) => (
+                <DayRow key={record.id} record={record} speciesName="Mark — not told yet" zone={zone} needsDetails />
+              ))}
+            </section>
+          ) : null}
+          <section className="flex flex-col gap-3" aria-label="Catches">
+            {resolved.map(({ record, speciesName, gear }) => (
+              <DayRow key={record.id} record={record} speciesName={speciesName ?? ""} zone={zone} gear={gear} />
+            ))}
+          </section>
+        </>
+      )}
+
+      <Link
+        href="/tides"
+        className="inline-flex min-h-touch-floor items-center justify-center self-start rounded-md border border-border-interactive px-4 text-label text-text-link focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+      >
+        Open tide chart
+      </Link>
+    </div>
+  );
+}
+
+function DayRow({
+  record,
+  speciesName,
+  zone,
+  gear = [],
+  needsDetails = false,
+}: {
+  record: {
+    id: string;
+    caught_at: string;
+    species_id: string | null;
+    species_other: string | null;
+    lat: number | null;
+    lng: number | null;
+    gps_accuracy_m: number | null;
+    disposition: "kept" | "released" | "n/a" | null;
+  };
+  speciesName: string;
+  zone: string;
+  gear?: readonly { role: string; label: string }[];
+  needsDetails?: boolean;
+}) {
+  const baits = gear.filter((g) => g.role === "bait" || g.role === "lure" || g.role === "jig");
+  const gpsText =
+    record.lat !== null && record.lng !== null
+      ? record.gps_accuracy_m !== null
+        ? `GPS ±${Math.round(record.gps_accuracy_m)} m`
+        : "GPS fix"
+      : "No GPS fix";
+
+  return (
+    <article
+      className={`rounded-lg border bg-surface p-4 ${
+        needsDetails ? "border-amber-flag/60" : "border-hairline"
+      }`}
+    >
+      <div className="flex items-baseline justify-between gap-3">
+        <h3 className="text-h3">{speciesName}</h3>
+        <time dateTime={record.caught_at} className="shrink-0 font-mono text-caption text-text-muted">
+          {formatClock(record.caught_at, zone)}
+        </time>
+      </div>
+      <p className="mt-1 text-caption text-text-muted">
+        {[
+          record.disposition && record.disposition !== "n/a" ? record.disposition : null,
+          ...baits.map((b) => `${GEAR_ROLE_LABEL[b.role as keyof typeof GEAR_ROLE_LABEL] ?? b.role}: ${b.label}`),
+          gpsText,
+        ]
+          .filter(Boolean)
+          .join(" · ")}
+      </p>
+      {needsDetails ? (
+        <Link
+          href="/log"
+          className="mt-2 inline-flex min-h-touch-floor items-center rounded-md text-label text-text-link focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+        >
+          Finish it in the Fish Log →
+        </Link>
+      ) : null}
+    </article>
+  );
+}

--- a/src/features/calendar/components/month-calendar.tsx
+++ b/src/features/calendar/components/month-calendar.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { useLog } from "@/features/catches/store";
+import { useLocalTimeZone } from "@/features/conditions/use-local-time-zone";
+import { useNow } from "@/lib/time/use-now";
+import {
+  WEEKDAY_HEADERS,
+  ariaForKey,
+  currentMonthCursor,
+  monthCells,
+  monthLabel,
+  shiftMonth,
+  summarizeDays,
+  type MonthCursor,
+} from "../calendar-data";
+
+/**
+ * The month grid — D23's home surface (founder requirements §7).
+ *
+ * Rules kept from the design notes: the grid is the page, day cells are buttons, a day
+ * with records shows the record dot, a day with things nobody has finished shows the
+ * amber flag dot beside it. Out-of-month cells stay visible so the week rows never
+ * reflow month to month, but they are inert — their days exist on their own months.
+ *
+ * The zone arrives a tick after mount (SSR can't know the angler's); the grid paints in
+ * UTC first on every platform so server and first client render are byte-identical.
+ */
+export function MonthCalendar() {
+  const router = useRouter();
+  const log = useLog();
+  const zone = useLocalTimeZone() ?? "UTC";
+  const now = useNow();
+  const nowMs = now === null ? 0 : Number(now);
+  /* Navigation is the ONLY state: until the angler moves, the cursor is just the current
+     month derived from the resolved zone + clock — no effect, no placeholder month that
+     would need "correcting" a tick later. Once they move, their month stays theirs:
+     zone resolution never yanks it back. */
+  const [navigated, setNavigated] = useState<MonthCursor | null>(null);
+  const cursor = navigated ?? (now !== null ? currentMonthCursor(zone, nowMs) : null);
+
+  const cells = useMemo(() => (cursor ? monthCells(cursor, zone, nowMs) : null), [cursor, zone, nowMs]);
+  const summaries = useMemo(() => summarizeDays(log.catches, zone), [log.catches, zone]);
+  const viewingNow = useMemo(() => {
+    if (!cursor) return true;
+    const current = currentMonthCursor(zone, nowMs);
+    return current.year === cursor.year && current.month === cursor.month;
+  }, [cursor, zone, nowMs]);
+
+  const NAV_BUTTON =
+    "inline-flex min-h-touch-floor min-w-touch-floor items-center justify-center rounded-md border border-border-interactive text-label text-text-link focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring active:scale-95 motion-reduce:transition-none";
+
+  if (cursor === null || cells === null) {
+    return (
+      <p className="rounded-lg border border-hairline bg-surface p-4 text-body text-text-muted">
+        Opening the calendar…
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-2">
+        <button
+          type="button"
+          aria-label="Previous month"
+          className={NAV_BUTTON}
+          onClick={() => cursor && setNavigated(shiftMonth(cursor, -1))}
+        >
+          ‹
+        </button>
+        <h2 className="text-h1 text-text-primary" aria-live="polite">
+          {monthLabel(cursor)}
+        </h2>
+        <div className="flex items-center gap-2">
+          {!viewingNow ? (
+            <button
+              type="button"
+              className={`${NAV_BUTTON} px-4`}
+              onClick={() => setNavigated(currentMonthCursor(zone, nowMs))}
+            >
+              Today
+            </button>
+          ) : null}
+          <button
+            type="button"
+            aria-label="Next month"
+            className={NAV_BUTTON}
+            onClick={() => cursor && setNavigated(shiftMonth(cursor, 1))}
+          >
+            ›
+          </button>
+        </div>
+      </div>
+
+      <div role="grid" aria-label={`Days with records, ${monthLabel(cursor)}`}>
+        <div role="row" className="grid grid-cols-7">
+          {WEEKDAY_HEADERS.map((day) => (
+            <span
+              key={day}
+              role="columnheader"
+              className="pb-1 text-center text-caption text-text-muted"
+            >
+              {day}
+            </span>
+          ))}
+        </div>
+        <div className="grid grid-cols-7 gap-1">
+          {cells.map((cell) => {
+            const summary = summaries.get(cell.key);
+            if (!cell.inCurrentMonth) {
+              return (
+                <span
+                  key={cell.key}
+                  aria-hidden="true"
+                  className="flex min-h-touch-floor flex-col items-center justify-center rounded-md text-caption text-text-muted/40 select-none"
+                >
+                  {cell.dayOfMonth}
+                </span>
+              );
+            }
+            return (
+              <button
+                key={cell.key}
+                type="button"
+                aria-label={ariaForKey(cell.key, summary)}
+                aria-current={cell.isToday ? "date" : undefined}
+                onClick={() => router.push(`/day/${cell.key}`)}
+                className={`flex min-h-touch-floor flex-col items-center justify-center gap-1 rounded-md border text-body font-semibold transition-colors focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-2 focus-visible:outline-focus-ring active:scale-95 motion-reduce:transition-none ${
+                  cell.isToday
+                    ? "border-signal-orange text-text-primary"
+                    : "border-transparent text-text-primary hover:border-border-interactive"
+                }`}
+              >
+                {cell.dayOfMonth}
+                <span className="flex h-2 items-center justify-center gap-1.5" aria-hidden="true">
+                  {summary && summary.catches > 0 ? (
+                    <span className="size-2 rounded-full bg-signal-orange" />
+                  ) : null}
+                  {summary && summary.needsDetails > 0 ? (
+                    <span className="size-2 rounded-full bg-amber-flag" />
+                  ) : null}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <p className="text-caption text-text-muted">
+        Orange dot: catches that day. Amber dot: something still needs details. Tap a day
+        to open it.
+      </p>
+      {!log.hydrated ? (
+        <p className="text-caption text-text-muted">Opening your log…</p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/conditions/catch-markers.test.ts
+++ b/src/features/conditions/catch-markers.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { clusterCatchMarkers, type CatchMarkerInput } from "./catch-markers";
+
+// 560 px/day scale, same as the chart: toX maps ms → px at that density.
+const PX_PER_MS = 560 / 86_400_000;
+const toX = (at: number) => at * PX_PER_MS;
+
+const mark = (id: string, hour: number, needsDetails = false): CatchMarkerInput => ({
+  id,
+  at: hour * 3_600_000,
+  label: "Test fish",
+  needsDetails,
+});
+
+describe("catch marker clustering", () => {
+  it("keeps well-separated catches as single markers", () => {
+    const clusters = clusterCatchMarkers([mark("a", 6), mark("b", 14)], toX);
+    expect(clusters).toHaveLength(2);
+    expect(clusters[0].members).toHaveLength(1);
+    expect(clusters[0].key).toBe("cluster-a");
+  });
+
+  it("clusters catches within one thumb-width of each other", () => {
+    // 20 minutes apart = ~9 px apart at the chart's own density.
+    const clusters = clusterCatchMarkers([mark("a", 6), mark("b", 6 + 20 / 60)], toX);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].members.map((m) => m.id)).toEqual(["a", "b"]);
+  });
+
+  it("resolves a hot bite chain into one cluster but never merges distant ones", () => {
+    const clusters = clusterCatchMarkers(
+      [mark("a", 6), mark("b", 6.3), mark("c", 6.6), mark("d", 20)],
+      toX,
+    );
+    expect(clusters).toHaveLength(2);
+    expect(clusters[0].members).toHaveLength(3);
+    expect(clusters[1].members).toHaveLength(1);
+  });
+
+  it("an unresolved mark inside the cluster flags the whole marker", () => {
+    const clusters = clusterCatchMarkers([mark("a", 6), mark("b", 6.1, true)], toX);
+    expect(clusters[0].anyNeedsDetails).toBe(true);
+    expect(clusterCatchMarkers([mark("a", 6)], toX)[0].anyNeedsDetails).toBe(false);
+  });
+
+  it("an empty log means no markers", () => {
+    expect(clusterCatchMarkers([], toX)).toEqual([]);
+  });
+});

--- a/src/features/conditions/catch-markers.ts
+++ b/src/features/conditions/catch-markers.ts
@@ -1,0 +1,69 @@
+/**
+ * Catch markers on the tide curve (founder requirements 2026-09-01 §6).
+ *
+ * Each catch lands on the curve at its exact logged instant; several catches inside one
+ * thumb-width read as one clustered marker with a count. This file is the pure half:
+ * what markers exist and how they cluster. The SVG half lives in `tide-timeline.tsx`,
+ * reusing the sun-marker interaction (tap reveals, keyboard works, a pan never counts
+ * as a tap).
+ *
+ * Clustering uses an x-scale callback rather than assuming one, so the same logic holds
+ * if the chart density ever changes and so the tests need no pixels from the fixture.
+ */
+
+export interface CatchMarkerInput {
+  readonly id: string;
+  /** Epoch milliseconds of the catch: `caught_at` at the exact logged instant. */
+  readonly at: number;
+  /** Display name: vocabulary species, the angler's own text, or "Mark" for unresolved. */
+  readonly label: string;
+  /** A mark that has not been told what happened yet — flagged amber, never hidden. */
+  readonly needsDetails: boolean;
+}
+
+export interface CatchMarkerCluster {
+  /** Stable key: the id of the earliest member (`cluster-<id>`). */
+  readonly key: string;
+  /** Instant of the earliest member — the marker position and the read-head target. */
+  readonly at: number;
+  readonly members: readonly CatchMarkerInput[];
+  readonly anyNeedsDetails: boolean;
+}
+
+/**
+ * Group markers that would draw on top of each other. Two clusters may never be closer
+ * than `minGapPx` to each other's running centre at the current scale; a new marker that
+ * breaks the gap starts the next cluster.
+ */
+export function clusterCatchMarkers(
+  markers: readonly CatchMarkerInput[],
+  toX: (at: number) => number,
+  minGapPx = 32,
+): readonly CatchMarkerCluster[] {
+  const sorted = [...markers].sort((a, b) => a.at - b.at);
+  const clusters: CatchMarkerCluster[] = [];
+  let lastCentreX: number | null = null;
+
+  for (const marker of sorted) {
+    const cluster = clusters[clusters.length - 1];
+    if (cluster && lastCentreX !== null && Math.abs(toX(marker.at) - lastCentreX) < minGapPx) {
+      const members = [...cluster.members, marker];
+      clusters[clusters.length - 1] = {
+        ...cluster,
+        members,
+        anyNeedsDetails: cluster.anyNeedsDetails || marker.needsDetails,
+      };
+      const total = members.reduce((sum, m) => sum + toX(m.at), 0);
+      lastCentreX = total / members.length;
+    } else {
+      clusters.push({
+        key: `cluster-${marker.id}`,
+        at: marker.at,
+        members: [marker],
+        anyNeedsDetails: marker.needsDetails,
+      });
+      lastCentreX = toX(marker.at);
+    }
+  }
+  return clusters;
+}

--- a/src/features/conditions/components/tide-timeline.tsx
+++ b/src/features/conditions/components/tide-timeline.tsx
@@ -7,6 +7,7 @@ import { heightAt, type TidePredictionSeries, type TideTurn } from "@/core/rules
 import type { DaylightSpan } from "@/core/rules/astro";
 
 import { unwrapSourced } from "./sourced-value";
+import { clusterCatchMarkers, type CatchMarkerInput } from "../catch-markers";
 import {
   DEFAULT_CHART_HEIGHT,
   MIN_CHART_HEIGHT,
@@ -32,6 +33,10 @@ const KEY_STEP_MS_FAST = 180 * 60_000;
 const TAP_SLOP_PX = 6;
 /** Two turn labels closer together than this share pixels; the later one drops its text. */
 const TURN_LABEL_MIN_GAP_PX = 78;
+/** Catches closer together than this read as one clustered marker with a count. */
+const CATCH_CLUSTER_MIN_GAP_PX = 32;
+/** The most a cluster's reveal panel lists; past that it says "+N more". */
+const CATCH_REVEAL_MAX_LINES = 4;
 /**
  * The height-axis labels sit on the same left line as the readout card and the day
  * stepper, rather than jammed against the screen edge. Kept in sync with `--tide-gutter`
@@ -84,6 +89,7 @@ export function TideTimeline({
   spans,
   turns,
   sunMarkers,
+  catchMarkers,
   dayBoundaries,
   valueText,
   nowAction,
@@ -101,6 +107,10 @@ export function TideTimeline({
   spans: readonly DaylightSpan[];
   turns: readonly TideTurn[];
   sunMarkers: readonly SunMarker[];
+  /** Logged catches whose `caught_at` falls inside the plotted window (§6 founder
+   *  requirements): drawn on the curve at their instant; tap reveals and pins the
+   *  read-head onto the catch. */
+  catchMarkers?: readonly CatchMarkerInput[];
   dayBoundaries: readonly number[];
   valueText: string;
   /** Returns the read-head to the present. Null while it is already there, or while the
@@ -120,6 +130,7 @@ export function TideTimeline({
 
   const [box, setBox] = useState({ width: 0, height: DEFAULT_CHART_HEIGHT });
   const [revealedSunAt, setRevealedSunAt] = useState<number | null>(null);
+  const [revealedCatchKey, setRevealedCatchKey] = useState<string | null>(null);
 
   const chartHeight = Math.max(MIN_CHART_HEIGHT, box.height);
   const plotHeight = plotHeightFor(chartHeight);
@@ -128,6 +139,14 @@ export function TideTimeline({
   const padInline = box.width / 2;
   const xFor = (at: number) => xForAt(at, seriesStart);
   const clampAt = (at: number) => Math.round(Math.max(seriesStart, Math.min(seriesEnd, at)));
+
+  // Catches cluster only when their marks would print on top of each other at this
+  // scale (founder §6). `xFor` closes over `seriesStart`, so that edge is the dep.
+  const catchClusters = useMemo(
+    () => clusterCatchMarkers(catchMarkers ?? [], xFor, CATCH_CLUSTER_MIN_GAP_PX),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- xFor is xForAt(_, seriesStart)
+    [catchMarkers, seriesStart],
+  );
 
   const { yMinimum, yMaximum } = useMemo(() => {
     const heights = series.samples.map((s) => Number(s.height));
@@ -421,6 +440,85 @@ export function TideTimeline({
                     <>
                       <rect x={plate.x} y={plate.y} width={plate.width} height={plate.height} rx="3" fill="var(--color-background)" />
                       <text x={x} y={labelY} textAnchor="middle" className="fill-text-primary font-mono text-[12px] font-semibold"><tspan fill={isSunrise ? "var(--color-amber-flag)" : "var(--color-signal-orange)"}>{isSunrise ? "↑" : "↓"}</tspan> {label} <tspan className="fill-text-muted font-normal">{time}</tspan></text>
+                    </>
+                  )}
+                </g>
+              );
+            })}
+
+            {/* Catch markers (founder requirements §6): every logged catch sits ON the
+                curve at its exact instant. Tapping one does two things — reveals
+                species + time, and pins the read-head onto the catch, so the header
+                readout immediately answers "what was the tide doing when I caught it"
+                (height and movement at that instant). Clusters carry a count instead
+                of overlapping glyphs. Same tap-not-pan guard and keyboard contract as
+                the sun markers above. */}
+            {catchClusters.map((cluster) => {
+              const height = heightAt(series, instant(cluster.at));
+              if (!height) return null;
+              const x = xFor(cluster.at);
+              const y = yFor(unwrapSourced(height));
+              const revealed = revealedCatchKey === cluster.key;
+              const markerFill = cluster.anyNeedsDetails ? "var(--color-amber-flag)" : "var(--color-signal-orange)";
+              const inkFill = cluster.anyNeedsDetails ? "var(--color-background)" : "var(--color-ink-on-orange)";
+              const count = cluster.members.length;
+              const memberLines = cluster.members
+                .slice(0, CATCH_REVEAL_MAX_LINES)
+                .map((m) => `${m.label} · ${clock(instant(m.at), displayTimeZone)}`);
+              const lines =
+                count > CATCH_REVEAL_MAX_LINES
+                  ? [...memberLines, `+${count - CATCH_REVEAL_MAX_LINES} more`]
+                  : memberLines;
+              const longest = lines.reduce((a, b) => (b.length > a.length ? b : a), "");
+              // Bubble unfolds with its last line just above the marker (y - 22)…
+              let firstBaseline = y - 22 - (lines.length - 1) * 15;
+              // …unless that runs off the chart: then it unfolds below the marker.
+              if (firstBaseline < PLOT_TOP + 12) firstBaseline = y + 26;
+              const plate = labelPlate(x, firstBaseline + (lines.length - 1) * 15, longest, 12, 1);
+              const desc =
+                count === 1
+                  ? `${cluster.members[0].label} caught ${clock(instant(cluster.at), displayTimeZone)}, tide ${formatHeight(unwrapSourced(height), unit)}`
+                  : `${count} catches here, ${cluster.members
+                      .slice(0, 3)
+                      .map((m) => m.label)
+                      .join(", ")}${count > 3 ? "…" : ""}`;
+              return (
+                <g
+                  key={cluster.key}
+                  data-catch-marker={cluster.key}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`${desc}. Activate to show it and point the read-head at the catch.`}
+                  onClick={() => {
+                    if (dragRef.current?.moved) return;
+                    onSelectedAtChange(cluster.at);
+                    setRevealedCatchKey((current) => (current === cluster.key ? null : cluster.key));
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key !== "Enter" && event.key !== " ") return;
+                    event.preventDefault();
+                    onSelectedAtChange(cluster.at);
+                    setRevealedCatchKey((current) => (current === cluster.key ? null : cluster.key));
+                  }}
+                >
+                  <circle cx={x} cy={y} r="9" fill={markerFill} stroke="var(--color-surface)" strokeWidth="2" />
+                  {count === 1 ? (
+                    // A fish body with a tail, sized to sit inside the marker.
+                    <path
+                      d={`M ${x - 4.4} ${y} Q ${x - 1} ${y - 3.2} ${x + 2.2} ${y - 1.3} L ${x + 4.4} ${y - 2.8} L ${x + 4.4} ${y + 2.8} L ${x + 2.2} ${y + 1.3} Q ${x - 1} ${y + 3.2} ${x - 4.4} ${y} Z`}
+                      fill={inkFill}
+                    />
+                  ) : (
+                    <text x={x} y={y + 4} textAnchor="middle" dominantBaseline="middle" className="font-mono text-[11px] font-bold" fill={inkFill}>
+                      {count}
+                    </text>
+                  )}
+                  {revealed && (
+                    <>
+                      <rect x={plate.x} y={plate.y - (lines.length - 1) * 15} width={plate.width} height={plate.height + (lines.length - 1) * 15} rx="4" fill="var(--color-background)" />
+                      {lines.map((line, index) => (
+                        <text key={line} x={x} y={firstBaseline + index * 15} textAnchor="middle" className="fill-text-primary font-mono text-[12px] font-semibold">{line}</text>
+                      ))}
                     </>
                   )}
                 </g>

--- a/src/features/conditions/tide-screen.tsx
+++ b/src/features/conditions/tide-screen.tsx
@@ -14,6 +14,8 @@ import {
 import { daylightSpans, moonPhaseAt, sunEventsFor } from "@/core/rules/astro";
 import { useNow } from "@/lib/time/use-now";
 import { useUnitPreference } from "@/features/settings/units";
+import { useLog } from "@/features/catches/store";
+import { speciesLabel } from "@/core/ontology/species";
 
 import { STATION_LOCATION, STATION_TIME_ZONE, TIDE_SELECTED_AT, loadTideSeriesFixture } from "./queries/tide-series";
 import { useLocalTimeZone } from "./use-local-time-zone";
@@ -25,6 +27,7 @@ import { MoonDetailsSheet } from "./components/moon-details-sheet";
 import { StationDetailsSheet } from "./components/station-details-sheet";
 import { TideDetailsSheet } from "./components/tide-details-sheet";
 import { localDayIndex, localMidnights } from "./tide-chart-geometry";
+import type { CatchMarkerInput } from "./catch-markers";
 import {
   clock,
   compactDate,
@@ -107,6 +110,27 @@ export function TideScreen() {
   const dayBoundaries = useMemo(
     () => [seriesStart, ...localMidnights(seriesStart, seriesEnd, STATION_TIME_ZONE)],
     [seriesStart, seriesEnd],
+  );
+
+  /* Catches onto the curve at their exact instant (founder §6). Only live, timestamped
+   * catches inside the loaded window become markers; anything outside the window is
+   * simply not on this chart yet (the window edge is the honest boundary). */
+  const log = useLog();
+  const catchMarkers = useMemo<readonly CatchMarkerInput[]>(
+    () =>
+      log.catches
+        .filter((c) => c.deleted_at === null)
+        .map((c) => {
+          const at = Date.parse(c.caught_at);
+          return {
+            id: c.id,
+            at,
+            label: speciesLabel(c.species_id, c.species_other) ?? "Mark",
+            needsDetails: c.species_id === null && c.species_other === null,
+          };
+        })
+        .filter((m) => m.at >= seriesStart && m.at <= seriesEnd),
+    [log.catches, seriesStart, seriesEnd],
   );
   const calendarDays: CalendarDay[] = useMemo(
     () =>
@@ -368,6 +392,7 @@ export function TideScreen() {
         spans={spans}
         turns={turns}
         sunMarkers={sunMarkers}
+        catchMarkers={catchMarkers}
         dayBoundaries={dayBoundaries.slice(1)}
         valueText={valueText}
         nowAction={currentAt !== null && !atNow ? () => goToAt(currentAt) : null}


### PR DESCRIPTION
## Views slice of the 2026-09-01 requirements (founder §6 + §7)
Independent of #17/#18 — merges in any order.

### §7 Calendar → Day → Catch
- `/` is now the real month calendar (D23's home surface): Mon-first grid, prev/next + Today, viewer-zone-correct day keys (a 22:30-PDT catch is a Tuesday catch — DST-safe, tested), tap a day → `/day/YYYY-MM-DD`.
- Dots tell the day's truth: **orange** = catches, **amber** = something needs details; legend in words; every cell speaks it ("Tue, September 1 — 2 catches, 1 needs details"). Trailing all-grey week rows trimmed; invalid dates 404.
- Day page: heading + honest counts, *Needs details* section first with a finish-in-the-log link, catch rows with time/disposition/bait/GPS honesty (±accuracy or "No GPS fix"), Calendar ← → Tide chart links. Empty days say so.

### §6 Catches on the tide curve
- Every logged catch lands ON the curve at its exact `caught_at`; overlapping-in-time catches cluster into one marker with a count (algorithm tested: hot-bite chains merge, distant catches never do).
- **Tap does the founder's ask twice over:** reveals species + times in an opaque plate (same interaction idiom as the sun markers — tap-not-pan guard, Enter/Space, full aria labels) **and pins the read-head onto the catch**, so the header instantly reads tide height + movement AT the catch (verified live: cluster of 3 revealed → −0.71 ft/hr falling at 8:46pm).
- Unresolved marks render amber, never hidden.

### Engineering notes
- Render-purity kept: no `Date.now()` in render; calendar month = derived-until-navigated (no effect-driven cursor).
- One tripwire catch on my own raw literal, fixed to the file's single-line `<text>` idiom instead of excepting it.

### Verification
`npm run verify` green: **330/330 tests** (14 new), tsc 0, lint + tripwires clean. Live-browser flow: log 2 catches + 1 mark → dots appear → day page lists them → tide chart clusters them → tap reveals + read-head pins. Zero console/page errors. Screenshots at 390/320px in the thread.

### Remaining from the requirements doc
Map view (#1 view half) · Spots system (#2) · filters (#8) · appearance modes (#9) · Don't-forget list (#10).