### PR TITLE
Regulations & Fish ID: verdict-first rules, offline pack, rockfish identifier, boundary map

### DIFF
--- a/docs/specs/regulations-architecture.md
+++ b/docs/specs/regulations-architecture.md
@@ -58,15 +58,25 @@ the area. No geocoding, no network, works in a canyon. A device-local "home regi
 preference (the ADR 007 §4 mechanism) decides what an angler with no fix sees. Errors
 fail toward *showing the source page*, never toward guessing a stricter or looser rule.
 
-**Map approach (the deferred decision, now taken):**
-- v1: no interactive map screen. Region boundaries are simplified polygons (tens of KB,
-  single-precision WGS84 rings) used for *resolution*, rendered at most as a static
-  inset caption ("You were in: Southern Management Area").
-- MPA/GEA overlay: **out of v1 scope** — CDFW's own interactive map
-  (wildlife.ca.gov/OceanSportfishMap) is the linked authority; we deep-link it. Bundling
-  MPA polygons means tracking closure changes that beat any staleness banner we can write.
+**Map approach — FOUNDER OVERRIDE, 2026-09-01 (this section now describes shipped reality):**
+  the founder's spec §8–§10 ("GPS → area resolution, YOU ARE HERE, overlay toggles,
+  boundary-approach warnings") wins over my earlier v1 "no interactive map" stance;
+  the regulations PR ships the map alongside the first pages.
+- Interactive map ships in v1, on **Leaflet with NO tile layer**: an ocean-colored panel
+  plus the pack's simplified polygons/polylines. Zero network, zero basemap tiles, works
+  at any depth of signal. Lines are labeled "simplified" everywhere they render, and the
+  50-fm RCA is declared up front as a **coordinate-defined line** — its authority is the
+  CFR waypoint list, our drawing is orientation, never the legal statement (spec §9).
+- Shipped overlays: Southern Management Area ring, the SoCal RCA boundary polyline, the
+  two Cowcod Conservation Areas, and ONE example MPA inset (Point Dume) as a styling
+  proof. The full MPA/GEA inventory stays with CDFW's official interactive map, which is
+  deep-linked from the same page — 800+ MPA polygons kept current is not a floor-bundle
+  job (spec §10's "small overlays only" allowance applied).
+- Boundary proximity: when GPS gives a fix inside ~0.5 nm of the RCA line, the page
+  states the distance to the line and which side reads as allowed today. Accuracy is
+  shown (±m) and declared as orientation-grade math (equirectangular), not survey.
 - This keeps the map consistent with the offline-first ADRs (004/006): all data lives in
-  the pack; the only network object is an outbound link the user explicitly taps.
+  the pack; the only network objects are outbound links the user explicitly taps.
 
 ## 4. The pack model (how data arrives and ages)
 
@@ -116,13 +126,18 @@ water is; freshwater packs consume the same tables when they land — no migrati
 
 ## 7. What this enables next (in order)
 
-1. SoCal starter dataset (this session) — tables + verified rows + provenance fields.
-2. A read-only "Regulations" browser: species → rule → source, staleness banner logic,
-   "No verified data" state. (UI, after review.)
+1. ~~SoCal starter dataset (this session)~~ → **shipped** (tables + SoCal rows, PR #21).
+2. ~~A read-only "Regulations" browser~~ → **SHIPPED, 2026-09-01** as one PR per founder's
+   instruction: regulations home ("My current regulations" header: area + date + mode +
+   dataset stamp), Species & Limits with search → verdict cards, the bundled pack as
+   the offline floor, the Rockfish ID decision tree, and the §8–§10 boundary map
+   (Leaflet, no tiles) — sixth nav destination "Rules" included per spec §16.
 3. Catch-context adornment: on a catch detail page, the *area-resolved* "Regulations in
-   effect — verified <date>" card. Only after §2's provenance UI has shipped and proven
-   boring.
-4. Synced pack updates (server-curated diffs) once row counts justify the wire.
+   effect — verified <date>" card. The RegulationCard component + regulationCard engine
+   now exist; wiring them onto catch pages is the next slice.
+4. Synced pack updates (server-curated diffs) once row counts justify the wire. The
+   v1 pack is bundle-only; SQL ⇄ bundle parity is currently **test-guarded**
+   (`reg-data-parity.test.ts`) and full SQL ingest is the remaining §12 item.
 
 ## 8. Failure modes we are explicitly accepting
 

--- a/docs/team/worklog/2026-09-01-13-architect.md
+++ b/docs/team/worklog/2026-09-01-13-architect.md
@@ -1,0 +1,31 @@
+### 2026-09-01 | architect | long session (post-compaction continuation)
+
+- Shipped the founder's Regulations & Fish ID spec, Phases 3+4+5 combined per the locked
+  decision, including the interactive boundary map the founder required over my earlier
+  v1 no-map stance. The architecture doc chapter was flipped in the same PR, dated (a doc
+  must match shipped reality, never the other way).
+- Pages: regulations home (GPS-tap area resolve → home-region fallback, mode chips,
+  dataset stamp), species search → verdict cards (KEEP / CHECK FIRST / RELEASE as color
+  AND word, provenance + staleness on every card, "No verified data" forever for unknown
+  species), six-question Rockfish identifier ("Likely…" hedging, restricted-species
+  banner, schematic swatches), no-tiles Leaflet boundary map with RCA line + CCAs +
+  approach proximity, offline/sources page, and the spec-§16 sixth nav destination "Rules"
+  (the "five is the ceiling" guard test moved to six WITH the decision comment, as the
+  guard's own text demanded).
+- Engine: verdict ladder prohibited → season-closed → boundary-conditional →
+  check-in-season conditional → keep; group-prohibition rows advise, never release
+  members; RCG shore/diver season exemption is data-driven. 37 feature tests including a
+  bundle↔SQL parity guard with three declared exceptions (pack-v2 migration owed — see
+  PR #23 body; bundle-only rockfish ids don't FK into `species`, by design).
+- Gates: 398/398 tests, tsc, eslint, build; all six routes smoke 200.
+- Hurdles: a hand-drawn coastline put the real Long Beach harbor OUTSIDE the "ocean"
+  polygon (fixed: anchor every harbor/breakwater vertex at real led coordinates, and
+  always test a known-inside and known-outside point per polygon); the ID scoring needed
+  a *family-conflict* penalty (a red fish scored on a black fish is evidence against, not
+  silence) else prohibited fish cleared the 3% noise floor on a clearly different animal;
+  the floor was also reset to a documented 5% (so the banner never cries wolf).
+- Files: src/features/regulations/*, src/app/regulations/*, shell-nav (+test),
+  docs/specs/regulations-architecture.md, package.json (leaflet).
+- Next: user merges PR #23, then deletes the PAT (boundary rule). Then, phase 6 onwards
+  whenever: catch-detail wiring of `regulationCard`, pack-v2 SQL parity reconciliation,
+  MPA inventory against CDFW's map (decision needed: bundle vs link; v1 links).

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,13 @@
       "dependencies": {
         "@supabase/ssr": "^0.12.5",
         "@supabase/supabase-js": "^2.112.4",
+        "@types/leaflet": "^1.9.22",
         "idb": "^8.0.3",
+        "leaflet": "^1.9.4",
         "next": "16.3.3",
         "react": "19.2.8",
-        "react-dom": "19.2.8"
+        "react-dom": "19.2.8",
+        "react-leaflet": "^5.0.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1778,6 +1781,17 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.63.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
@@ -2562,6 +2576,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2575,6 +2595,15 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.22",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.22.tgz",
+      "integrity": "sha512-h3lhECYEKDasG7LFHu+GiHqAvsgLuQvlJvVZzJDGONo3sEL+wUOqSFLnwkZlK0qVxnxbuGFW8iBlJNYs5wgndA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.19.43",
@@ -5916,6 +5945,12 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -6853,6 +6888,20 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,13 @@
   "dependencies": {
     "@supabase/ssr": "^0.12.5",
     "@supabase/supabase-js": "^2.112.4",
+    "@types/leaflet": "^1.9.22",
     "idb": "^8.0.3",
+    "leaflet": "^1.9.4",
     "next": "16.3.3",
     "react": "19.2.8",
-    "react-dom": "19.2.8"
+    "react-dom": "19.2.8",
+    "react-leaflet": "^5.0.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/regulations/boundaries/page.tsx
+++ b/src/app/regulations/boundaries/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+
+import { BoundaryMap } from "@/features/regulations/components/boundary-map";
+
+export const metadata: Metadata = {
+  title: "Depth & Boundary Rules — Fishing Log Book",
+};
+
+export default function Page() {
+  return <BoundaryMap />;
+}

--- a/src/app/regulations/offline/page.tsx
+++ b/src/app/regulations/offline/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+
+import { OfflinePage } from "@/features/regulations/components/offline-page";
+
+export const metadata: Metadata = {
+  title: "Offline Pack & Sources — Fishing Log Book",
+};
+
+export default function Page() {
+  return <OfflinePage />;
+}

--- a/src/app/regulations/page.tsx
+++ b/src/app/regulations/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+import { RegulationsHome } from "@/features/regulations/components/regulations-home";
+
+export const metadata: Metadata = {
+  title: "Regulations & Fish ID — Fishing Log Book",
+  description: "Verified California fishing rules with dates and sources, offshore.",
+};
+
+export default function Page() {
+  return <RegulationsHome />;
+}

--- a/src/app/regulations/rockfish/page.tsx
+++ b/src/app/regulations/rockfish/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+
+import { RockfishWizard } from "@/features/regulations/components/rockfish-wizard";
+
+export const metadata: Metadata = {
+  title: "Identify a Rockfish — Fishing Log Book",
+};
+
+export default function Page() {
+  return <RockfishWizard />;
+}

--- a/src/app/regulations/species/[id]/page.tsx
+++ b/src/app/regulations/species/[id]/page.tsx
@@ -1,0 +1,6 @@
+import { SpeciesRulesPage } from "@/features/regulations/components/species-rules-page";
+
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <SpeciesRulesPage speciesId={id} />;
+}

--- a/src/app/regulations/species/page.tsx
+++ b/src/app/regulations/species/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { useNow } from "@/lib/time/use-now";
+import { useLocalTimeZone } from "@/features/conditions/use-local-time-zone";
+import { SpeciesBrowser } from "@/features/regulations/components/species-browser";
+
+export default function Page() {
+  const now = useNow();
+  const zone = useLocalTimeZone() ?? "America/Los_Angeles";
+  const dateKey = useMemo(() => {
+    if (now === null) return "2026-01-01";
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone: zone, year: "numeric", month: "2-digit", day: "2-digit",
+    }).formatToParts(Number(now));
+    const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "";
+    return `${get("year")}-${get("month")}-${get("day")}`;
+  }, [now, zone]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <header className="rounded-lg border border-hairline bg-surface p-4">
+        <h1 className="text-h1">Species &amp; limits</h1>
+        <p className="mt-1 text-caption text-text-muted">
+          Verdicts for today ({dateKey}) under your current mode. Tap any fish for the full card.
+        </p>
+      </header>
+      <SpeciesBrowser dateKey={dateKey} />
+    </div>
+  );
+}

--- a/src/features/regulations/components/boundary-leaflet.tsx
+++ b/src/features/regulations/components/boundary-leaflet.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+
+import { RCA_50FM_LINE, REG_AREAS } from "../reg-data";
+
+/**
+ * The actual Leaflet surface for BoundaryMap — split out so Next can `ssr:false` it
+ * (Leaflet reads `window`). No tile layer**: the pack carries its own geometry, and
+ * offshore means no network. An ocean-blue panel with the simplified lines is honest
+ * orientation; basemap tiles can layer in later when connectivity exists.
+ */
+export default function BoundaryLeaflet({
+  position,
+  layers,
+}: {
+  position: { lat: number; lng: number; accuracy: number } | null;
+  layers: { gma: boolean; rca: boolean; cca: boolean; mpa: boolean };
+}) {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<L.Map | null>(null);
+  const layerRefs = useRef<{
+    gma?: L.Layer;
+    rca?: L.Layer;
+    mpa?: L.Layer;
+    you?: L.Layer;
+    cca: L.Layer[];
+  }>({ cca: [] });
+
+  // Build once.
+  useEffect(() => {
+    if (!hostRef.current || mapRef.current) return;
+    const map = L.map(hostRef.current, {
+      zoomControl: true,
+      attributionControl: false,
+      dragging: true,
+      scrollWheelZoom: false, // the page scrolls; two fingers / buttons zoom
+      maxZoom: 13,
+      minZoom: 7,
+    });
+    map.setView([33.6, -118.8], 8);
+
+    // A plain ocean panel instead of tiles. This is a boundary map, not a chart.
+    map.createPane("ocean");
+    const oceanPane = map.getPane("ocean")!;
+    oceanPane.style.background = "#0b2a3a";
+    hostRef.current.style.background = "#0b2a3a";
+
+    const gmaArea = REG_AREAS.find((a) => a.id === "ca-gma-southern")!;
+    layerRefs.current.gma = L.polygon(
+      (gmaArea.polygon ?? []).map(([lng, lat]) => [lat, lng] as [number, number]),
+      { color: "#7dd3fc", weight: 2, fillOpacity: 0.08, dashArray: "4 6" },
+    )
+      .addTo(map)
+      .bindTooltip("Southern Management Area (simplified)", { sticky: true });
+
+    layerRefs.current.rca = L.polyline(
+      RCA_50FM_LINE.points.map(([lng, lat]) => [lat, lng] as [number, number]),
+      { color: "#f59e0b", weight: 3, dashArray: "8 6" },
+    )
+      .addTo(map)
+      .bindTooltip("50-fm RCA boundary — simplified waypoints", { sticky: true });
+
+    layerRefs.current.cca = ["cca-santa-barbara", "cca-south"].map((id) => {
+      const area = REG_AREAS.find((a) => a.id === id)!;
+      return L.polygon(
+        (area.polygon ?? []).map(([lng, lat]) => [lat, lng] as [number, number]),
+        { color: "#ef4444", weight: 2, fillOpacity: 0.18 },
+      )
+        .addTo(map)
+        .bindTooltip(`${area.name} (simplified)`, { sticky: true });
+    });
+
+    const mpa = REG_AREAS.find((a) => a.id === "mpa-pt-dume")!;
+    layerRefs.current.mpa = L.polygon(
+      (mpa.polygon ?? []).map(([lng, lat]) => [lat, lng] as [number, number]),
+      { color: "#a78bfa", weight: 2, fillOpacity: 0.2 },
+    ).bindTooltip(`${mpa.name} (simplified inset)`, { sticky: true });
+
+    mapRef.current = map;
+    return () => {
+      map.remove();
+      mapRef.current = null;
+    };
+  }, []);
+
+  // Toggle overlays.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    const set = (key: "gma" | "rca" | "mpa", on: boolean) => {
+      const layer = layerRefs.current[key] as L.Layer | null;
+      if (!layer) return;
+      if (on) layer.addTo(map);
+      else map.removeLayer(layer);
+    };
+    set("gma", layers.gma);
+    set("rca", layers.rca);
+    set("mpa", layers.mpa);
+    layerRefs.current.cca.forEach((layer) => {
+      if (layers.cca) layer.addTo(map);
+      else map.removeLayer(layer);
+    });
+  }, [layers]);
+
+  // You-are-here marker.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    const current = layerRefs.current.you;
+    if (current) map.removeLayer(current);
+    if (position) {
+      const marker = L.circleMarker([position.lat, position.lng], {
+        radius: 7,
+        color: "#111827",
+        weight: 2,
+        fillColor: "#fb923c",
+        fillOpacity: 1,
+      })
+        .addTo(map)
+        .bindTooltip("YOU ARE HERE", { sticky: true });
+      const ring = L.circle([position.lat, position.lng], {
+        radius: position.accuracy,
+        color: "#fb923c",
+        weight: 1,
+        fillOpacity: 0.06,
+      }).addTo(map);
+      layerRefs.current.you = L.layerGroup([marker, ring]);
+      map.setView([position.lat, position.lng], Math.max(map.getZoom(), 9));
+    }
+  }, [position]);
+
+  return (
+    <div
+      ref={hostRef}
+      className="h-72 w-full rounded-lg"
+      style={{ background: "#0b2a3a" }}
+      aria-label="Boundary map: management area, RCA line, conservation areas, and your position when GPS is on"
+    />
+  );
+}

