### PR TITLE
tackle: taps-only quick inventory — blank name names itself from the buttons

### DIFF
--- a/src/features/tackle/auto-name.test.ts
+++ b/src/features/tackle/auto-name.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { autoName } from "./types";
+
+/**
+ * Founder request 2026-09-01: blank name box = the name is the buttons pushed.
+ * The pinned example is the founder's own words: hooks tapped as Owner / 2/0 / J-hook
+ * must read "Hook Owner 2/0 J-hook".
+ */
+describe("autoName", () => {
+  it("composes the founder's exact hook example", () => {
+    expect(autoName("hooks", { brand: "Owner", size: "2/0", style: "J-hook" })).toBe(
+      "Hook Owner 2/0 J-hook",
+    );
+  });
+
+  it("works taps-only: category with no buttons is still a name", () => {
+    expect(autoName("hooks", {})).toBe("Hook");
+    expect(autoName("other", {})).toBe("Gear");
+  });
+
+  it("skips blank attributes instead of leaving holes", () => {
+    expect(autoName("jigs", { brand: "Tady", weight: "", style: "Surface iron" })).toBe(
+      "Jig Tady Surface iron",
+    );
+  });
+
+  it("orders size before style for hooks, matching the founder's wording", () => {
+    // Field order in the registry is brand/style/size; the NAME order is brand/size/style.
+    expect(autoName("hooks", { style: "Circle", brand: "Owner", size: "4/0" })).toBe(
+      "Hook Owner 4/0 Circle",
+    );
+  });
+
+  it("composes sinkers as style + weight", () => {
+    expect(autoName("sinkers-weights", { style: "Pyramid", weight: "4 oz" })).toBe(
+      "Sinker Pyramid 4 oz",
+    );
+  });
+
+  it("trims button values that spilled extra space", () => {
+    expect(autoName("line", { brand: "  Izorline  ", poundTest: "40 lb" })).toBe(
+      "Line Izorline 40 lb",
+    );
+  });
+});

--- a/src/features/tackle/components/tackle-editor-sheet.tsx
+++ b/src/features/tackle/components/tackle-editor-sheet.tsx
@@ -3,6 +3,7 @@
 import { type FormEvent, useEffect, useRef, useState } from "react";
 
 import {
+  autoName,
   categoryFor,
   clampQuantity,
   retainedAttributes,
@@ -167,7 +168,7 @@ function EditorForm({
   function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setSubmitted(true);
-    if (!draft.category || !draft.label.trim()) return;
+    if (!draft.category) return;
 
     const attributes: Record<string, string> = {};
     for (const [key, value] of Object.entries(draft.attributes)) {
@@ -178,7 +179,10 @@ function EditorForm({
     onSave(
       {
         category: draft.category,
-        label: draft.label.trim(),
+        // Typed name wins. Blank name = the category noun plus the buttons pushed
+        // ("Hook Owner 2/0 J-hook") — quick inventory stays a taps-only flow
+        // (founder request 2026-09-01).
+        label: draft.label.trim() || (draft.category ? autoName(draft.category, attributes) : ""),
         quantity: clampQuantity(draft.quantity),
         lowStockAt: draft.lowStockAt,
         attributes,
@@ -246,28 +250,22 @@ function EditorForm({
         </fieldset>
 
         <label className="flex flex-col gap-2 text-label">
-          Item name
+          Item name <span className="font-normal text-text-muted">(optional)</span>
           <input
             ref={nameRef}
             value={draft.label}
             onChange={(event) => update({ label: event.target.value })}
-            placeholder={categorySpec?.namePlaceholder ?? "e.g. Owner Mutu circle 4/0"}
-            aria-invalid={submitted && !draft.label.trim()}
-            aria-describedby={
-              [
-                submitted && !draft.label.trim() ? "tackle-name-error" : "",
-                submitted && !draft.category ? "tackle-category-error" : "",
-              ]
-                .filter(Boolean)
-                .join(" ") || undefined
+            placeholder={
+              draft.category
+                ? `Saves as “${autoName(draft.category, draft.attributes)}”`
+                : "e.g. Owner Mutu circle 4/0"
             }
+            aria-describedby={submitted && !draft.category ? "tackle-category-error" : undefined}
             className={INPUT_CLASS}
           />
-          {submitted && !draft.label.trim() ? (
-            <span id="tackle-name-error" className="text-caption text-error-red">
-              Give this item a name.
-            </span>
-          ) : null}
+          <span className="text-caption text-text-muted">
+            Leave it blank and the buttons you tap become the name.
+          </span>
         </label>
 
         <fieldset className="flex flex-col gap-3">

--- a/src/features/tackle/types.ts
+++ b/src/features/tackle/types.ts
@@ -436,6 +436,39 @@ export function categoryFor(id: CategoryId): CategorySpec {
   return spec;
 }
 
+/**
+ * The no-type name (founder request 2026-09-01): an angler stocking a box quickly taps
+ * category + buttons and hits save — typing is optional. If the name box is blank, the
+ * item's name is the noun plus whatever buttons were pushed, in the order the founder
+ * spelled out ("Hook Owner 2/0 J-hook"). A typed name always wins; this only ever fills
+ * the blank.
+ */
+const AUTO_NAME_ORDER: Record<CategoryId, { noun: string; keys: readonly string[] }> = {
+  hooks: { noun: "Hook", keys: ["brand", "size", "style"] },
+  jigs: { noun: "Jig", keys: ["brand", "weight", "style", "color"] },
+  "hard-baits": { noun: "Hard bait", keys: ["brand", "size", "weight", "type", "color"] },
+  "soft-plastics": { noun: "Soft plastic", keys: ["brand", "size", "style", "color"] },
+  line: { noun: "Line", keys: ["brand", "poundTest", "material", "spoolLength", "color"] },
+  leaders: { noun: "Leader", keys: ["brand", "poundTest", "material", "spoolLength"] },
+  "sinkers-weights": { noun: "Sinker", keys: ["style", "weight", "material"] },
+  "terminal-tackle": { noun: "Terminal tackle", keys: ["brand", "kind", "size"] },
+  rods: { noun: "Rod", keys: ["brand", "length", "rating", "type"] },
+  reels: { noun: "Reel", keys: ["brand", "size", "type"] },
+  tools: { noun: "Tool", keys: ["brand", "kind"] },
+  accessories: { noun: "Accessory", keys: ["kind"] },
+  other: { noun: "Gear", keys: [] },
+};
+
+export function autoName(category: CategoryId, attributes: Record<string, string>): string {
+  const { noun, keys } = AUTO_NAME_ORDER[category];
+  const parts = [noun];
+  for (const key of keys) {
+    const value = attributes[key]?.trim();
+    if (value) parts.push(value);
+  }
+  return parts.join(" ");
+}
+
 export function isOutOfStock(item: TackleItem): boolean {
   return item.quantity === 0;
 }


### PR DESCRIPTION
One commit (`af63cec`) that landed seconds after #21 was merged — so it rode the branch but never made main. Opening this follow-up to carry it in.

**Founder request 2026-09-01:** the Add gear form blocked on a typed name. Now the name is optional; blank at save names the item from the buttons pushed, in your exact example order — *"Hook Owner 2/0 J-hook"* — while the box live-previews `Saves as "…"` with every tap. Typed names always win; category stays required.

Pure `autoName()` order-map in `types.ts`; 6 new tests. **361/361 tests, lint / tsc / next build all green** at push.