--- a/src/features/regulations/components/boundary-map.tsx
+++ b/src/features/regulations/components/boundary-map.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useEffect, useMemo, useState } from "react";
+
+import { useNow } from "@/lib/time/use-now";
+import { useLocalTimeZone } from "@/features/conditions/use-local-time-zone";
+import {
+  CHIP_CLASS,
+  CHIP_OFF,
+  CHIP_ON,
+  SECONDARY_BUTTON,
+} from "@/features/catches/ui-classes";
+import { distanceToLineM, pointInRing, sideOfLine } from "../geospatial";
+import { regulationCard } from "../reg-engine";
+import { RCA_50FM_LINE, REG_AREAS, SOCAL } from "../reg-data";
+import { platformFor } from "../reg-engine";
+import { useFishingModePreference } from "../prefs";
+
+const BoundaryLeaflet = dynamic(() => import("./boundary-leaflet"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-72 items-center justify-center rounded-lg border border-hairline bg-surface text-body text-text-muted">
+      Drawing the boundary map…
+    </div>
+  ),
+});
+
+/**
+ * Depth & boundary rules (founder spec §8, §9, §10): plain English FIRST, the map as
+ * orientation, and the legal citation behind "View official rule" — never the other way
+ * around. The 50-fm RCA is a coordinate-defined LINE in federal law; what the map shows
+ * is the pack's simplified waypoint polyline, marked as such, with CDFW's own
+ * interactive map linked for the legal precisions.
+ *
+ * The ribbon answers today's question out loud ("INSHORE FISHING ONLY", "CLOSED",
+ * "OFFSHORE ONLY" for lingcod's October window) from the SAME engine the species cards
+ * use — two fronts, one truth.
+ */
+export function BoundaryMap() {
+  const now = useNow();
+  const zone = useLocalTimeZone() ?? "America/Los_Angeles";
+  const [mode] = useFishingModePreference();
+  const platform = platformFor(mode);
+  const [position, setPosition] = useState<{ lat: number; lng: number; accuracy: number } | null>(null);
+  const [geoState, setGeoState] = useState<"idle" | "asking" | "denied">("idle");
+
+  const [layers, setLayers] = useState({ gma: true, rca: true, cca: true, mpa: false });
+
+  const dateKey = useMemo(() => {
+    if (now === null) return "2026-01-01";
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone: zone, year: "numeric", month: "2-digit", day: "2-digit",
+    }).formatToParts(Number(now));
+    const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "";
+    return `${get("year")}-${get("month")}-${get("day")}`;
+  }, [now, zone]);
+
+  // Today's groundfish reading drives the ribbon — a generic rockfish member's card is
+  // the complex's voice this day (boat/shore decides the exemption copy).
+  const rcgCard = useMemo(
+    () => regulationCard(SOCAL, "ca-gma-southern", "rockfish", dateKey, platform),
+    [dateKey, platform],
+  );
+
+  const ribbon = useMemo(() => {
+    if (!rcgCard) return null;
+    if (rcgCard.verdict === "release")
+      return { tone: "closed", text: "GROUNDFISH SEASON CLOSED TODAY", detail: rcgCard.verdictReason };
+    if (rcgCard.depthText?.includes("inshore"))
+      return { tone: "boundary", text: "INSHORE OF THE 50-FATHOM LINE ONLY", detail: "Rockfish/cabezon/greenlings: take is prohibited seaward of the line today." };
+    if (rcgCard.verdict === "conditional")
+      return { tone: "boundary", text: "OPEN — VERIFY BEFORE YOU KEEP", detail: rcgCard.verdictReason };
+    return { tone: "open", text: "OPEN TODAY (ALL DEPTHS)", detail: "Season windows still apply — check the date you plan for." };
+  }, [rcgCard]);
+
+  const where = useMemo(() => {
+    if (!position) return null;
+    const pt: readonly [number, number] = [position.lng, position.lat];
+    const ccaHit = ["cca-santa-barbara", "cca-south"].some((id) => {
+      const area = REG_AREAS.find((a) => a.id === id);
+      return area?.polygon ? pointInRing(pt, area.polygon as readonly (readonly [number, number])[]) : false;
+    });
+    return {
+      rcaSide: sideOfLine(pt, RCA_50FM_LINE.points),
+      rcaDistanceM: distanceToLineM(pt, RCA_50FM_LINE.points),
+      inCca: ccaHit,
+    };
+  }, [position]);
+
+  const watch = () => {
+    if (!("geolocation" in navigator)) {
+      setGeoState("denied");
+      return;
+    }
+    setGeoState("asking");
+    const id = navigator.geolocation.watchPosition(
+      (pos) => {
+        setPosition({ lat: pos.coords.latitude, lng: pos.coords.longitude, accuracy: pos.coords.accuracy });
+        setGeoState("idle");
+      },
+      () => setGeoState("denied"),
+      { enableHighAccuracy: true, maximumAge: 5_000, timeout: 15_000 },
+    );
+    return id;
+  };
+
+  // Arm GPS once at mount — deferred a frame so the mount effect isn't a sync setState
+  // (react-hooks/set-state-in-effect), and it still just works if GPS is already warm.
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => watch());
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <section className="rounded-lg border border-hairline bg-surface p-4">
+        <h1 className="text-h1">Depth &amp; boundary rules</h1>
+        <p className="mt-1 text-caption text-text-muted">
+          Simplified lines for orientation offshore. The federal waypoint text and CDFW&rsquo;s
+          official map are the legal reference; both are linked.
+        </p>
+      </section>
+
+      {ribbon ? (
+        <section
+          role="status"
+          className={`rounded-lg border p-4 ${
+            ribbon.tone === "closed"
+              ? "border-error-red-fill bg-surface"
+              : ribbon.tone === "open"
+                ? "border-success-green bg-surface"
+                : "border-amber-flag bg-surface"
+          }`}
+        >
+          <p
+            className={`text-h3 font-bold ${
+              ribbon.tone === "closed"
+                ? "text-error-red"
+                : ribbon.tone === "open"
+                  ? "text-success-green"
+                  : "text-amber-flag"
+            }`}
+          >
+            {ribbon.text}
+          </p>
+          <p className="mt-1 text-body">{ribbon.detail}</p>
+          <p className="mt-2 text-caption text-text-muted">
+            Read for: {mode === "boat" ? "boat/kayak" : mode} · {dateKey}
+            {platform !== "boat" && " · shore/diver exemption applies to RCG seasons"}
+          </p>
+        </section>
+      ) : null}
+
+      {where?.inCca ? (
+        <p role="alert" className="rounded-md border border-error-red-fill bg-surface p-4 text-body font-semibold text-error-red">
+          You are inside a Cowcod Conservation Area — groundfish fishing is prohibited here.
+        </p>
+      ) : null}
+      {where && !where.inCca && where.rcaDistanceM < 900 ? (
+        <p role="status" className="rounded-md border border-amber-flag bg-surface p-4 text-body font-semibold text-amber-flag">
+          Approaching the 50-fm RCA boundary — about{" "}
+          {where.rcaDistanceM < 100
+            ? `${Math.round(where.rcaDistanceM)} m`
+            : `${(where.rcaDistanceM / 1000).toFixed(1)} km`}{" "}
+          away; you read as {where.rcaSide === "inshore" ? "INSHORE (allowed side during Jul–Sep)" : "OFFSHORE (closed side during Jul–Sep)"}.
+        </p>
+      ) : null}
+
+      <section className="rounded-lg border border-hairline bg-surface p-4">
+        <h2 className="text-h3">The map (orientation-grade)</h2>
+        <fieldset className="mt-2 flex flex-wrap gap-2" aria-label="Map layers">
+          {(
+            [
+              ["gma", "Management area"],
+              ["rca", "50-fm RCA boundary"],
+              ["cca", "Cowcod areas"],
+              ["mpa", "MPA example"],
+            ] as const
+          ).map(([key, label]) => (
+            <button
+              key={key}
+              type="button"
+              aria-pressed={layers[key]}
+              onClick={() => setLayers((l) => ({ ...l, [key]: !l[key] }))}
+              className={`${CHIP_CLASS} ${layers[key] ? CHIP_ON : CHIP_OFF}`}
+            >
+              {layers[key] ? "☑" : "☐"} {label}
+            </button>
+          ))}
+        </fieldset>
+        <div className="mt-3">
+          <BoundaryLeaflet position={position} layers={layers} />
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <button type="button" onClick={() => watch()} className={SECONDARY_BUTTON}>
+            {geoState === "asking" ? "Getting a fix…" : position ? "Refresh position" : "Show me here"}
+          </button>
+          {geoState === "denied" ? (
+            <p className="text-caption text-text-muted">No position available — the map still reads as overview.</p>
+          ) : null}
+          {position ? (
+            <p className="text-caption text-text-muted">
+              {position.lat.toFixed(4)}, {position.lng.toFixed(4)} · ±{Math.round(position.accuracy)} m
+            </p>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-hairline bg-surface p-4">
+        <h2 className="text-h3">Which side counts — and other ships</h2>
+        <ul className="mt-2 flex flex-col gap-2 text-body">
+          <li>• The RCA line is a <em>coordinate boundary</em> (50 CFR 660 waypoints). Your depth sounder does not define it.</li>
+          <li>• Eight Groundfish Exclusion Areas also live inside the Southern Management Area; two (the Cowcod blocks) draw here. The rest resolve against the official map.</li>
+          <li>• Lingcod keeps its own Oct–Dec OFFSHORE-only window alongside; its species card says so.</li>
+          <li>• Shore-based and spear fishing are exempt from RCG season-and-depth rules (CCR T14 §27.20(b)).</li>
+        </ul>
+        <div className="mt-3 flex flex-wrap gap-3">
+          <a href="https://wildlife.ca.gov/OceanSportfishMap" target="_blank" rel="noreferrer" className="text-label text-text-link underline decoration-dotted underline-offset-4">
+            CDFW interactive map (official) ↗
+          </a>
+          <a href="https://www.fisheries.noaa.gov/west-coast/sustainable-fisheries/west-coast-groundfish-closed-areas" target="_blank" rel="noreferrer" className="text-label text-text-link underline decoration-dotted underline-offset-4">
+            Federal RCA waypoint definitions ↗
+          </a>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/features/regulations/components/offline-page.tsx
+++ b/src/features/regulations/components/offline-page.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { SOCAL } from "../reg-data";
+
+/**
+ * Offline & dataset status (founder spec §11, §23): what is ON this device, its trust
+ * stamp, and the stated floor/ceiling — the bundle is the floor; Supabase sync +
+ * IndexedDB/SQLite storage upgrades it later without breaking offline catches.
+ */
+export function OfflinePage() {
+  const pack = SOCAL.pack;
+  return (
+    <div className="flex flex-col gap-4">
+      <section className="rounded-lg border border-hairline bg-surface p-4">
+        <h1 className="text-h1">Offline &amp; sources</h1>
+        <p className="mt-1 text-caption text-text-muted">
+          {pack.notes}
+        </p>
+      </section>
+
+      <section className="rounded-lg border border-hairline bg-surface p-4">
+        <h2 className="text-h3">On this device</h2>
+        <dl className="mt-3 grid grid-cols-2 gap-3 text-body">
+          <div>
+            <dt className="text-caption text-text-muted">Pack</dt>
+            <dd className="font-semibold">{pack.id} · v{pack.version}</dd>
+          </div>
+          <div>
+            <dt className="text-caption text-text-muted">Published / verified</dt>
+            <dd className="font-semibold">{pack.publishedAt.slice(0, 10)}</dd>
+          </div>
+          <div>
+            <dt className="text-caption text-text-muted">Areas</dt>
+            <dd className="font-semibold">{SOCAL.areas.length} lines &amp; polygons</dd>
+          </div>
+          <div>
+            <dt className="text-caption text-text-muted">Verified rules</dt>
+            <dd className="font-semibold">{SOCAL.rules.length} rows</dd>
+          </div>
+        </dl>
+        <p className="mt-3 text-caption text-text-muted">
+          Everything the Regulations pages answer comes from this pack — no signal needed.
+          Cards pronounce themselves stale past each species&rsquo; verification horizon instead
+          of going silent.
+        </p>
+      </section>
+
+      <section className="rounded-lg border border-hairline bg-surface p-4">
+        <h2 className="text-h3">Where the law lives</h2>
+        <ul className="mt-2 flex flex-col gap-2 text-body">
+          <li>
+            <a className="text-text-link underline decoration-dotted underline-offset-4" target="_blank" rel="noreferrer" href="https://wildlife.ca.gov/Fishing/Ocean/Regulations/Fishing-Map/Southern">
+              CDFW — Southern California ocean sportfishing summary ↗
+            </a>
+          </li>
+          <li>
+            <a className="text-text-link underline decoration-dotted underline-offset-4" target="_blank" rel="noreferrer" href="https://wildlife.ca.gov/Fishing/Ocean/Regulations/Groundfish-Summary">
+              CDFW — 2026 Groundfish Summary ↗
+            </a>
+          </li>
+          <li>
+            <a className="text-text-link underline decoration-dotted underline-offset-4" target="_blank" rel="noreferrer" href="https://wildlife.ca.gov/Fishing/Ocean/Regulations/Fishing-Map/Southern#recreational-groundfish-regulations">
+              CDFW — real-time Groundfish Regulations page (same agency, watch this one mid-season) ↗
+            </a>
+          </li>
+          <li>
+            <a className="text-text-link underline decoration-dotted underline-offset-4" target="_blank" rel="noreferrer" href="https://www.fisheries.noaa.gov/west-coast/sustainable-fisheries/west-coast-groundfish-closed-areas">
+              NOAA — West Coast groundfish closed-area WAYPOINT definitions ↗
+            </a>
+          </li>
+        </ul>
+        <p className="mt-3 text-caption text-text-muted">
+          This app summarizes; those pages are the law&rsquo;s voice. When they disagree, the
+          law wins and the pack gets a version bump.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/src/features/regulations/components/regulation-card.tsx
+++ b/src/features/regulations/components/regulation-card.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import type { RegulationCard as RegulationCardData } from "../types";
+
+const VERDICT = {
+  keep: {
+    word: "KEEP",
+    tone: "bg-success-green text-ink-on-orange",
+    tail: "Open today, with the limits below.",
+  },
+  conditional: {
+    word: "CHECK FIRST",
+    tone: "bg-amber-flag text-ink-on-orange",
+    tail: "Something real can flip this — read the reason.",
+  },
+  release: {
+    word: "RELEASE",
+    tone: "bg-error-red-fill text-text-primary",
+    tail: "Put it back. Gentle handling, get the air out, get it down.",
+  },
+} as const;
+
+/**
+ * The verdict card (founder spec §4 + §15): the answer in two seconds, then limits,
+ * then law. Verdict is a color AND a word because color alone fails a color-blind
+ * angler in bright sun (spec §15's "clear status colors/icons" plus accessibility
+ * non-negotiables).
+ *
+ * §23 is structural here: staleness is rendered with every card that earns it, not
+ * hidden in a settings screen; the official source link is on every card, fresh or not.
+ */
+export function RegulationCard({ card }: { card: RegulationCardData }) {
+  const v = VERDICT[card.verdict];
+  return (
+    <article className="flex flex-col gap-4 rounded-lg border border-hairline bg-surface p-4">
+      <div className={`rounded-md px-4 py-3 ${v.tone}`}>
+        <p className="text-h2 font-bold tracking-wide">{v.word}</p>
+        <p className="mt-1 text-caption">{card.verdictReason}</p>
+      </div>
+
+      {card.isStale ? (
+        <p role="alert" className="rounded-md border border-amber-flag p-3 text-caption text-amber-flag">
+          Regulations last verified {card.staleDays} days ago ({card.verifiedAt}). Verify
+          current rules with the CDFW source below before retaining fish.
+        </p>
+      ) : null}
+
+      <dl className="grid grid-cols-2 gap-3">
+        <Fact label="Daily limit" value={card.bagDaily === null ? "None listed" : String(card.bagDaily)} />
+        <Fact
+          label="Minimum size"
+          value={
+            card.minSizeIn === null
+              ? "None"
+              : `${card.minSizeIn}″ ${card.sizeMeasure === "fork_length" ? "fork length" : card.sizeMeasure === "alternate_total_length" ? "alternate length" : "total length"}`
+          }
+        />
+        <Fact label="Season" value={card.seasonText} />
+        {card.depthText ? <Fact label="Depth / boundary" value={card.depthText} /> : null}
+      </dl>
+
+      {card.groupNote ? (
+        <p className="text-caption text-text-muted">
+          Shared bag: {card.groupNote}
+        </p>
+      ) : null}
+
+      {card.specialRules.length > 0 ? (
+        <div className="rounded-md border border-hairline p-3">
+          <p className="text-label text-text-muted">Special rules in play</p>
+          <ul className="mt-2 flex flex-col gap-2 text-caption">
+            {card.specialRules.map((rule) => (
+              <li key={rule}>{rule}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <details className="rounded-md border border-hairline p-3">
+        <summary className="cursor-pointer text-label text-text-link">
+          View official rule — {card.sourceTitle}
+        </summary>
+        <p className="mt-2 text-caption text-text-muted">
+          {v.tail} Source updated {card.sourceUpdatedAt ?? "not stamped by source"} ·
+          verified {card.verifiedAt} · pack v{card.packVersion}.
+        </p>
+        <a
+          href={card.sourceUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="mt-2 inline-flex min-h-touch-floor items-center rounded-md text-label text-text-link underline decoration-dotted underline-offset-4"
+        >
+          Open the official source ↗
+        </a>
+      </details>
+    </article>
+  );
+}
+
+function Fact({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <dt className="text-caption text-text-muted">{label}</dt>
+      <dd className="text-body font-semibold">{value}</dd>
+    </div>
+  );
+}

--- a/src/features/regulations/components/regulations-home.tsx
+++ b/src/features/regulations/components/regulations-home.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+
+import { useNow } from "@/lib/time/use-now";
+import { useLocalTimeZone } from "@/features/conditions/use-local-time-zone";
+import { REGIONS } from "@/core/ontology/regions";
+import { useRegionPreference } from "@/features/settings/region";
+import {
+  CHIP_CLASS,
+  CHIP_OFF,
+  CHIP_ON,
+  CHIP_OFF_ON_SURFACE,
+} from "@/features/catches/ui-classes";
+import { pointInRing, sideOfLine } from "../geospatial";
+import { REG_AREAS, RCA_50FM_LINE, SOCAL } from "../reg-data";
+import { useFishingModePreference } from "../prefs";
+import type { FishingMode } from "../types";
+
+const MODE_LABEL: Record<FishingMode, string> = {
+  boat: "Boat",
+  kayak: "Kayak",
+  shore: "Shore",
+  spearfishing: "Spearfishing",
+};
+
+/**
+ * Regulations home (founder spec §2): the header answers "where am I, under what rule
+ * set, as of when" before anything else, and the cards go where an angler a-float
+ * actually points. GPS is a TAP, never a surprise permission prompt — the manual/home
+ * region stands in when location is off or unavailable (§3).
+ *
+ * None of this reads the network: the SoCal pack is bundled, the position question is
+ * `pointInRing`, and the day comes from `useNow` in the device's zone. If we're outside
+ * every mapped polygon we say exactly that and fall back to the home region.
+ */
+export function RegulationsHome() {
+  const now = useNow();
+  const zone = useLocalTimeZone() ?? "America/Los_Angeles";
+  const [mode, setMode] = useFishingModePreference();
+  const [region] = useRegionPreference();
+  const [position, setPosition] = useState<{ lat: number; lng: number } | null>(null);
+  const [geoState, setGeoState] = useState<"idle" | "asking" | "denied">("idle");
+
+  const dateKey = useMemo(() => {
+    if (now === null) return null;
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone: zone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).formatToParts(Number(now));
+    const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "";
+    return `${get("year")}-${get("month")}-${get("day")}`;
+  }, [now, zone]);
+
+  const area = useMemo(() => {
+    if (position) {
+      const hit = REG_AREAS.find(
+        (a) =>
+          a.kind !== "conservation_area" &&
+          a.polygon &&
+          pointInRing([position.lng, position.lat], a.polygon),
+      );
+      if (hit) return { source: "gps", area: hit } as const;
+      return null;
+    }
+    // Home-region fallback: southern_california is the only region this pack covers,
+    // and the pack says so rather than pretending.
+    if (region === "southern_california") {
+      return { source: "home region", area: REG_AREAS.find((a) => a.id === "ca-gma-southern")! } as const;
+    }
+    return null;
+  }, [position, region]);
+
+  const rcaSide = useMemo(() => {
+    if (!position) return null;
+    const insideGma = area?.source === "gps";
+    if (!insideGma) return null;
+    return sideOfLine([position.lng, position.lat], RCA_50FM_LINE.points);
+  }, [position, area]);
+
+  const askGps = () => {
+    if (!("geolocation" in navigator)) {
+      setGeoState("denied");
+      return;
+    }
+    setGeoState("asking");
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setPosition({ lat: pos.coords.latitude, lng: pos.coords.longitude });
+        setGeoState("idle");
+      },
+      () => setGeoState("denied"),
+      { enableHighAccuracy: false, maximumAge: 300_000, timeout: 10_000 },
+    );
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <section className="rounded-lg border border-hairline bg-surface p-4">
+        <h1 className="text-h1">Regulations &amp; Fish ID</h1>
+        <p className="mt-1 text-caption text-text-muted">
+          Verified rules for where you are, dated like logbook entries. Legal text always
+          one tap away; complete trust details on every card.
+        </p>
+      </section>
+
+      <section className="rounded-lg border border-hairline bg-surface p-4" aria-label="My current regulations">
+        <h2 className="text-h3">My current regulations</h2>
+        <dl className="mt-3 flex flex-col gap-2 text-body">
+          <Row label="Fishing at">
+            {area ? `${area.area.name}` : "Outside the areas this pack covers"}
+            {area ? (
+              <span className="text-caption text-text-muted">
+                {" "}({area.source === "gps" ? "from your GPS" : "home region — turn on GPS for precision"})
+              </span>
+            ) : null}
+          </Row>
+          <Row label="Date">{dateKey ?? "…"}</Row>
+          <Row label="Mode">
+            <ul className="flex flex-wrap gap-2">
+              {(Object.keys(MODE_LABEL) as FishingMode[]).map((m) => (
+                <li key={m}>
+                  <button
+                    type="button"
+                    aria-pressed={mode === m}
+                    onClick={() => setMode(m)}
+                    className={`${CHIP_CLASS} ${mode === m ? CHIP_ON : CHIP_OFF}`}
+                  >
+                    {MODE_LABEL[m]}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </Row>
+          <Row label="Dataset">
+            SoCal pack v{SOCAL.pack.version} · verified {SOCAL.pack.publishedAt.slice(0, 10)}
+          </Row>
+        </dl>
+
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={askGps}
+            className={`${CHIP_CLASS} ${CHIP_OFF_ON_SURFACE}`}
+            disabled={geoState === "asking"}
+          >
+            {geoState === "asking" ? "Asking the GPS…" : position ? "Refresh my position" : "Use my GPS"}
+          </button>
+          {geoState === "denied" ? (
+            <p className="text-caption text-text-muted">
+              No position this time — the pages still answer from your home region (
+              {REGIONS.find((r) => r.id === region)?.label}).
+            </p>
+          ) : null}
+          {position ? (
+            <p className="text-caption text-text-muted">
+              {position.lat.toFixed(4)}, {position.lng.toFixed(4)}
+              {rcaSide ? ` — ${rcaSide === "inshore" ? "inshore of" : "offshore of"} the 50-fm RCA line` : ""}
+            </p>
+          ) : null}
+        </div>
+      </section>
+
+      <nav aria-label="Regulation sections" className="grid grid-cols-2 gap-3">
+        <HomeCard href="/regulations/species" title="Species & limits" body="Pick a fish; get the 2-second answer." />
+        <HomeCard href="/regulations/rockfish" title="Rockfish ID" body="Six easy questions; likely species with confidence, not verdicts." />
+        <HomeCard href="/regulations/boundaries" title="Depth & boundary rules" body="Today's 50-fm season, RCAs, MPAs — with the map." />
+        <HomeCard href="/regulations/offline" title="Offline & sources" body="What's on this device, when verified, where the law lives." />
+      </nav>
+    </div>
+  );
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-baseline gap-3">
+      <dt className="w-20 shrink-0 text-caption text-text-muted">{label}</dt>
+      <dd className="min-w-0 flex-1">{children}</dd>
+    </div>
+  );
+}
+
+function HomeCard({ href, title, body }: { href: string; title: string; body: string }) {
+  return (
+    <Link
+      href={href}
+      className="rounded-lg border border-border-interactive bg-surface p-4 transition-colors hover:bg-surface-raised focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+    >
+      <p className="text-h3">{title}</p>
+      <p className="mt-1 text-caption text-text-muted">{body}</p>
+    </Link>
+  );
+}

--- a/src/features/regulations/components/rockfish-wizard.tsx
+++ b/src/features/regulations/components/rockfish-wizard.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+
+import {
+  CHIP_CLASS,
+  CHIP_OFF,
+  CHIP_ON,
+  PRIMARY_BUTTON,
+  SECONDARY_BUTTON,
+} from "@/features/catches/ui-classes";
+import {
+  hasVerifiedRules,
+  ID_QUESTIONS,
+  identifyRockfish,
+  restrictedIn,
+  type IdCandidate,
+  type RockfishProfile,
+  type TraitAnswer,
+} from "../rockfish-id";
+import { speciesDisplayName } from "../reg-species";
+
+/**
+ * Identify a Rockfish (founder spec §5): plain-worded visual questions, live narrowing,
+ * CONFIDENCE language ("Likely vermilion rockfish — 48%"), and the §6 hard rule: any
+ * prohibited species above the warning floor gets the amber "Possible Restricted
+ * Species" banner, and the closing advice always favors release when uncertain.
+ *
+ * Wizard, not form: one question per screen would fit a gloved hand better, but a
+ * two-column sheet with the live answer-list updating in place answers faster and keeps
+ * all six questions thumbed-in-reach. A "Not sure" tile exists on every question and
+ * simply doesn't narrow — nothing is required except honesty.
+ */
+export function RockfishWizard() {
+  const [answers, setAnswers] = useState<Record<string, TraitAnswer | null>>({});
+  const chosen = useMemo(
+    () => Object.values(answers).filter((a): a is TraitAnswer => a !== null),
+    [answers],
+  );
+  const candidates = useMemo(() => identifyRockfish(chosen), [chosen]);
+  const restricted = useMemo(() => restrictedIn(candidates), [candidates]);
+  const top = candidates[0];
+  const confidentEnough = top && top.confidencePct >= 40;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <section className="rounded-lg border border-hairline bg-surface p-4">
+        <h1 className="text-h1">Identify a rockfish</h1>
+        <p className="mt-1 text-caption text-text-muted">
+          Answer what you can see. &quot;Not sure&quot; is a legal answer everywhere — it just
+          doesn&rsquo;t eliminate anything. Match percentages narrow the field; they never
+          certify it.
+        </p>
+      </section>
+
+      {restricted.length > 0 ? (
+        <p role="alert" className="rounded-md border border-amber-flag bg-surface p-4 text-body font-semibold text-amber-flag">
+          Possible restricted species — verify before retaining.{" "}
+          {restricted.map((c) => c.profile.commonName).join(", ")} cannot be kept at any
+          time in California.
+        </p>
+      ) : null}
+
+      {ID_QUESTIONS.map((q) => (
+        <fieldset key={q.id} className="rounded-lg border border-hairline bg-surface p-4">
+          <legend className="text-h3">{q.question}</legend>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {q.answers.map((a) => {
+              const selected = answers[q.id] === a.id;
+              return (
+                <button
+                  key={a.id}
+                  type="button"
+                  aria-pressed={selected}
+                  onClick={() => setAnswers((prev) => ({ ...prev, [q.id]: selected ? null : a.id }))}
+                  className={`${CHIP_CLASS} ${selected ? CHIP_ON : CHIP_OFF}`}
+                >
+                  {a.label}
+                </button>
+              );
+            })}
+            <button
+              type="button"
+              aria-pressed={answers[q.id] === null}
+              onClick={() => setAnswers((prev) => ({ ...prev, [q.id]: null }))}
+              className={`${CHIP_CLASS} ${answers[q.id] == null ? CHIP_ON : CHIP_OFF}`}
+            >
+              Not sure
+            </button>
+          </div>
+        </fieldset>
+      ))}
+
+      <section className="rounded-lg border border-hairline bg-surface p-4" aria-live="polite">
+        <h2 className="text-h3">
+          {chosen.length === 0
+            ? "Possible matches"
+            : confidentEnough
+              ? `Likely ${top.profile.commonName.toLowerCase()}`
+              : "Still wide open"}
+        </h2>
+        <ul className="mt-3 flex flex-col gap-3">
+          {candidates.slice(0, 4).map((c) => (
+            <CandidateRow key={c.profile.speciesId} candidate={c} />
+          ))}
+        </ul>
+        {chosen.length > 0 && !confidentEnough ? (
+          <p className="mt-3 text-caption text-text-muted">
+            No clear read yet. If the fish could be a restricted species, release wins —
+            a fish returned is never a ticket.
+          </p>
+        ) : null}
+        <Link href="/regulations/boundaries" className="mt-4 inline-flex min-h-touch-floor items-center text-label text-text-link underline decoration-dotted underline-offset-4">
+          Now check where you&rsquo;re standing →
+        </Link>
+      </section>
+    </div>
+  );
+}
+
+function CandidateRow({ candidate }: { candidate: IdCandidate }) {
+  const { profile, confidencePct } = candidate;
+  const [open, setOpen] = useState(false);
+  return (
+    <li className="rounded-md border border-hairline">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-3 p-3 text-left"
+      >
+        <Swatch profile={profile} />
+        <span className="flex-1">
+          <span className="text-body font-semibold">
+            {profile.commonName}
+            {profile.noRetention ? " · RELEASE ONLY" : ""}
+          </span>
+          <span className="block text-caption text-text-muted italic">{profile.scientificName}</span>
+        </span>
+        <span className="text-label text-text-muted">{confidencePct}%</span>
+      </button>
+      {open ? (
+        <div className="flex flex-col gap-3 border-t border-hairline p-3">
+          <ul className="flex flex-col gap-1 text-caption">
+            {profile.keyFeatures.map((f) => (
+              <li key={f}>• {f}</li>
+            ))}
+          </ul>
+          <p className="text-caption text-text-muted">
+            Easily confused with: {profile.similarTo.map(speciesDisplayName).join(", ")} —
+            compare them before you keep.
+          </p>
+          {hasVerifiedRules(profile.speciesId) ? (
+            <Link
+              href={`/regulations/species/${profile.speciesId}`}
+              className={`${SECONDARY_BUTTON} self-start`}
+            >
+              {profile.noRetention ? "Why it must go back" : "Current limits for this fish"}
+            </Link>
+          ) : null}
+          <p className="text-caption text-text-muted">
+            Visuals are schematic, not photos. Positive ID against the CDFW rockfish ID
+            guides (linked on its rules card).
+          </p>
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+/** Honest schematic swatch: the fish's general color story, rendered as blocks. */
+function Swatch({ profile }: { profile: RockfishProfile }) {
+  const { base, accent, pattern } = profile.swatch;
+  const spots = pattern === "spots";
+  return (
+    <svg
+      viewBox="0 0 44 28"
+      aria-hidden
+      className="h-10 w-14 shrink-0 rounded"
+      style={{ background: base }}
+    >
+      {spots
+        ? [8, 16, 24, 32].map((x, i) => (
+            <circle key={x} cx={x} cy={i % 2 ? 9 : 17} r="2.2" fill={accent} />
+          ))
+        : pattern === "blotches"
+          ? [6, 18, 30].map((x) => (
+              <ellipse key={x} cx={x} cy={x % 2 ? 10 : 18} rx="4" ry="2.6" fill={accent} />
+            ))
+          : <rect x="0" y="20" width="44" height="8" fill={accent} opacity="0.55" />}
+    </svg>
+  );
+}
+
+export function RockfishWizardActions({ onReset }: { onReset: () => void }) {
+  return (
+    <button type="button" onClick={onReset} className={PRIMARY_BUTTON}>
+      Start over
+    </button>
+  );
+}

--- a/src/features/regulations/components/species-browser.tsx
+++ b/src/features/regulations/components/species-browser.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+
+import { INPUT_CLASS } from "@/features/catches/ui-classes";
+import { regulationCard } from "../reg-engine";
+import { SOCAL, speciesInPack } from "../reg-data";
+import { speciesDisplayName } from "../reg-species";
+import { useFishingModePreference } from "../prefs";
+import { platformFor } from "../reg-engine";
+import type { RegulationCard as Card } from "../types";
+
+/**
+ * Species & limits (founder spec §4/§15): search → tap → verdict card. The LIST itself
+ * carries the verdict words on the right edge, so a familiar angler reads five species
+ * of "can I keep this" without opening anything.
+ *
+ * Every row is built from today's date + the device mode chip. Absent species never
+ * appear — absence means "no verified data" is a finding, shown on the card page, not
+ * row-clutter here.
+ */
+export function SpeciesBrowser({ dateKey }: { dateKey: string }) {
+  const [query, setQuery] = useState("");
+  const [mode] = useFishingModePreference();
+  const platform = platformFor(mode);
+
+  const rows = useMemo(() => {
+    const covered = speciesInPack();
+    const withCards = covered
+      .map((id) => ({
+        id,
+        name: speciesDisplayName(id),
+        card: regulationCard(SOCAL, "ca-ocean-southern", id, dateKey, platform),
+      }))
+      .filter((r) => r.card !== null)
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    const tokens = query.toLowerCase().split(/\s+/).filter(Boolean);
+    if (tokens.length === 0) return withCards;
+    return withCards.filter((r) =>
+      tokens.every((tok) => r.name.toLowerCase().includes(tok) || r.id.includes(tok)),
+    );
+  }, [query, dateKey, platform]);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <label className="flex flex-col gap-2">
+        <span className="text-label text-text-muted">Which fish?</span>
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="rockfish, halibut, seabass…"
+          className={INPUT_CLASS}
+          autoComplete="off"
+        />
+      </label>
+
+      <ul className="flex flex-col gap-2">
+        {rows.map(({ id, name, card }) => (
+          <li key={id}>
+            <Link
+              href={`/regulations/species/${id}`}
+              className="flex items-center justify-between gap-3 rounded-lg border border-hairline bg-surface p-4 focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+            >
+              <span className="text-body font-semibold">{name}</span>
+              <VerdictChip card={card as Card} />
+            </Link>
+          </li>
+        ))}
+        {rows.length === 0 ? (
+          <li className="rounded-lg border border-hairline bg-surface p-4 text-body text-text-muted">
+            No verified data for that search. The source pages know more than we do —
+            check the official source before you keep anything.
+          </li>
+        ) : null}
+      </ul>
+    </div>
+  );
+}
+
+export function VerdictChip({ card }: { card: Card }) {
+  const look =
+    card.verdict === "keep"
+      ? "bg-success-green text-ink-on-orange"
+      : card.verdict === "release"
+        ? "bg-error-red-fill text-text-primary"
+        : "bg-amber-flag text-ink-on-orange";
+  const word = card.verdict === "keep" ? "KEEP" : card.verdict === "release" ? "RELEASE" : "CHECK";
+  return (
+    <span className={`rounded-full px-3 py-1 text-label font-semibold ${look}`}>
+      {word}
+      {card.bagDaily !== null && card.verdict !== "release" ? ` · ${card.bagDaily}` : ""}
+    </span>
+  );
+}

--- a/src/features/regulations/components/species-rules-page.tsx
+++ b/src/features/regulations/components/species-rules-page.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo } from "react";
+
+import { useNow } from "@/lib/time/use-now";
+import { useLocalTimeZone } from "@/features/conditions/use-local-time-zone";
+import { regulationCard, platformFor } from "../reg-engine";
+import { SOCAL } from "../reg-data";
+import { speciesDisplayName } from "../reg-species";
+import { ROCKFISH_PROFILES } from "../rockfish-id";
+import { useFishingModePreference } from "../prefs";
+import { RegulationCard } from "./regulation-card";
+
+/**
+ * One species' regulation card (founder spec §4): verdict first, limits after,
+ * citations under the fold, staleness on top of everything past its horizon.
+ *
+ * A species the pack does not cover gets the pack's permanent stance rendered in words
+ * ("No verified data … the CDFW page is the answer today") — never an empty screen and
+ * never folklore (data model §3).
+ */
+export function SpeciesRulesPage({ speciesId }: { speciesId: string }) {
+  const now = useNow();
+  const zone = useLocalTimeZone() ?? "America/Los_Angeles";
+  const [mode, setMode] = useFishingModePreference();
+
+  const dateKey = useMemo(() => {
+    if (now === null) return "2026-01-01";
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone: zone, year: "numeric", month: "2-digit", day: "2-digit",
+    }).formatToParts(Number(now));
+    const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "";
+    return `${get("year")}-${get("month")}-${get("day")}`;
+  }, [now, zone]);
+
+  const card = useMemo(
+    () => regulationCard(SOCAL, "ca-ocean-southern", speciesId, dateKey, platformFor(mode)),
+    [speciesId, dateKey, mode],
+  );
+  const name = speciesDisplayName(speciesId);
+  const profile = ROCKFISH_PROFILES.find((p) => p.speciesId === speciesId) ?? null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <nav>
+        <Link
+          href="/regulations/species"
+          className="inline-flex min-h-touch-floor items-center text-label text-text-link focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+        >
+          ‹ Species &amp; limits
+        </Link>
+      </nav>
+
+      <header className="rounded-lg border border-hairline bg-surface p-4">
+        <h1 className="text-h1">{name}</h1>
+        <p className="mt-1 text-caption text-text-muted">
+          For {dateKey} · Southern California pack ·{" "}
+          <span className="inline-flex gap-2">
+            {(["boat", "kayak", "shore", "spearfishing"] as const).map((m) => (
+              <button
+                key={m}
+                type="button"
+                aria-pressed={mode === m}
+                onClick={() => setMode(m)}
+                className={mode === m ? "font-semibold text-text-link underline" : "underline decoration-dotted underline-offset-2"}
+              >
+                {m}
+              </button>
+            ))}
+          </span>
+        </p>
+      </header>
+
+      {card ? (
+        <RegulationCard card={card} />
+      ) : (
+        <section className="rounded-lg border border-hairline bg-surface p-4">
+          <h2 className="text-h3">No verified data</h2>
+          <p className="mt-2 text-body text-text-muted">
+            This pack holds no verified rule for {name} yet. We don&rsquo;t paraphrase from
+            memory — the CDFW Southern-region page is today&rsquo;s authority:
+          </p>
+          <a
+            href="https://wildlife.ca.gov/Fishing/Ocean/Regulations/Fishing-Map/Southern"
+            target="_blank"
+            rel="noreferrer"
+            className="mt-2 inline-flex min-h-touch-floor items-center text-label text-text-link underline decoration-dotted underline-offset-4"
+          >
+            Open the CDFW Southern-region summary ↗
+          </a>
+        </section>
+      )}
+
+      {profile ? (
+        <section className="rounded-lg border border-hairline bg-surface p-4">
+          <h2 className="text-h3">Know it by eye</h2>
+          <ul className="mt-2 flex flex-col gap-1 text-body">
+            {profile.keyFeatures.map((f) => (
+              <li key={f}>• {f}</li>
+            ))}
+          </ul>
+          <p className="mt-2 text-caption text-text-muted">
+            Mix-ups happen: {profile.similarTo.map(speciesDisplayName).join(", ")}.{" "}
+            <Link href="/regulations/rockfish" className="text-text-link underline decoration-dotted underline-offset-4">
+              Run the identifier
+            </Link>{" "}
+            if the one in your hand doesn&rsquo;t match the one in your head.
+          </p>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/regulations/geospatial.test.ts
+++ b/src/features/regulations/geospatial.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { REG_AREAS, RCA_50FM_LINE } from "./reg-data";
+import { distanceToLineM, distanceToRingM, pointInRing, sideOfLine } from "./geospatial";
+
+const SOUTHERN = REG_AREAS.find((a) => a.id === "ca-gma-southern")!.polygon!;
+const CCA = REG_AREAS.find((a) => a.id === "cca-santa-barbara")!.polygon!;
+
+describe("pointInRing — 'am I inside the agency's area' (spec §8)", () => {
+  it("places Long Beach harbor inside the Southern Management Area", () => {
+    expect(pointInRing([-118.2, 33.71], SOUTHERN)).toBe(true);
+  });
+
+  it("places the Farallon Islands outside it", () => {
+    expect(pointInRing([-123.0, 37.7], SOUTHERN)).toBe(false);
+  });
+
+  it("places a boat inside the CCA box and one near Dana Point outside", () => {
+    expect(pointInRing([-119.6, 33.4], CCA)).toBe(true);
+    expect(pointInRing([-117.7, 33.45], CCA)).toBe(false);
+  });
+});
+
+describe("sideOfLine — inshore/offshore of the RCA (spec §9)", () => {
+  const line = RCA_50FM_LINE.points;
+
+  it("reads the coastline side as inshore", () => {
+    // Redondo Beach pier area: well east of the 50-fm line.
+    expect(sideOfLine([-118.4, 33.83], line)).toBe("inshore");
+  });
+
+  it("reads blue water past the line as offshore", () => {
+    expect(sideOfLine([-119.6, 33.4], line)).toBe("offshore");
+  });
+});
+
+describe("boundary proximity (spec §9's approaching-boundary warning)", () => {
+  it("measures a few hundred meters, not a few kilometers, near the CCA corner", () => {
+    // ~0.005° east of the CCA east wall at 33.4°N ≈ 460 m.
+    const d = distanceToRingM([-118.83, 33.4], CCA);
+    expect(d).toBeGreaterThan(300);
+    expect(d).toBeLessThan(800);
+  });
+
+  it("measures meaningful kilometers offshore of the RCA line", () => {
+    const d = distanceToLineM([-119.6, 33.4], RCA_50FM_LINE.points);
+    expect(d).toBeGreaterThan(5_000);
+    expect(d).toBeLessThan(80_000);
+  });
+});

--- a/src/features/regulations/geospatial.ts
+++ b/src/features/regulations/geospatial.ts
@@ -1,0 +1,86 @@
+/**
+ * Geospatial regulation helpers (founder spec §8): resolve "where am I" against the
+ * pack's polygons and boundary polylines, on device, no network, no geocoder.
+ *
+ * WGS84 degrees in, meters out. The SoCal pack sits near 33°N where the equirectangular
+ * approximation is off by a fraction of a percent over a few kilometers — the error is
+ * declared and every polygon in the pack is labeled simplified anyway. Precise geodesy
+ * (Turf/Proj) can replace these two functions without touching the engine.
+ */
+
+export type LngLat = readonly [number, number];
+
+const EARTH_M = 6_371_008.8;
+const DEG = Math.PI / 180;
+
+function toXY([lng, lat]: LngLat, [lng0, lat0]: LngLat): [number, number] {
+  return [(lng - lng0) * DEG * EARTH_M * Math.cos(lat0 * DEG), (lat - lat0) * DEG * EARTH_M];
+}
+
+/** Ray casting. Boundary-point "on the line" answers via distance instead of casting luck. */
+export function pointInRing(point: LngLat, ring: readonly LngLat[]): boolean {
+  const [px] = toXY(point, point);
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const [xi, yi] = toXY(ring[i], point);
+    const [xj, yj] = toXY(ring[j], point);
+    const crosses = yi > 0 !== yj > 0;
+    if (crosses && px < ((xj - xi) * (0 - yi)) / (yj - yi) + xi) inside = !inside;
+  }
+  return inside;
+}
+
+function segmentDistanceM(p: LngLat, a: LngLat, b: LngLat): number {
+  const [px, py] = toXY(p, p);
+  const [ax, ay] = toXY(a, p);
+  const [bx, by] = toXY(b, p);
+  const dx = bx - ax;
+  const dy = by - ay;
+  const len2 = dx * dx + dy * dy;
+  const t = len2 === 0 ? 0 : Math.max(0, Math.min(1, ((px - ax) * dx + (py - ay) * dy) / len2));
+  const cx = ax + t * dx;
+  const cy = ay + t * dy;
+  return Math.hypot(px - cx, py - cy);
+}
+
+export function distanceToRingM(point: LngLat, ring: readonly LngLat[]): number {
+  let min = Number.POSITIVE_INFINITY;
+  for (let i = 0; jSafe(ring, i); i++) {
+    min = Math.min(min, segmentDistanceM(point, ring[i], ring[(i + 1) % ring.length]));
+  }
+  return min;
+}
+function jSafe(ring: readonly LngLat[], i: number) {
+  return ring.length > 1 && i < ring.length;
+}
+
+export function distanceToLineM(point: LngLat, line: readonly LngLat[]): number {
+  let min = Number.POSITIVE_INFINITY;
+  for (let i = 0; i + 1 < line.length; i++) {
+    min = Math.min(min, segmentDistanceM(point, line[i], line[i + 1]));
+  }
+  return min;
+}
+
+/**
+ * The RCA is a boundary polyline: "inshore of the line" reads as "seaward distance from
+ * the MAINLAND side". The pack's simplified line only spans SoCal, so the side test is
+ * a cheap longitude-of-nearest-point heuristic with the coastline east of it — honest
+ * for this pack, replaced by winding rules if a polygonal RCA ever arrives.
+ */
+export function sideOfLine(
+  point: LngLat,
+  line: readonly LngLat[],
+): "inshore" | "offshore" {
+  // Nearest vertex on the line; the coastline is east (higher lng) of the RCA in SoCal.
+  let bestIdx = 0;
+  let best = Number.POSITIVE_INFINITY;
+  for (let i = 0; i < line.length; i++) {
+    const d = Math.abs(line[i][0] - point[0]) + Math.abs(line[i][1] - point[1]);
+    if (d < best) {
+      best = d;
+      bestIdx = i;
+    }
+  }
+  return point[0] >= line[bestIdx][0] ? "inshore" : "offshore";
+}

--- a/src/features/regulations/prefs.ts
+++ b/src/features/regulations/prefs.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { createLocalPreference } from "@/features/settings/preference";
+import type { FishingMode } from "./types";
+
+/**
+ * Device-local (ADR 004/ADR 007 §4): the fishing MODE is how you're fishing right now,
+ * not who you are. It never lands on a catch — platforms on catches stay the trip's own
+ * field — it only steers how regulation cards read the platform split.
+ */
+export const fishingModePreference = createLocalPreference<FishingMode>({
+  key: "flb:regs-fishing-mode",
+  defaultValue: "boat",
+  parse: (raw) =>
+    raw === "kayak" || raw === "shore" || raw === "spearfishing" || raw === "boat"
+      ? raw
+      : "boat",
+  serialize: (value) => value,
+});
+
+export function useFishingModePreference() {
+  return fishingModePreference.use();
+}

--- a/src/features/regulations/reg-data-parity.test.ts
+++ b/src/features/regulations/reg-data-parity.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { SOCAL } from "./reg-data";
+
+/*
+ * The regulations dataset exists twice by design: the SQL pack (server source of truth,
+ * syncable) and this TypeScript bundle (the offline floor the app reads offshore).
+ * Twice means drift is possible, so the bundle is tested against the migrations rather
+ * than trusted — same discipline as the species vocabulary.
+ */
+
+const migrationsDir = fileURLToPath(new URL("../../../supabase/migrations/", import.meta.url));
+const sql = readdirSync(migrationsDir)
+  .filter((name) => name.endsWith(".sql"))
+  .sort()
+  .map((name) => readFileSync(migrationsDir + name, "utf8"))
+  .join("\n")
+  .replace(/''/g, "'"); // SQL string escaping, so sentence text compares equal
+
+describe("SoCal pack ↔ migration parity", () => {
+  // The four per-species zero-retention rows exist ONLY in the bundle for now: the SQL
+  // side carries the single group-level §28.55 row. The bundle is the more precise form
+  // (species-scoped prohibitions let the engine release exactly those four); a future
+  // pack-v2 migration reconciles it (handoff noted in the PR).
+  const BUNDLE_ONLY = new Set([
+    "zero-yelloweye_rockfish",
+    "zero-cowcod",
+    "zero-bronzespotted_rockfish",
+    "zero-quillback_rockfish",
+  ]);
+
+  it("every bundle rule's verbatim sentence exists in the migration", () => {
+    const missing = SOCAL.rules
+      .filter((r) => !BUNDLE_ONLY.has(r.id))
+      .filter((r) => !sql.includes(r.verbatim));
+    expect(missing.map((r) => r.id)).toEqual([]);
+  });
+
+  it("every area id and name pair exists in the migration", () => {
+    // Conservation-area geometry rows are bundle-only in v1: the SQL v1 schema keeps
+    // boundary_geojson null until polygons ship as a pack-v2 migration (arch §3).
+    const BUNDLE_ONLY_AREAS = new Set(["cca-santa-barbara", "cca-south", "mpa-pt-dume"]);
+    for (const area of SOCAL.areas) {
+      if (BUNDLE_ONLY_AREAS.has(area.id)) continue;
+      expect(sql).toContain(`'${area.id}'`);
+    }
+  });
+
+  it("every group id exists in the migration", () => {
+    for (const group of SOCAL.groups) {
+      expect(sql).toContain(`'${group.id}'`);
+    }
+  });
+
+  it("bundle pack version matches the migration's reg_pack version", () => {
+    expect(sql).toContain(`'socal-2026-09-01', ${SOCAL.pack.version}`);
+  });
+});

--- a/src/features/regulations/reg-data.ts
+++ b/src/features/regulations/reg-data.ts
@@ -1,0 +1,636 @@
+/**
+ * The verified SoCal regulations pack, TypeScript side.
+ *
+ * This is the migration `20260901230000` dataset's offline floor: the app reads THESE
+ * objects with no network, on a boat, in a canyon. The SQL copy exists so a server-side
+ * pack pipeline (spec §12) can version and diff it later; neither side is allowed to
+ * silently drift — `reg-data-parity.test.ts` compares the verbatim sentences against
+ * the migration, the same way species-parity guards the vocabulary.
+ *
+ * Polygons: SIMPLIFIED WGS84 rings hand-drawn around the named landmarks the source
+ * pages publish (Point Conception line, the coastal counties, the CCA corner
+ * coordinates as popularly charted). They are for RESOLUTION and orientation, and every
+ * one carries `simplified` in its notes. Exact legal lines live with the agency —
+ * deep-linked from every card (spec §9: a map is not a substitute for the official
+ * boundary).
+ *
+ * Groundfish RCA: the 50-fathom line is a connected-waypoint series in 50 CFR 660
+ * Subpart C, not a depth number, and spec §9 forbids substituting sonar. We carry a
+ * simplified waypoint polyline for display and orientation only; the card text names
+ * the CFR, and CDFW's interactive map is the precising cross-reference.
+ */
+import type { RegArea, RegGroup, RegPack, RegRule, SocalPack } from "./types";
+
+export const SOCAL_PACK: RegPack = {
+  id: "socal-2026-09-01",
+  version: 1,
+  publishedAt: "2026-09-01T00:00:00.000Z",
+  notes: "Hand-verified starter set. Bundle mirrors migration 20260901230000.",
+};
+
+const SOUTHERN_RING: readonly (readonly [number, number])[] = [
+  [-120.4716, 34.4486], // Point Conception (34°27' N) — the named corner of the GMA
+  [-121.6, 34.7],
+  [-121.6, 32.2], // far offshore SW corner
+  [-117.05, 32.28], // offshore at the border latitude
+  [-117.1231, 32.5343], // border meets the surf
+  [-117.27, 32.85], // San Diego
+  [-117.38, 33.16], // Del Mar
+  [-117.6, 33.2], // Carlsbad
+  [-117.92, 33.42], // Dana Point
+  [-118.12, 33.58], // Newport
+  [-117.99, 33.68], // Seal Beach
+  [-118.18, 33.715], // Long Beach harbor north wall
+  [-118.32, 33.7], // San Pedro
+  [-118.43, 33.712], // Pt. Fermin / PV east
+  [-118.43, 33.75],
+  [-118.9, 34.02], // Santa Monica/Malibu
+  [-119.05, 34.06],
+  [-119.29, 34.27], // Ventura
+  [-119.69, 34.42], // Santa Barbara
+  [-119.85, 34.41],
+  [-120.25, 34.46], // Gaviota
+];
+
+export const REG_AREAS: readonly RegArea[] = [
+  {
+    id: "ca-ocean-southern",
+    authority: "cdfw",
+    kind: "ocean_region",
+    name: "Southern — Point Conception to the U.S.–Mexico border",
+    polygon: SOUTHERN_RING,
+    sourceUrl: "https://wildlife.ca.gov/Fishing/Ocean/Regulations/Fishing-Map/Southern",
+    verifiedAt: "2026-09-01",
+    notes: "Simplified polygon for orientation/resolution. Includes part of Santa Barbara County and all of Ventura, Los Angeles, Orange and San Diego counties.",
+  },
+  {
+    id: "ca-gma-southern",
+    authority: "cdfw",
+    kind: "groundfish_management_area",
+    name: "Southern Management Area — Point Conception to the U.S.–Mexico border",
+    polygon: SOUTHERN_RING,
+    sourceUrl: "https://wildlife.ca.gov/Fishing/Ocean/Regulations/Groundfish-Summary",
+    verifiedAt: "2026-09-01",
+    notes: "Simplified polygon. CCR T14 §27.45(a). Eight Groundfish Exclusion Areas apply (§27.50) — CDFW interactive map is the legal reference.",
+  },
+  {
+    id: "cca-santa-barbara",
+    authority: "cdfw",
+    kind: "conservation_area",
+    name: "Cowcod Conservation Area (large block)",
+    polygon: [
+      [-118.837, 33.0],
+      [-120.484, 33.0],
+      [-120.484, 33.837],
+      [-118.837, 33.837],
+    ],
+    sourceUrl: "https://wildlife.ca.gov/Conservation/Marine/Cowcod",
+    verifiedAt: "2026-09-01",
+    notes: "SIMPLIFIED box of the large CCA for orientation — the legal corners are in CCR T14 §27.82. Groundfish take prohibited inside.",
+  },
+  {
+    id: "cca-south",
+    authority: "cdfw",
+    kind: "conservation_area",
+    name: "Cowcod Conservation Area (south block)",
+    polygon: [
+      [-117.9, 32.55],
+      [-118.1, 32.55],
+      [-118.1, 32.767],
+      [-117.9, 32.767],
+    ],
+    sourceUrl: "https://wildlife.ca.gov/Conservation/Marine/Cowcod",
+    verifiedAt: "2026-09-01",
+    notes: "SIMPLIFIED box of the southern CCA for orientation. Groundfish take prohibited inside.",
+  },
+  {
+    id: "mpa-pt-dume",
+    authority: "cdfw",
+    kind: "conservation_area",
+    name: "Point Dume State Marine Conservation Area",
+    polygon: [
+      [-118.72, 34.0],
+      [-118.8, 33.99],
+      [-118.82, 33.95],
+      [-118.74, 33.955],
+    ],
+    sourceUrl: "https://wildlife.ca.gov/Conservation/Marine/MPAs",
+    verifiedAt: "2026-09-01",
+    notes: "SIMPLIFIED inset of one MPA as a pack example. The full MPA network is linked out to CDFW's interactive map until the MPA layer ships as its own pack.",
+  },
+];
+
+/** The 50-fathom RCA line as orientation geometry (a polyline — a boundary, not an area). */
+export const RCA_50FM_LINE: {
+  readonly id: "rca-50fm-southern";
+  readonly name: string;
+  readonly points: readonly (readonly [number, number])[];
+  readonly citation: string;
+  readonly sourceUrl: string;
+  readonly verifiedAt: string;
+} = {
+  id: "rca-50fm-southern",
+  name: "50-fathom Rockfish Conservation Area boundary (simplified)",
+  points: [
+    [-120.6, 34.5],
+    [-120.35, 34.25],
+    [-119.9, 34.08],
+    [-119.3, 33.95],
+    [-119.0, 33.8],
+    [-118.6, 33.6],
+    [-118.25, 33.35],
+    [-117.9, 33.1],
+    [-117.5, 32.75],
+    [-117.35, 32.5],
+    [-117.2, 32.32],
+  ],
+  citation: "50 CFR Part 660, Subpart C (waypoint series)",
+  sourceUrl:
+    "https://www.fisheries.noaa.gov/west-coast/sustainable-fisheries/west-coast-groundfish-closed-areas",
+  verifiedAt: "2026-09-01",
+};
+
+export const REG_GROUPS: readonly RegGroup[] = [
+  {
+    id: "paralabrax-bass",
+    name: "Kelp bass, barred sand bass, spotted sand bass (Paralabrax)",
+    memberSpeciesIds: ["kelp_bass", "barred_sand_bass", "spotted_sand_bass"],
+  },
+  {
+    id: "rcg-complex",
+    name: "Rockfish, Cabezon, and Greenlings complex (RCG)",
+    memberSpeciesIds: [
+      "rockfish",
+      "vermilion_rockfish",
+      "canary_rockfish",
+      "yelloweye_rockfish",
+      "copper_rockfish",
+      "bocaccio",
+      "blue_rockfish",
+      "black_rockfish",
+      "olive_rockfish",
+      "gopher_rockfish",
+      "cowcod",
+      "cabezon",
+      "kelp_greenling",
+    ],
+  },
+];
+
+const A = {
+  url: "https://wildlife.ca.gov/Fishing/Ocean/Regulations/Fishing-Map/Southern",
+  title: "Current California Ocean Recreational Fishing Regulations — Southern Region",
+  updated: "2026-09-01",
+} as const;
+const B = {
+  url: "https://wildlife.ca.gov/Fishing/Ocean/Regulations/Groundfish-Summary",
+  title: "Summary of Recreational Groundfish Fishing Regulations",
+  updated: "2026-06-23",
+} as const;
+const VERIFIED = "2026-09-01";
+
+function rule(partial: Omit<RegRule, "id" | "regGroupId" | "speciesId" | "packVersion"> & {
+  id: string;
+  speciesId?: string | null;
+  regGroupId?: string | null;
+}): RegRule {
+  return {
+    speciesId: null,
+    regGroupId: null,
+    packVersion: 1,
+    ...partial,
+  };
+}
+
+export const REG_RULES: readonly RegRule[] = [
+  // ---------------- California halibut ----------------
+  rule({
+    id: "hal-season", speciesId: "california_halibut", regAreaId: "ca-ocean-southern", kind: "season",
+    verbatim: "The recreational fishery for California halibut (Paralichthys californicus) remains open year-round.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "hal-bag", speciesId: "california_halibut", regAreaId: "ca-ocean-southern", kind: "bag_limit",
+    verbatim: "The daily bag and possession limit is five fish south of Point Sur, Monterey County.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "hal-size", speciesId: "california_halibut", regAreaId: "ca-ocean-southern", kind: "min_size",
+    verbatim: "The minimum size limit is 22 inches total length.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: 22, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+
+  // ---------------- Paralabrax basses ----------------
+  rule({
+    id: "bass-season", regGroupId: "paralabrax-bass", regAreaId: "ca-ocean-southern", kind: "season",
+    verbatim: "The fisheries for kelp bass, barred sand bass, and spotted sand bass (Paralabrax species) remains open year-round.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "bass-bag", regGroupId: "paralabrax-bass", regAreaId: "ca-ocean-southern", kind: "bag_limit",
+    verbatim: "The daily bag and possession limit is five fish in any combination of species, except no more than 4 barred sand bass may be taken.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: true,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "bass-size", regGroupId: "paralabrax-bass", regAreaId: "ca-ocean-southern", kind: "min_size",
+    verbatim: "The minimum size limit is 14 inches total length or 10 inches alternate length.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: 14, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "bsb-bag", speciesId: "barred_sand_bass", regAreaId: "ca-ocean-southern", kind: "bag_limit",
+    verbatim: "no more than 4 barred sand bass may be taken",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 4, possessionLimit: null, bagSharesWithGroup: true,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+
+  // ---------------- White seabass ----------------
+  rule({
+    id: "wsb-season", speciesId: "white_seabass", regAreaId: "ca-ocean-southern", kind: "season",
+    verbatim: "The recreational fishery for white seabass (Atractoscion nobilis) remains open year-round.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "wsb-bag", speciesId: "white_seabass", regAreaId: "ca-ocean-southern", kind: "bag_limit",
+    verbatim: "The daily bag and possession limit is three fish except that only one fish may be taken in waters south of Point Conception between March 15 and June 15.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 3, possessionLimit: 3, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "wsb-bag-window", speciesId: "white_seabass", regAreaId: "ca-ocean-southern", kind: "bag_limit",
+    verbatim: "between March 15 and June 15 [ south of Point Conception ] only one fish may be taken",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: "2026-03-15", seasonEnd: "2026-06-15", bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "wsb-size", speciesId: "white_seabass", regAreaId: "ca-ocean-southern", kind: "min_size",
+    verbatim: "The minimum size limit is 28 inches total length or 20 inches alternate length.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: 28, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+
+  // ---------------- California sheephead (platform-split) ----------------
+  rule({
+    id: "she-season-diver", speciesId: "california_sheephead", regAreaId: "ca-ocean-southern", kind: "season",
+    verbatim: "open year-round to divers and shore-based anglers",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: "diver", depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "she-season-shore", speciesId: "california_sheephead", regAreaId: "ca-ocean-southern", kind: "season",
+    verbatim: "open year-round to divers and shore-based anglers",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: "shore", depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "she-season-boat", speciesId: "california_sheephead", regAreaId: "ca-ocean-southern", kind: "season",
+    verbatim: "This fishery is open to boat-based anglers from March 1, 2026 through December 31, 2026.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: "2026-03-01", seasonEnd: "2026-12-31", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: "boat", depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "she-bag", speciesId: "california_sheephead", regAreaId: "ca-ocean-southern", kind: "bag_limit",
+    verbatim: "The daily bag and possession limit is 2 fish",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 2, possessionLimit: 2, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "she-size", speciesId: "california_sheephead", regAreaId: "ca-ocean-southern", kind: "min_size",
+    verbatim: "a minimum size limit of 12 inches total length",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: 12, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+
+  // ---------------- Simple rows: whitefish / scorpionfish / leopard / yellowtail ----------------
+  rule({
+    id: "owf-season", speciesId: "ocean_whitefish", regAreaId: "ca-ocean-southern", kind: "season",
+    verbatim: "The recreational fishery for ocean whitefish (Caulolatilus princeps) is open year-round, at all depths.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "all depths",
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "owf-bag", speciesId: "ocean_whitefish", regAreaId: "ca-ocean-southern", kind: "bag_limit",
+    verbatim: "The daily bag and possession limit is 10 fish within the general daily bag limit of 20 fish total.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 10, possessionLimit: 10, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "scp-season", speciesId: "california_scorpionfish", regAreaId: "ca-ocean-southern", kind: "season",
+    verbatim: "The recreational fishery for California scorpionfish (Scorpaena guttata) is open year-round, at all depths.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "all depths",
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "scp-bag", speciesId: "california_scorpionfish", regAreaId: "ca-ocean-southern", kind: "bag_limit",
+    verbatim: "The daily bag and possession limit is 5 fish with no minimum size limit.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "leo-season", speciesId: "leopard_shark", regAreaId: "ca-ocean-southern", kind: "season",
+    verbatim: "The recreational fishery for leopard shark (Triakis semifasciata) is open year-round, at all depths.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "all depths",
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "leo-bag", speciesId: "leopard_shark", regAreaId: "ca-ocean-southern", kind: "bag_limit",
+    verbatim: "The daily bag and possession limit is 3 fish with a minimum size limit of 36 inches total length.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 3, possessionLimit: 3, bagSharesWithGroup: false,
+    minSizeIn: 36, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "yt-season", speciesId: "yellowtail", regAreaId: "ca-ocean-southern", kind: "season",
+    verbatim: "The fishery for yellowtail (Seriola dorsalis) remains open year-round.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "yt-bag", speciesId: "yellowtail", regAreaId: "ca-ocean-southern", kind: "bag_limit",
+    verbatim: "The daily bag and possession limit is ten fish.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 10, possessionLimit: 10, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "yt-size", speciesId: "yellowtail", regAreaId: "ca-ocean-southern", kind: "min_size",
+    verbatim: "The minimum size limit is 24 inches fork length, except that up to five fish less than 24 inches fork length may be taken or possessed.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: 24, maxSizeIn: null, sizeMeasure: "fork_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+
+  // ---------------- Giant sea bass: prohibited ----------------
+  rule({
+    id: "gsb-prohibited", speciesId: "giant_sea_bass", regAreaId: "ca-ocean-southern", kind: "prohibited",
+    verbatim: "Giant Sea Bass (a.k.a. black sea bass) — Closed. Take of broomtail grouper, gulf grouper, and giant (black) sea bass (a type of grouper) is prohibited.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 0, possessionLimit: 0, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+
+  // ---------------- Ocean salmon (in-season, harvest guideline) ----------------
+  rule({
+    id: "sal-season", speciesId: "chinook_salmon", regAreaId: "ca-ocean-southern", kind: "season",
+    verbatim: "The recreational fishery for ocean salmon is open beginning September 1, 2026 south of Pigeon Point, San Mateo County, to the US-Mexico border. In this area, the season will continue through September 30, 2026 or until the 20,000 fish harvest guideline is reached, whichever is earlier.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: "2026-09-01", seasonEnd: "2026-09-30", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "sal-bag", speciesId: "chinook_salmon", regAreaId: "ca-ocean-southern", kind: "bag_limit",
+    verbatim: "The daily bag and possession limit is 2 salmon of any species except coho (silver), which may not be taken or possessed.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 2, possessionLimit: 2, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "sal-size", speciesId: "chinook_salmon", regAreaId: "ca-ocean-southern", kind: "min_size",
+    verbatim: "The salmon minimum size limit is 20 inches total length.",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: 20, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "coho-prohibited", speciesId: "coho_salmon", regAreaId: "ca-ocean-southern", kind: "prohibited",
+    verbatim: "coho (silver) [salmon] may not be taken or possessed",
+    sourceUrl: A.url, sourceTitle: A.title, sourceUpdatedAt: A.updated, verifiedAt: VERIFIED,
+    seasonStart: "2026-09-01", seasonEnd: "2026-09-30", bagDaily: 0, possessionLimit: 0, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+
+  // ---------------- RCG complex ----------------
+  rule({
+    id: "rcg-bag", regGroupId: "rcg-complex", regAreaId: "ca-gma-southern", kind: "bag_limit",
+    verbatim: "RCG Complex: 10 fish in combination per person, except: Copper rockfish: 1 fish per person; Vermilion/sunset rockfish: 2 fish per person combined [all areas except Northern]; Canary rockfish: 2 fish per person.",
+    sourceUrl: B.url, sourceTitle: B.title, sourceUpdatedAt: B.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 10, possessionLimit: 10, bagSharesWithGroup: true,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "rcg-size", regGroupId: "rcg-complex", regAreaId: "ca-gma-southern", kind: "min_size",
+    verbatim: "All Rockfish: No minimum size limit. Cabezon and Greenlings: No minimum size limit.",
+    sourceUrl: B.url, sourceTitle: B.title, sourceUpdatedAt: B.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "rcg-zero", regGroupId: "rcg-complex", regAreaId: "ca-gma-southern", kind: "prohibited",
+    verbatim: "These Rockfishes May Not Be Taken or Possessed in California — No Retention at Any Time: Bronzespotted Rockfish, Cowcod, Quillback Rockfish, and Yelloweye Rockfish (CCR T14, §28.55). Fishing is closed year-round, at all depths, no retention at any time (zero fish per person).",
+    sourceUrl: B.url, sourceTitle: B.title, sourceUpdatedAt: B.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 0, possessionLimit: 0, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "rcg-gear", regGroupId: "rcg-complex", regAreaId: "ca-gma-southern", kind: "gear",
+    verbatim: "Descending Devices Required: No one may take or possess any federal groundfish from any boat or other floating device in ocean waters without a descending device in possession (CCR T14, §27.20(b)(2)).",
+    sourceUrl: B.url, sourceTitle: B.title, sourceUpdatedAt: B.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: "boat", depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "rcg-exempt", regGroupId: "rcg-complex", regAreaId: "ca-gma-southern", kind: "note",
+    verbatim: "Shore-based anglers and spear divers are exempt from seasons and depths. Divers and shore-based anglers are exempt from season and depth restrictions affecting the RCG Complex and other federally managed groundfish (CCR T14, §27.20(b)(1)(C) and (b)(1)(D)).",
+    sourceUrl: B.url, sourceTitle: B.title, sourceUpdatedAt: B.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  // Species-level exceptions inside the complex
+  rule({
+    id: "copper-bag", speciesId: "copper_rockfish", regAreaId: "ca-gma-southern", kind: "bag_limit",
+    verbatim: "Copper rockfish: 1 fish per person",
+    sourceUrl: B.url, sourceTitle: B.title, sourceUpdatedAt: B.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: true,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "vermilion-bag", speciesId: "vermilion_rockfish", regAreaId: "ca-gma-southern", kind: "bag_limit",
+    verbatim: "Vermilion/sunset rockfish: 2 fish per person combined [all areas except Northern]",
+    sourceUrl: B.url, sourceTitle: B.title, sourceUpdatedAt: B.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 2, possessionLimit: 2, bagSharesWithGroup: true,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "canary-bag", speciesId: "canary_rockfish", regAreaId: "ca-gma-southern", kind: "bag_limit",
+    verbatim: "Canary rockfish: 2 fish per person",
+    sourceUrl: B.url, sourceTitle: B.title, sourceUpdatedAt: B.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 2, possessionLimit: 2, bagSharesWithGroup: true,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  ...(["yelloweye_rockfish", "cowcod", "bronzespotted_rockfish", "quillback_rockfish"] as const).map(
+    (speciesId) =>
+      rule({
+        id: `zero-${speciesId}`, speciesId, regAreaId: "ca-gma-southern", kind: "prohibited",
+        verbatim: "No Retention at Any Time (CCR T14, §28.55). Closed year-round, at all depths (zero fish per person).",
+        sourceUrl: B.url, sourceTitle: B.title, sourceUpdatedAt: B.updated, verifiedAt: VERIFIED,
+        seasonStart: null, seasonEnd: null, bagDaily: 0, possessionLimit: 0, bagSharesWithGroup: false,
+        minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+        checkInseason: false, staleAfterDays: 60,
+      }),
+  ),
+
+  // Southern GMA season windows (nearshore RCG vs shelf/slope + lingcod Oct–Dec split)
+  rule({
+    id: "rcg-win-1", regGroupId: "rcg-complex", regAreaId: "ca-gma-southern", kind: "season",
+    verbatim: "Southern Management Area, Nearshore Rockfish, Cabezon, and Greenlings: Jan 1 - Mar 31: Closed — unlawful to possess in all waters.",
+    sourceUrl: B.url, sourceTitle: B.title, sourceUpdatedAt: B.updated, verifiedAt: VERIFIED,
+    seasonStart: "2026-01-01", seasonEnd: "2026-03-31", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "closed — unlawful to possess in all waters",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "rcg-win-2", regGroupId: "rcg-complex", regAreaId: "ca-gma-southern", kind: "season",
+    verbatim: "Southern Management Area, Nearshore Rockfish, Cabezon, and Greenlings: April 1 - June 30: Open All Depths.",
+    sourceUrl: B.url, sourceTitle: B.title, sourceUpdatedAt: B.updated, verifiedAt: VERIFIED,
+    seasonStart: "2026-04-01", seasonEnd: "2026-06-30", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "open all depths",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "rcg-win-3", regGroupId: "rcg-complex", regAreaId: "ca-gma-southern", kind: "season",
+    verbatim: "Southern Management Area, Nearshore Rockfish, Cabezon, and Greenlings: July 1 - Sep 30: 50 Fathom - Inshore Only. Take is prohibited seaward of the 50 fathom (300 feet) Rockfish Conservation Area boundary line.",
+    sourceUrl: B.url, sourceTitle: B.title, sourceUpdatedAt: B.updated, verifiedAt: VERIFIED,
+    seasonStart: "2026-07-01", seasonEnd: "2026-09-30", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "50 fathom RCA: inshore only",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "rcg-win-4", regGroupId: "rcg-complex", regAreaId: "ca-gma-southern", kind: "season",
+    verbatim: "Southern Management Area, Nearshore Rockfish, Cabezon, and Greenlings: Oct 1 - Dec 31: Closed — unlawful to possess in all waters.",
+    sourceUrl: B.url, sourceTitle: B.title, sourceUpdatedAt: B.updated, verifiedAt: VERIFIED,
+    seasonStart: "2026-10-01", seasonEnd: "2026-12-31", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "closed — unlawful to possess in all waters",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ling-win-1", speciesId: "lingcod", regAreaId: "ca-gma-southern", kind: "season",
+    verbatim: "Southern Management Area, Shelf and Slope Rockfish and Lingcod: Jan 1 - Mar 31: Closed — unlawful to possess in all waters.",
+    sourceUrl: B.url, sourceTitle: B.title, sourceUpdatedAt: B.updated, verifiedAt: VERIFIED,
+    seasonStart: "2026-01-01", seasonEnd: "2026-03-31", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "closed — unlawful to possess in all waters",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ling-win-2", speciesId: "lingcod", regAreaId: "ca-gma-southern", kind: "season",
+    verbatim: "Southern Management Area, Shelf and Slope Rockfish and Lingcod: April 1 - June 30: Open All Depths.",
+    sourceUrl: B.url, sourceTitle: B.title, sourceUpdatedAt: B.updated, verifiedAt: VERIFIED,
+    seasonStart: "2026-04-01", seasonEnd: "2026-06-30", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "open all depths",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ling-win-3", speciesId: "lingcod", regAreaId: "ca-gma-southern", kind: "season",
+    verbatim: "Southern Management Area, Shelf and Slope Rockfish and Lingcod: July 1 - Sep 30: 50 Fathom - Inshore Only. Take is prohibited seaward of the 50 fathom (300 feet) Rockfish Conservation Area boundary line.",
+    sourceUrl: B.url, sourceTitle: B.title, sourceUpdatedAt: B.updated, verifiedAt: VERIFIED,
+    seasonStart: "2026-07-01", seasonEnd: "2026-09-30", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "50 fathom RCA: inshore only",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ling-win-4b", speciesId: "lingcod", regAreaId: "ca-gma-southern", kind: "season",
+    verbatim: "Southern Management Area, Shelf and Slope Rockfish and Lingcod: Oct 1 - Dec 31: 50 Fathom - Offshore Only. Take is prohibited shoreward of the 50 fathom (300 feet) Rockfish Conservation Area boundary line.",
+    sourceUrl: B.url, sourceTitle: B.title, sourceUpdatedAt: B.updated, verifiedAt: VERIFIED,
+    seasonStart: "2026-10-01", seasonEnd: "2026-12-31", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "50 fathom RCA: offshore only",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ling-bag", speciesId: "lingcod", regAreaId: "ca-gma-southern", kind: "bag_limit",
+    verbatim: "Lingcod (§28.27): 2 fish per person.",
+    sourceUrl: B.url, sourceTitle: B.title, sourceUpdatedAt: B.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 2, possessionLimit: 2, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ling-size", speciesId: "lingcod", regAreaId: "ca-gma-southern", kind: "min_size",
+    verbatim: "Lingcod (§28.27): minimum size 22\" total length.",
+    sourceUrl: B.url, sourceTitle: B.title, sourceUpdatedAt: B.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: 22, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+];
+
+export const SOCAL: SocalPack = {
+  pack: SOCAL_PACK,
+  areas: REG_AREAS,
+  groups: REG_GROUPS,
+  rules: REG_RULES,
+};
+
+/** Species with at least one verified rule or group membership in this pack. */
+export function speciesInPack(): readonly string[] {
+  const ids = new Set<string>();
+  for (const r of REG_RULES) {
+    if (r.speciesId) ids.add(r.speciesId);
+  }
+  for (const g of REG_GROUPS) for (const id of g.memberSpeciesIds) ids.add(id);
+  return [...ids];
+}

--- a/src/features/regulations/reg-engine.test.ts
+++ b/src/features/regulations/reg-engine.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import { SOCAL } from "./reg-data";
+import { platformFor, regulationCard } from "./reg-engine";
+
+const TODAY = "2026-09-01"; // pack verification day — Southern region page's own stamp
+
+describe("regulation engine (founder §4/§15 verdict ladder)", () => {
+  it("answers an in-limit staple as keep with its numbers", () => {
+    const card = regulationCard(SOCAL, "ca-ocean-southern", "california_halibut", TODAY, "boat");
+    expect(card).not.toBeNull();
+    expect(card!.verdict).toBe("keep");
+    expect(card!.bagDaily).toBe(5);
+    expect(card!.minSizeIn).toBe(22);
+    expect(card!.sizeMeasure).toBe("total_length");
+  });
+
+  it("prohibited species are release, with the law's own words as the reason", () => {
+    const card = regulationCard(SOCAL, "ca-ocean-southern", "giant_sea_bass", TODAY, "boat");
+    expect(card!.verdict).toBe("release");
+    expect(card!.verdictReason).toContain("Zero retention");
+  });
+
+  it("coho is release inside the salmon window (prohibited, season-scoped)", () => {
+    const card = regulationCard(SOCAL, "ca-ocean-southern", "coho_salmon", TODAY, "boat");
+    expect(card!.verdict).toBe("release");
+  });
+
+  it("chinook is conditional inside the window: the harvest guideline can close early", () => {
+    const card = regulationCard(SOCAL, "ca-ocean-southern", "chinook_salmon", TODAY, "boat");
+    expect(card!.verdict).toBe("conditional");
+    expect(card!.bagDaily).toBe(2);
+    expect(card!.verdictReason).toContain("in-season");
+  });
+
+  it("chinook is release the morning after the window closes (spec QA: season changing at midnight)", () => {
+    const card = regulationCard(SOCAL, "ca-ocean-southern", "chinook_salmon", "2026-10-01", "boat");
+    expect(card!.verdict).toBe("release");
+    expect(card!.verdictReason).toContain("closed");
+  });
+
+  it("sheephead by boat is keep in September and release in January", () => {
+    expect(
+      regulationCard(SOCAL, "ca-ocean-southern", "california_sheephead", TODAY, "boat")!.verdict,
+    ).toBe("keep");
+    expect(
+      regulationCard(SOCAL, "ca-ocean-southern", "california_sheephead", "2026-01-15", "boat")!.verdict,
+    ).toBe("release");
+  });
+
+  it("sheephead from shore is keep all year — the year-round platform rows stand", () => {
+    const card = regulationCard(SOCAL, "ca-ocean-southern", "california_sheephead", "2026-01-15", "shore");
+    expect(card!.verdict).toBe("keep");
+  });
+
+  it("vermilion rockfish by boat in September is conditional on the 50-fm line, bag 2", () => {
+    const card = regulationCard(SOCAL, "ca-ocean-southern", "vermilion_rockfish", TODAY, "boat");
+    expect(card!.verdict).toBe("conditional");
+    expect(card!.bagDaily).toBe(2);
+    expect(card!.verdictReason).toContain("50 fathom");
+    expect(card!.groupNote).toContain("10 fish in combination");
+  });
+
+  it("the same vermilion from SHORE is keep — the exempt footnote is data, not decoration", () => {
+    const card = regulationCard(SOCAL, "ca-ocean-southern", "vermilion_rockfish", TODAY, "shore");
+    expect(card!.verdict).toBe("keep");
+    expect(card!.specialRules.some((s) => s.includes("exempt"))).toBe(true);
+  });
+
+  it("groundfish seasons reopen but stay conditional in May (all-depth window, in-season flag)", () => {
+    const card = regulationCard(SOCAL, "ca-gma-southern", "blue_rockfish", "2026-05-15", "boat");
+    expect(card!.verdict).toBe("conditional"); // checkInseason: groundfish moves in-season
+    expect(card!.verdictReason).not.toContain("50 fathom");
+  });
+
+  it("groundfish boat in February is release — closed window", () => {
+    const card = regulationCard(SOCAL, "ca-ocean-southern", "blue_rockfish", "2026-02-01", "boat");
+    expect(card!.verdict).toBe("release");
+    expect(card!.verdictReason).toContain("closed");
+  });
+
+  it("lingcod in October is offshore-only — the split season is not the nearshore one", () => {
+    const card = regulationCard(SOCAL, "ca-ocean-southern", "lingcod", "2026-10-15", "boat");
+    expect(card!.verdict).toBe("conditional");
+    expect(card!.verdictReason).toContain("offshore only");
+  });
+
+  it("yelloweye is release regardless of the season window (prohibited outranks windows)", () => {
+    expect(
+      regulationCard(SOCAL, "ca-ocean-southern", "yelloweye_rockfish", TODAY, "boat")!.verdict,
+    ).toBe("release");
+    expect(
+      regulationCard(SOCAL, "ca-ocean-southern", "yelloweye_rockfish", TODAY, "shore")!.verdict,
+    ).toBe("release");
+  });
+
+  it("a species the pack does not cover returns null — the screen says No verified data", () => {
+    expect(regulationCard(SOCAL, "ca-ocean-southern", "pacific_mackerel", TODAY, "boat")).toBeNull();
+  });
+
+  it("barred sand bass names its own tighter cap inside the shared bag", () => {
+    const card = regulationCard(SOCAL, "ca-ocean-southern", "barred_sand_bass", TODAY, "boat");
+    expect(card!.verdict).toBe("keep");
+    expect(card!.bagDaily).toBe(4);
+    expect(card!.groupNote).toContain("five fish in any combination");
+  });
+
+  it("cards born yesterday are fresh; the same card in December is stale (§23)", () => {
+    expect(regulationCard(SOCAL, "ca-ocean-southern", "california_halibut", TODAY, "boat")!.isStale).toBe(false);
+    const stale = regulationCard(SOCAL, "ca-ocean-southern", "california_halibut", "2026-12-15", "boat")!;
+    expect(stale.isStale).toBe(true);
+    expect(stale.staleDays).toBeGreaterThan(100);
+  });
+
+  it("platform mapping: kayak is a vessel, spearfishing is the diver carve-out", () => {
+    expect(platformFor("kayak")).toBe("boat");
+    expect(platformFor("spearfishing")).toBe("diver");
+  });
+});

--- a/src/features/regulations/reg-engine.ts
+++ b/src/features/regulations/reg-engine.ts
@@ -1,0 +1,221 @@
+/**
+ * The regulation engine (founder spec §3, §4, §15): date + species (+ group) + platform
+ * → ONE verdict card, verdict first. Pure: the day is a parameter (ADR 006 §7 — no
+ * wall-clock reads in rules), the pack is a parameter.
+ *
+ * Reading order the UI mirrors: KEEP / RELEASE / CONDITIONAL → bag → size → season →
+ * depth → special. `conditional` is the honest middle: something real (platform split,
+ * in-season change, a boundary line) can flip the answer, and the card says what.
+ *
+ * The engine never returns "perfectly fine": a card is data with citations or nothing
+ * at all (`null` → the screen renders "No verified data", spec §4/§23).
+ */
+import type {
+  FishingMode,
+  PlatformScope,
+  RegGroup,
+  RegRule,
+  RegulationCard,
+  SocalPack,
+} from "./types";
+
+/** Kayak is a vessel under CDFW groundfish law; spearfishing counts as the diver carve-out. */
+export function platformFor(mode: FishingMode): PlatformScope {
+  if (mode === "shore") return "shore";
+  if (mode === "spearfishing") return "diver";
+  return "boat";
+}
+
+/** Inclusive [start, end] on YYYY-MM-DD; null bound = unbounded (year-round). */
+export function inSeasonWindow(rule: RegRule, dateKey: string): boolean {
+  if (rule.seasonStart && dateKey < rule.seasonStart) return false;
+  if (rule.seasonEnd && dateKey > rule.seasonEnd) return false;
+  return true;
+}
+
+function isClosedNote(note: string | null): boolean {
+  return note !== null && note.toLowerCase().startsWith("closed");
+}
+
+/** All rows that speak to this species in this area: its own plus its groups'. */
+export function rulesForSpecies(
+  pack: SocalPack,
+  areaId: string,
+  speciesId: string,
+): { rules: readonly RegRule[]; groups: readonly RegGroup[] } {
+  const groups = pack.groups.filter((g) => g.memberSpeciesIds.includes(speciesId));
+  const groupIds = new Set(groups.map((g) => g.id));
+  const rules = pack.rules.filter(
+    (r) =>
+      r.regAreaId === areaId &&
+      (r.speciesId === speciesId || (r.regGroupId !== null && groupIds.has(r.regGroupId))),
+  );
+  return { rules, groups };
+}
+
+function platformMatches(rule: RegRule, platform: PlatformScope): boolean {
+  return rule.platformScope === null || rule.platformScope === platform;
+}
+
+function buildCard(
+  speciesId: string,
+  rules: readonly RegRule[],
+  groups: readonly RegGroup[],
+  dateKey: string,
+  platform: PlatformScope,
+): RegulationCard | null {
+  if (rules.length === 0) return null;
+
+  const usable = rules.filter((r) => platformMatches(r, platform));
+
+  // Shore-based anglers and spear divers are exempt from RCG-complex season and DEPTH
+  // restrictions (CCR T14 §27.20(b)(1)(C)/(D), the rcg-exempt note row). For those
+  // platforms the groundfish windows drop out of the VERDICT reading entirely — the
+  // exemption note itself still lands in specialRules, so the card explains why.
+  const groundfishExempt =
+    platform !== "boat" && rules.some((r) => r.regGroupId === "rcg-complex");
+  const verdictPool = usable.filter(
+    (r) => !(groundfishExempt && r.regGroupId === "rcg-complex" && r.kind === "season"),
+  );
+  const active = verdictPool.filter((r) => inSeasonWindow(r, dateKey));
+
+  const pick = <T>(map: (r: RegRule) => T | null): T | null => {
+    for (const r of [...active].sort((a, b) => (b.bagDaily ?? 99) - (a.bagDaily ?? 99))) {
+      const v = map(r);
+      if (v !== null) return v;
+    }
+    return null;
+  };
+
+  // Tightest reading wins: a species-level bag cap (copper 1) beats the group 10.
+  const bagRules = active.filter((r) => r.kind === "bag_limit" && r.bagDaily !== null);
+  const speciesCap = bagRules.filter((r) => r.speciesId === speciesId);
+  const bagRule =
+    [...speciesCap].sort((a, b) => (a.bagDaily ?? 99) - (b.bagDaily ?? 99))[0] ??
+    [...bagRules].sort((a, b) => (a.bagDaily ?? 99) - (b.bagDaily ?? 99))[0] ??
+    null;
+  const sizeRule = active.find((r) => r.kind === "min_size" && r.minSizeIn !== null) ?? null;
+  // Group-level zero-retention ("these four rockfish may never be kept") is NOT a
+  // prohibition on the complex — it is a warning that belongs on every member's card
+  // (spec §6), while this member's own prohibition row is what can RELEASE it below.
+  const groupProhibitionWarnings = active
+    .filter((r) => r.kind === "prohibited" && r.regGroupId !== null && r.speciesId === null)
+    .map((r) => r.verbatim);
+  const specialRules = [
+    ...groupProhibitionWarnings,
+    ...active.filter((r) => r.kind === "note" || r.kind === "gear").map((r) => r.verbatim),
+  ];
+  const groupBag = groups.length > 0 ? (bagRules.find((r) => r.bagSharesWithGroup) ?? null) : null;
+
+  // Lowest horizon among the rows on the card governs staleness (in-season rows age
+  // faster; the card inherits that).
+  const horizon = Math.min(...[...active, ...usable].map((r) => r.staleAfterDays));
+  const verifiedAt = [...active, ...usable]
+    .map((r) => r.verifiedAt)
+    .sort()[0]; // oldest verification on the card is the honest one
+  const daysSince = Math.floor((Date.parse(`${dateKey}T00:00:00Z`) - Date.parse(`${verifiedAt}T00:00:00Z`)) / 86_400_000);
+
+  // Verdict ladder (§15): prohibited > closed season > boundary/platform conditional >
+  // in-season-change conditional > keep.
+  //
+  // Only THIS species' own prohibited row can release it — the complex-level
+  // zero-retention quartet (bronze/cowcod/quillback/yelloweye) is an advisory carried
+  // on every member's card, never a verdict for the member.
+  const prohibited = active.find((r) => r.kind === "prohibited" && r.speciesId === speciesId);
+  // Shore-based anglers and spear divers are exempt from RCG-complex season and DEPTH
+  // restrictions (CCR T14 §27.20(b)(1)(C)/(D), the rcg-exempt note row). For those
+  // platforms the groundfish windows below must not close or condition the card — the
+  // note itself lands in specialRules, which is how the card says why.
+  // A dated season row that ends before/starts after today means "closed now" UNLESS a
+  // platform-matching year-round row also stands (sheephead from shore and by diver).
+  const datedSeasons = verdictPool.filter((r) => r.kind === "season" && (r.seasonStart || r.seasonEnd));
+  const yearRoundCover = verdictPool.some(
+    (r) => r.kind === "season" && !r.seasonStart && !r.seasonEnd,
+  );
+  const coveringSeason = datedSeasons.filter((r) => inSeasonWindow(r, dateKey));
+  const seasonClosedNow =
+    datedSeasons.length > 0 && coveringSeason.length === 0 && !yearRoundCover;
+  const activeClosedSeason = coveringSeason.find((r) => isClosedNote(r.depthNote));
+  const boundarySeason = coveringSeason.find(
+    (r) => r.depthNote !== null && !isClosedNote(r.depthNote) && !/all depths/i.test(r.depthNote),
+  );
+  const inSeasonFlag = active.some((r) => r.checkInseason);
+
+  let verdict: RegulationCard["verdict"];
+  let reason: string;
+  if (prohibited) {
+    verdict = "release";
+    reason = "Zero retention — this species may not be taken or possessed.";
+  } else if (seasonClosedNow || activeClosedSeason) {
+    verdict = "release";
+    reason = "Season closed today in this management area.";
+  } else if (boundarySeason) {
+    verdict = "conditional";
+    reason = `Legal only ${boundarySeason.depthNote} today — position against the boundary decides.`;
+  } else if (inSeasonFlag) {
+    verdict = "conditional";
+    reason = "This fishery can change in-season — verify before you keep it.";
+  } else {
+    verdict = "keep";
+    reason = "Open, with the limits shown. You still must verify closures (MPAs and special areas below).";
+  }
+
+  const seasonText = coveringSeason.length > 0
+    ? coveringSeason.map((r) =>
+        r.seasonStart && r.seasonEnd
+          ? `${r.seasonStart} → ${r.seasonEnd}${r.depthNote ? ` (${r.depthNote})` : ""}`
+          : "Year-round",
+      )[0]
+    : yearRoundCover
+      ? "Year-round"
+      : datedSeasons.length > 0
+        ? `Closed today (window ${datedSeasons[0].seasonStart} → ${datedSeasons[0].seasonEnd})`
+        : "Year-round";
+
+  const sources = [...new Set(active.map((r) => `${r.sourceUrl}|${r.sourceTitle}`))];
+  const firstSource = active[0] ?? usable[0];
+
+  return {
+    speciesId,
+    verdict,
+    verdictReason: reason,
+    bagDaily: bagRule?.bagDaily ?? null,
+    possessionLimit: bagRule?.possessionLimit ?? null,
+    minSizeIn: sizeRule?.minSizeIn ?? null,
+    sizeMeasure: sizeRule?.sizeMeasure ?? null,
+    seasonText,
+    depthText: boundarySeason?.depthNote ?? pick((r) => r.depthNote),
+    specialRules,
+    groupNote: groupBag ? groupBag.verbatim : null,
+    sourceUrl: sources[0]?.split("|")[0] ?? firstSource.sourceUrl,
+    sourceTitle: sources[0]?.split("|")[1] ?? firstSource.sourceTitle,
+    sourceUpdatedAt: firstSource.sourceUpdatedAt,
+    verifiedAt,
+    packVersion: firstSource.packVersion,
+    staleDays: Math.max(0, daysSince),
+    isStale: daysSince > horizon,
+  };
+}
+
+/**
+ * The one question the angler asks out loud (spec §1): “I am here, today, and I caught
+ * this fish — what am I legally allowed to do?”
+ */
+export function regulationCard(
+  pack: SocalPack,
+  areaId: string,
+  speciesId: string,
+  dateKey: string,
+  platform: PlatformScope,
+): RegulationCard | null {
+  const { rules, groups } = rulesForSpecies(pack, areaId, speciesId);
+  // Group exceptions live in the GMA; if the caller asked the ocean region for an
+  // RCG member, also fold the GMA group rows in (the two areas share a coastline).
+  const { rules: gmaRules, groups: gmaGroups } =
+    areaId === "ca-ocean-southern"
+      ? rulesForSpecies(pack, "ca-gma-southern", speciesId)
+      : { rules: [] as readonly RegRule[], groups: [] as readonly RegGroup[] };
+  const allRules = [...rules, ...gmaRules];
+  const allGroups = [...groups, ...gmaGroups.filter((g) => !groups.some((x) => x.id === g.id))];
+  return buildCard(speciesId, allRules, allGroups, dateKey, platform);
+}

--- a/src/features/regulations/reg-species.ts
+++ b/src/features/regulations/reg-species.ts
@@ -1,0 +1,30 @@
+/**
+ * Species display names for the regulations surface. The catch vocabulary
+ * (`core/ontology/species`) is the mirror it reads first; the rockfish wizard profiles
+ * name the rest. Stable ids come from those two forms — this file adds nothing new, only
+ * the join.
+ */
+import { SPECIES } from "@/core/ontology/species";
+import { ROCKFISH_PROFILES } from "./rockfish-id";
+
+const BY_ID = new Map<string, string>([
+  ...SPECIES.map((s) => [s.id, s.commonName] as const),
+  ...ROCKFISH_PROFILES.map((p) => [p.speciesId, p.commonName] as const),
+]);
+
+const ID_FALLBACKS: Record<string, string> = {
+  sunset_rockfish: "Sunset rockfish",
+  bronzespotted_rockfish: "Bronzespotted rockfish",
+  quillback_rockfish: "Quillback rockfish",
+};
+
+export function speciesDisplayName(id: string): string {
+  return (
+    BY_ID.get(id) ??
+    ID_FALLBACKS[id] ??
+    id
+      .split("_")
+      .map((w) => w[0].toUpperCase() + w.slice(1))
+      .join(" ")
+  );
+}

--- a/src/features/regulations/rockfish-id.test.ts
+++ b/src/features/regulations/rockfish-id.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  hasVerifiedRules,
+  ID_QUESTIONS,
+  identifyRockfish,
+  restrictedIn,
+  ROCKFISH_PROFILES,
+} from "./rockfish-id";
+
+describe("identifyRockfish (spec §5/§6)", () => {
+  it("has no wrong answer for 'not sure' — zero answers mean a uniform field", () => {
+    const result = identifyRockfish([]);
+    expect(result.length).toBe(ROCKFISH_PROFILES.length);
+    expect(result[0].confidencePct).toBe(result[result.length - 1].confidencePct);
+  });
+
+  it("favors vermilion on vermilion's own traits", () => {
+    const result = identifyRockfish(["red-orange", "spots-yes", "jaw-small", "size-mid"]);
+    expect(result[0].profile.speciesId).toBe("vermilion_rockfish");
+  });
+
+  it("favors copper on blotch + brown + mid size", () => {
+    const result = identifyRockfish(["brown", "spots-yes", "size-mid", "jaw-small"]);
+    expect(result[0].profile.speciesId).toBe("copper_rockfish");
+  });
+
+  it("favors bocaccio on the big jaw of a brownish fish", () => {
+    const result = identifyRockfish(["jaw-big", "spots-no", "size-big", "brown"]);
+    expect(result[0].profile.speciesId).toBe("bocaccio");
+  });
+
+  it("percentages are shares across the whole surviving pool", () => {
+    const result = identifyRockfish(["brown"]);
+    const sum = result.reduce((n, c) => n + c.confidencePct, 0);
+    expect(Math.abs(sum - 100)).toBeLessThanOrEqual(ROCKFISH_PROFILES.length);
+  });
+
+  it("shining-on-orange raises the prohibited pair into the warning window", () => {
+    const result = identifyRockfish(["red-orange", "spots-no", "size-big"]);
+    const restricted = restrictedIn(result);
+    expect(restricted.some((c) => c.profile.speciesId === "yelloweye_rockfish")).toBe(true);
+    expect(restricted.some((c) => c.profile.speciesId === "cowcod")).toBe(true);
+  });
+
+  it("a clearly-black, small fish keeps the prohibited pair below the noise floor", () => {
+    const result = identifyRockfish(["black-blue", "spots-no", "size-small", "jaw-small"]);
+    expect(restrictedIn(result).length).toBe(0);
+  });
+});
+
+describe("pack linkage + question integrity", () => {
+  it("every wizard species with rules in the pack links out to a card", () => {
+    // All ten wizard species carry RCG-complex group rules (plus species exceptions).
+    for (const p of ROCKFISH_PROFILES) expect(hasVerifiedRules(p.speciesId)).toBe(true);
+  });
+
+  it("every question stays answerable by hand (no science words, modest option lists)", () => {
+    for (const q of ID_QUESTIONS) {
+      expect(q.answers.length).toBeGreaterThanOrEqual(2);
+      expect(q.answers.length).toBeLessThanOrEqual(6);
+    }
+  });
+});

--- a/src/features/regulations/rockfish-id.ts
+++ b/src/features/regulations/rockfish-id.ts
@@ -1,0 +1,334 @@
+/**
+ * Guided rockfish identification (founder spec §5, §6, §7).
+ *
+ * A decision tree that asks plain visual questions and answers with CONFIDENCE LANGUAGE,
+ * never certainty: "Likely vermilion rockfish" with a percentage, plus a hard
+ * restricted-species warning whenever the candidate pool contains anything California
+ * says zero-retention on. The product rule is §6: when identification is uncertain the
+ * answer favors release, and the UI says so.
+ *
+ * Images in v1 are SCHEMATIC swatches (drawn color/pattern blocks), labeled as such — a
+ * schematic is honest about what it is. §7's camera path narrows candidates through the
+ * same scoring seam later; identification and regulation stay separate systems.
+ */
+import { SOCAL, speciesInPack } from "./reg-data";
+
+export type TraitAnswer =
+  | "red-orange"
+  | "brown"
+  | "black-blue"
+  | "pink-copper"
+  | "mixed"
+  | "spots-yes"
+  | "spots-no"
+  | "bands-yes"
+  | "bands-no"
+  | "jaw-small"
+  | "jaw-big"
+  | "fins-uniform"
+  | "fins-light"
+  | "size-small"
+  | "size-mid"
+  | "size-big";
+
+export interface IdQuestion {
+  readonly id: string;
+  readonly question: string;
+  readonly answers: readonly { id: TraitAnswer; label: string }[];
+}
+
+export const ID_QUESTIONS: readonly IdQuestion[] = [
+  {
+    id: "color",
+    question: "What is the fish's main color?",
+    answers: [
+      { id: "red-orange", label: "Red / orange" },
+      { id: "brown", label: "Brown / olive" },
+      { id: "black-blue", label: "Black / blue" },
+      { id: "pink-copper", label: "Pink / copper shades" },
+      { id: "mixed", label: "Mixed or patterned" },
+    ],
+  },
+  {
+    id: "spots",
+    question: "Noticeable spots or blotches?",
+    answers: [
+      { id: "spots-yes", label: "Yes" },
+      { id: "spots-no", label: "No / plain" },
+    ],
+  },
+  {
+    id: "bands",
+    question: "Visible bars or stripes across the body?",
+    answers: [
+      { id: "bands-yes", label: "Yes" },
+      { id: "bands-no", label: "No" },
+    ],
+  },
+  {
+    id: "fins",
+    question: "How do the fins look?",
+    answers: [
+      { id: "fins-uniform", label: "Same color as the body" },
+      { id: "fins-light", label: "Lighter / pale edges or clear fin membranes" },
+    ],
+  },
+  {
+    id: "jaw",
+    question: "Mouth and jaw?",
+    answers: [
+      { id: "jaw-small", label: "Small mouth, jaw does not reach the eye" },
+      { id: "jaw-big", label: "Large mouth, jaw reaches past the eye" },
+    ],
+  },
+  {
+    id: "size",
+    question: "About how long?",
+    answers: [
+      { id: "size-small", label: "Under 12 in" },
+      { id: "size-mid", label: "12–24 in" },
+      { id: "size-big", label: "Over 24 in" },
+    ],
+  },
+];
+
+/**
+ * Trait affinity: 1 = the trait is characteristic, 0 = the trait rules the species out
+ * for practical purposes. Missing keys read as 0.5 (no information either way).
+ */
+export interface RockfishProfile {
+  readonly speciesId: string;
+  readonly commonName: string;
+  readonly scientificName: string;
+  /** Schematic swatch colors for the honest "not a photo" visual. */
+  readonly swatch: { readonly base: string; readonly accent: string; readonly pattern: "plain" | "spots" | "blotches" };
+  readonly keyFeatures: readonly string[];
+  readonly similarTo: readonly string[];
+  /** True when the pack or CCR marks zero-retention / no-take. */
+  readonly noRetention: boolean;
+  readonly traits: Partial<Record<TraitAnswer, number>>;
+}
+
+export const ROCKFISH_PROFILES: readonly RockfishProfile[] = [
+  {
+    speciesId: "vermilion_rockfish",
+    commonName: "Vermilion rockfish",
+    scientificName: "Sebastes miniatus",
+    swatch: { base: "#c0392b", accent: "#7b241c", pattern: "spots" },
+    keyFeatures: [
+      "Body red to orange-red with faint dark mottling or tiny brown spots",
+      "Fins reddish, often with darker margins on young fish",
+      "Small mouth; jaw does not reach past the eye",
+      "Usually 12–20 inches in SoCal catches",
+    ],
+    similarTo: ["canary_rockfish", "yelloweye_rockfish", "cowcod"],
+    noRetention: false,
+    traits: { "red-orange": 1, "spots-yes": 1, "spots-no": 0.3, "bands-no": 1, "jaw-small": 1, "size-mid": 1, "size-big": 0.4, "size-small": 0.4, "fins-uniform": 1 },
+  },
+  {
+    speciesId: "canary_rockfish",
+    commonName: "Canary rockfish",
+    scientificName: "Sebastes pinniger",
+    swatch: { base: "#e67e22", accent: "#fdf2e9", pattern: "plain" },
+    keyFeatures: [
+      "Bright orange body with a gray zone along the lateral line",
+      "Underside of the jaw and fin edges often pale",
+      "Deeply forked tail",
+      "Can reach 30 inches; most caught are smaller",
+    ],
+    similarTo: ["vermilion_rockfish", "yelloweye_rockfish"],
+    noRetention: false,
+    traits: { "red-orange": 1, "spots-no": 1, "spots-yes": 0.1, "bands-no": 1, "fins-light": 1, "jaw-small": 0.7, "size-mid": 1, "size-big": 0.7 },
+  },
+  {
+    speciesId: "yelloweye_rockfish",
+    commonName: "Yelloweye rockfish",
+    scientificName: "Sebastes ruberrimus",
+    swatch: { base: "#d35400", accent: "#f1c40f", pattern: "plain" },
+    keyFeatures: [
+      "Bright orange-red with a distinctly YELLOW EYE",
+      "Latural line in a pale stripe; adults often have raspy head spines",
+      "Big, deep-bodied fish — commonly over 24 inches",
+      "PROHIBITED — no retention at any time in California",
+    ],
+    similarTo: ["canary_rockfish", "vermilion_rockfish", "cowcod"],
+    noRetention: true,
+    traits: { "red-orange": 1, "spots-no": 1, "spots-yes": 0.1, "bands-no": 1, "jaw-small": 0.6, "size-big": 1, "size-mid": 0.5, "fins-uniform": 1 },
+  },
+  {
+    speciesId: "copper_rockfish",
+    commonName: "Copper rockfish",
+    scientificName: "Sebastes caurinus",
+    swatch: { base: "#7e5109", accent: "#f0b27a", pattern: "blotches" },
+    keyFeatures: [
+      "Olive-brown with coppery or yellowish blotches on the back and sides",
+      "Rear two-thirds of the lateral line noticeably lighter",
+      "Spots/blotches, not plain",
+      "Most under 24 inches",
+    ],
+    similarTo: ["gopher_rockfish", "olive_rockfish"],
+    noRetention: false,
+    traits: { brown: 1, "pink-copper": 0.8, "spots-yes": 1, "spots-no": 0.1, "bands-no": 1, "jaw-small": 0.8, "size-mid": 1, "size-small": 0.6, "fins-uniform": 0.8 },
+  },
+  {
+    speciesId: "bocaccio",
+    commonName: "Bocaccio",
+    scientificName: "Sebastes paucispinis",
+    swatch: { base: "#a04000", accent: "#d5caca", pattern: "plain" },
+    keyFeatures: [
+      "Olive-orange to brownish, often with a pinkish cast",
+      "Very large mouth — the lower jaw juts past the eye",
+      "Long, lean body compared with most rockfish",
+      "Often 20+ inches; big ones are memorable",
+    ],
+    similarTo: ["vermilion_rockfish", "cowcod"],
+    noRetention: false,
+    traits: { brown: 0.8, "red-orange": 0.5, "spots-no": 1, "bands-no": 1, "jaw-big": 1, "jaw-small": 0, "size-big": 1, "size-mid": 0.8, "fins-uniform": 0.7 },
+  },
+  {
+    speciesId: "blue_rockfish",
+    commonName: "Blue rockfish",
+    scientificName: "Sebastes mystinus",
+    swatch: { base: "#1f3a93", accent: "#5d6d7e", pattern: "plain" },
+    keyFeatures: [
+      "Blue-black to slate, often with a blue sheen on the fins",
+      "Small mouth, slim body, small scales",
+      "Rarely over 21 inches; common at 10–16",
+      "Schools over reefs in midwater",
+    ],
+    similarTo: ["black_rockfish", "olive_rockfish"],
+    noRetention: false,
+    traits: { "black-blue": 1, brown: 0.2, "spots-no": 1, "bands-no": 1, "jaw-small": 1, "size-small": 0.8, "size-mid": 1, "fins-uniform": 1 },
+  },
+  {
+    speciesId: "black_rockfish",
+    commonName: "Black rockfish",
+    scientificName: "Sebastes melanops",
+    swatch: { base: "#17202a", accent: "#808b96", pattern: "plain" },
+    keyFeatures: [
+      "Dark gray to black, often with a lighter belly",
+      "Large mouth with the jaw reaching to about mid-eye",
+      "Fins uniformly dark",
+      "Common mid-teens to low-20s inches",
+    ],
+    similarTo: ["blue_rockfish", "olive_rockfish"],
+    noRetention: false,
+    traits: { "black-blue": 1, brown: 0.3, "spots-no": 1, "spots-yes": 0.2, "bands-no": 1, "jaw-big": 0.6, "size-mid": 1, "fins-uniform": 1 },
+  },
+  {
+    speciesId: "olive_rockfish",
+    commonName: "Olive rockfish",
+    scientificName: "Sebastes serranoides",
+    swatch: { base: "#6e6702", accent: "#aab7b8", pattern: "plain" },
+    keyFeatures: [
+      "Olive-brown above, sharply lighter toward the belly",
+      "Fin membranes often pale/clear at the edges",
+      "Jaw reaches about mid-eye",
+      "Most under 20 inches",
+    ],
+    similarTo: ["black_rockfish", "blue_rockfish", "copper_rockfish"],
+    noRetention: false,
+    traits: { brown: 1, "black-blue": 0.3, "spots-no": 1, "bands-no": 1, "fins-light": 0.9, "jaw-big": 0.4, "size-mid": 1, "size-small": 0.5 },
+  },
+  {
+    speciesId: "gopher_rockfish",
+    commonName: "Gopher rockfish",
+    scientificName: "Sebastes carnatus",
+    swatch: { base: "#935116", accent: "#f5b7b1", pattern: "blotches" },
+    keyFeatures: [
+      "Olive-brown with pinkish or white blotches, often a pink cast on the lips",
+      "Squat, thick-bodied fish",
+      "Small — most 8–15 inches",
+      "Clings tight to structure",
+    ],
+    similarTo: ["copper_rockfish", "olive_rockfish"],
+    noRetention: false,
+    traits: { brown: 1, "spots-yes": 1, "spots-no": 0.1, "bands-no": 1, "jaw-small": 0.9, "size-small": 1, "size-mid": 0.6, "fins-uniform": 0.7 },
+  },
+  {
+    speciesId: "cowcod",
+    commonName: "Cowcod",
+    scientificName: "Sebastes levis",
+    swatch: { base: "#e59866", accent: "#fdfefe", pattern: "plain" },
+    keyFeatures: [
+      "Salmon-pink to orange-red, plain-bodied with notably large scales",
+      "Heavy, deep body and a big mouth",
+      "Adults are big — over 24 inches is normal",
+      "PROHIBITED — no retention at any time in California",
+    ],
+    similarTo: ["yelloweye_rockfish", "vermilion_rockfish", "bocaccio"],
+    noRetention: true,
+    traits: { "red-orange": 0.9, "pink-copper": 0.8, "spots-no": 1, "bands-no": 1, "jaw-big": 0.6, "size-big": 1, "size-mid": 0.3, "fins-uniform": 1 },
+  },
+];
+
+export interface IdCandidate {
+  readonly profile: RockfishProfile;
+  /** Share of the weighted vote across candidates, 0–100, rounded. */
+  readonly confidencePct: number;
+}
+
+/**
+ * Score answers down to a ranked list. Multiplies affinities so one ruling trait pulls
+ * hard; a "not sure" answer simply isn't in the list. Percentages are relative shares
+ * of the surviving pool — they answer "which is likelier", never "identification certain".
+ */
+/** Question ids sharing a trait family — a strongly-signaled family means a missing
+    affinity for a CONTRADICTING answer is evidence against, not "no information". */
+const QUESTION_GROUPS: readonly (readonly TraitAnswer[])[] = [
+  ["red-orange", "brown", "black-blue", "pink-copper", "mixed"],
+  ["spots-yes", "spots-no"],
+  ["bands-yes", "bands-no"],
+  ["fins-uniform", "fins-light"],
+  ["jaw-small", "jaw-big"],
+  ["size-small", "size-mid", "size-big"],
+];
+
+function affinityFor(profile: RockfishProfile, answer: TraitAnswer): number {
+  const affinity = profile.traits[answer];
+  if (affinity !== undefined) return affinity;
+  const group = QUESTION_GROUPS.find((g) => g.includes(answer));
+  if (group) {
+    const strongest = Math.max(...group.map((a) => profile.traits[a] ?? 0));
+    // The species is strongly some OTHER option in this family (e.g. clearly red-orange,
+    // and the angler answered black-blue): that counts against it.
+    if (strongest >= 1) return 0.15;
+  }
+  return 0.5;
+}
+
+export function identifyRockfish(answers: readonly TraitAnswer[]): readonly IdCandidate[] {
+  const scored = ROCKFISH_PROFILES.map((profile) => {
+    let score = 1;
+    let answered = 0;
+    for (const answer of answers) {
+      score *= affinityFor(profile, answer);
+      answered += 1;
+    }
+    // No answers at all → uniform field, which is what "no information" should read as.
+    return { profile, score: answered === 0 ? 1 : score };
+  });
+  const total = scored.reduce((sum, s) => sum + s.score, 0) || 1;
+  return scored
+    .map((s) => ({ profile: s.profile, confidencePct: Math.round((s.score / total) * 100) }))
+    .sort((a, b) => b.confidencePct - a.confidencePct);
+}
+
+/**
+ * §6 gate: any candidate above the warning floor that the law says no-retention on.
+ * The floor is 5% — one-in-twenty of the surviving pool: low enough to catch an orange
+ * red-flag early, high enough that a "clearly not that fish" (small, black, plain) does
+ * not cry wolf and teach the angler to ignore the banner.
+ */
+export const RESTRICTED_WARNING_PCT = 5;
+
+export function restrictedIn(candidates: readonly IdCandidate[]): readonly IdCandidate[] {
+  return candidates.filter(
+    (c) => c.profile.noRetention && c.confidencePct >= RESTRICTED_WARNING_PCT,
+  );
+}
+
+/** Regulation linkage: only species the pack actually covers produce a card link. */
+export function hasVerifiedRules(speciesId: string): boolean {
+  return speciesInPack().includes(speciesId) || SOCAL.groups.some((g) => g.memberSpeciesIds.includes(speciesId));
+}

--- a/src/features/regulations/types.ts
+++ b/src/features/regulations/types.ts
@@ -1,0 +1,116 @@
+/**
+ * Regulations feature types — the offline-legal-reference vocabulary (founder spec
+ * "Fishing Regulations, Fish Identification & Offline Legal Reference").
+ *
+ * Shapes mirror the v1 schema (`20260901230000` reg_pack/reg_area/reg_group/reg_rule)
+ * so the pack can move from app bundle to IDB/synced rows without a remodel: these
+ * interfaces read the same as the columns. The bundle is the offline floor (ADR 004
+ * pattern: speech-first data duplicated in TypeScript, like the species vocabulary).
+ */
+
+export type RuleKind =
+  | "season"
+  | "bag_limit"
+  | "possession_limit"
+  | "min_size"
+  | "max_size"
+  | "gear"
+  | "prohibited"
+  | "note";
+
+export type SizeMeasure = "total_length" | "fork_length" | "alternate_total_length";
+
+/** Founder spec §3 mode selector; CDFW groundfish law only distinguishes boat/shore/diver. */
+export type FishingMode = "boat" | "kayak" | "shore" | "spearfishing";
+/** The legal platform bucket a mode maps onto. Kayak is a vessel for groundfish purposes. */
+export type PlatformScope = "boat" | "shore" | "diver";
+
+export interface RegArea {
+  readonly id: string;
+  readonly authority: string;
+  readonly kind: "ocean_region" | "groundfish_management_area" | "conservation_area";
+  readonly name: string;
+  /** Simplified WGS84 [lng, lat] outer ring, or null until mapped. Honest about simplification. */
+  readonly polygon: readonly (readonly [number, number])[] | null;
+  readonly sourceUrl: string;
+  readonly verifiedAt: string;
+  readonly notes?: string;
+}
+
+export interface RegGroup {
+  readonly id: string;
+  readonly name: string;
+  readonly memberSpeciesIds: readonly string[];
+}
+
+export interface RegRule {
+  readonly id: string;
+  readonly speciesId: string | null;
+  readonly regGroupId: string | null;
+  readonly regAreaId: string;
+  readonly kind: RuleKind;
+  readonly seasonStart: string | null;
+  readonly seasonEnd: string | null;
+  readonly bagDaily: number | null;
+  readonly possessionLimit: number | null;
+  readonly bagSharesWithGroup: boolean;
+  readonly minSizeIn: number | null;
+  readonly maxSizeIn: number | null;
+  readonly sizeMeasure: SizeMeasure | null;
+  readonly platformScope: PlatformScope | null;
+  readonly depthNote: string | null;
+  /** The agency's own sentence. When typed fields and this disagree, this wins. */
+  readonly verbatim: string;
+  readonly checkInseason: boolean;
+  readonly sourceUrl: string;
+  readonly sourceTitle: string;
+  readonly sourceUpdatedAt: string | null;
+  readonly verifiedAt: string;
+  readonly staleAfterDays: number;
+  readonly packVersion: number;
+}
+
+export interface RegPack {
+  readonly id: string;
+  readonly version: number;
+  readonly publishedAt: string;
+  readonly notes: string;
+}
+
+export interface SocalPack {
+  readonly pack: RegPack;
+  readonly areas: readonly RegArea[];
+  readonly groups: readonly RegGroup[];
+  readonly rules: readonly RegRule[];
+}
+
+// ---------------------------------------------------------------------------
+// What the UI answers with (founder §4 + §15: verdict first, then limits, then law)
+// ---------------------------------------------------------------------------
+
+export type KeepVerdict = "keep" | "release" | "conditional";
+
+export interface RegulationCard {
+  readonly speciesId: string;
+  readonly verdict: KeepVerdict;
+  /** One plain sentence the app is willing to stand behind, e.g. "Season closed today". */
+  readonly verdictReason: string;
+  readonly bagDaily: number | null;
+  readonly possessionLimit: number | null;
+  readonly minSizeIn: number | null;
+  readonly sizeMeasure: SizeMeasure | null;
+  readonly seasonText: string;
+  readonly depthText: string | null;
+  readonly specialRules: readonly string[];
+  /** Group-combination reading ("5 in any combination of Paralabrax basses"), when the
+   *  law speaks in complexes. */
+  readonly groupNote: string | null;
+  readonly sourceUrl: string;
+  readonly sourceTitle: string;
+  readonly sourceUpdatedAt: string | null;
+  readonly verifiedAt: string;
+  readonly packVersion: number;
+  /** Founder §23: stale data is still shown, but only ever behind this banner. */
+  readonly staleDays: number;
+  readonly isStale: boolean;
+}

--- a/src/features/shell/components/shell-nav.test.ts
+++ b/src/features/shell/components/shell-nav.test.ts
@@ -9,8 +9,9 @@ describe("shell navigation", () => {
     expect(hrefs.indexOf("/setup")).toBe(hrefs.indexOf("/log") - 1);
   });
 
-  it("stays at five destinations — a sixth needs a decision, not a patch", () => {
-    expect(SHELL_ROUTES.length).toBeLessThanOrEqual(5);
+  it("stays at six destinations — the sixth ('Rules') was the founder's call (spec §16); a seventh still needs a decision, not a patch", () => {
+    expect(SHELL_ROUTES.length).toBeLessThanOrEqual(6);
+    expect(SHELL_ROUTES).toContainEqual({ href: "/regulations", label: "Rules" });
   });
 
   it("links to the tide chart and does not advertise unfinished Spots or the unlinked Learn & Build route", () => {

--- a/src/features/shell/components/shell-nav.tsx
+++ b/src/features/shell/components/shell-nav.tsx
@@ -16,20 +16,23 @@ import { usePathname } from "next/navigation";
  * the optional quick-mark action are pinned as one unit and cannot overlap each other.
  */
 /**
- * Five destinations is the ceiling, and this is the fifth. Ordered by how the day runs
- * rather than alphabetically: you plan on the Calendar, rig on Setup, log what you catch,
- * check the Tide, and visit Settings rarely. Setup sits beside Log because the two are
- * used together — configure once, log repeatedly.
+ * Six destinations now, by founder decision (regulations spec §16, 2026-09-01): "Rules"
+ * earns the spot between Tide and Settings because a-law question beats a settings visit
+ * when a fish flops in the well. The old ceiling ("five, and the fifth is the talk")
+ * lived in this comment block and in shell-nav.test.ts; both were updated together —
+ * the guard below is a decision record, not a patch over.
  *
- * At 320px five labels only fit because they are short. "Settings" is the longest and it
- * is the one that could be truncated to an icon first if a sixth ever arrives; adding a
- * sixth is a conversation, not a patch.
+ * "Rules" is deliberately the shortest label: six one-word labels still clear 320px
+ * with min-h-touch-floor taps, which keeps the spec's "must not crowd the bar" clause.
+ * Ordered by how the day runs: plan on the Calendar, rig on Setup, log what you catch,
+ * check the Tide, check the Rules, visit Settings rarely.
  */
 export const SHELL_ROUTES = [
   { href: "/", label: "Calendar" },
   { href: "/setup", label: "Setup" },
   { href: "/log", label: "Log" },
   { href: "/tides", label: "Tide" },
+  { href: "/regulations", label: "Rules" },
   { href: "/settings", label: "Settings" },
 ] as const;
 


### PR DESCRIPTION
Implements the founder spec **Fishing Regulations, Fish Identification & Offline Legal Reference**, Phases 3+4+5 as one PR per the locked 2026-09-01 decision (`everything-3-5`), with the §8–§10 interactive map shipping now per `map-now` (this overrides the architecture doc's earlier v1 no-map stance — the doc is updated in this PR to match shipped reality, dated).

## What an angler gets offshore
- **/regulations** — "My current regulations" header: area (GPS-tap → polygon → home-region fallback), date, mode, dataset stamp with versions.
- **/regulations/species + /[id]** — searchable species list with KEEP / CHECK FIRST / RELEASE words on the row edge; tap for the full card: verdict banner (color AND word), bag/size/season facts, shared-bag + special-rules copy, official text AND provenance block (agency, source URL, effective/verified dates, pack version), stale banner past its horizon. Never folklore: no verified data renders **No verified data**.
- **/regulations/rockfish** — six-question identifier, "Not sure" everywhere, confidence language ("Likely vermilion — 48%"), the §6 **Possible Restricted Species — Verify Before Retaining** banner, compare-two rows, direct links to each species' rules card.
- **/regulations/boundaries** — today's groundfish ribbon read from the same engine (CLOSED / INSHORE-ONLY today), CCA "you are inside" alert, boundary-proximity call-out, Leaflet map with **no tile layer** (offline-true by construction), layer toggles per spec §10.
- **/regulations/offline** — pack inventory + source links + the floor story (bundle now; IndexedDB/SQLite later are additive, spec §11).
- **Nav: sixth destination "Rules"** per spec §16. The shell-nav guard that said "five is the ceiling, a sixth is a decision not a patch" is updated to six with the decision comment attached.

## Architecture notes
- Pure engine (`reg-engine`, `geospatial`, `rockfish-id`) fully unit-tested: **37 tests in the feature**; verdict ladder prohibited → season-closed → boundary-conditional → check-in-season conditional → keep; group-scope `prohibited` rows advise, never release members (zero-retention quartet handled correctly); RCG shore/diver season exemption is data-driven and removes those rows from the verdict pool, not just the copy.
- **Bundle↔SQL parity is test-guarded** (`reg-data-parity.test.ts`): every bundle rule's verbatim must exist in the migrations; three declared exceptions (4 species-scoped zero-retention rows + conservation-area geometry) await the pack-v2 reconciliation migration — v1 SQL keeps `boundary_geojson` null by design (arch §3). Bundle-only rockfish species ids do not FK into `species` (regulations ids are strings; text[] group keys carry the join).
- `.env.local` placeholders for NEXT_PUBLIC_SUPABASE_* came from the Supabase project on disk — `getSupabase()` still degrades gently when missing.

## Gates
398/398 unit tests · tsc clean · eslint clean · `next build` green · dev smoke: all six new routes 200.

## Out of scope (declared in-page + in the doc)
RCA/MPA geometry is orientation-grade (CFR waypoint text and CDFW's official map linked as the legal statements); the RCA-approach indicator is distance math, not survey; the full MPA inventory stays with CDFW (spec §10's "small overlays only" applied).