### PR TITLE
fix(fish-legal): unbreak main — boundary map colour tokens

### DIFF
--- a/docs/team/meetings/2026-09-02-wednesday-team-meeting.md
+++ b/docs/team/meetings/2026-09-02-wednesday-team-meeting.md
@@ -1,0 +1,321 @@
+# Fish Logbook — Wednesday Morning Team Meeting
+
+**Date:** 2026-09-02 · **Facilitator:** `coo` · **Compared against:**
+[2026-09-01 September staff meeting](2026-09-01-september-staff-meeting.md) ·
+**Record type:** permanent, reviewable
+
+**Ground rule, unchanged from yesterday:** every claim below was checked against the
+working tree at commit `87ea99d` this morning. Where a check was run, its output is
+quoted. Where something is unverified, it says so. Yesterday's meeting is treated as a
+scorecard to be marked, not a document to be re-agreed with.
+
+---
+
+## 1. The 24-hour scorecard — yesterday's plan vs. what happened
+
+Yesterday's meeting closed with five September priorities and a "Now — this week" table of
+three items. Here is that table, marked honestly.
+
+| Yesterday's **Now** (top 3) | State this morning |
+|---|---|
+| 1. Provision hosted Supabase, apply migrations, wire auth, retire `LOCAL_ANGLER_ID` | **Not started.** `LOCAL_ANGLER_ID` still hard-coded at `src/features/catches/store.ts:214`, used across four files. No provisioning evidence. |
+| 2. Outbox flusher (push/pull/conflict); fix the "Backed up" string in the same lane | **Not started.** `src/core/sync/store.ts` still does not exist. `readBackupState()` still returns `{ kind: "settled" }` unconditionally, so every screen still says **"Backed up"** and it is still false. |
+| 3. Live NOAA CO-OPS fetch — **before 2026-09-04** | **Not started.** `tide-fixture.ts` still in place, window still ends 2026-09-04 23:00 UTC. **Two days.** |
+
+Zero of three. And yet this was not an idle 24 hours — it was one of the most productive
+on record. That contradiction is the meeting.
+
+### What *did* ship (27 commits, PRs #18, #20, #21, #22, #23, #24, #25 merged)
+
+| Shipped | Was it on yesterday's list? |
+|---|---|
+| Month calendar home, day pages, catch markers on the tide curve (#20) | **Yes** — "High / Calendar + day page (D23)". The spine's front half. |
+| Historical catch slices: backfill entry, conditions capture, Catch Detail pages, tide snapshots (#21/#22) | **Yes** — "Medium / backfill with the after-the-fact flag (D24)". |
+| Expansion foundations: regions, freshwater types, vocabulary parity, region-driven species (#18) | Partly — vocabulary work was an owner item. |
+| Tackle taps-only quick inventory | No. |
+| **Fish Legal** — 8 routes (`/fish-legal` + species, limits, alerts, offline, rockfish, boundaries), CA SoCal/NorCal/freshwater packs, Florida, jurisdiction chips, CDFW photos, Leaflet boundary map (#23, #24, #25) | **No.** Not in D21–D25, not on any Now list. Six new migrations underneath it. |
+
+So: the calendar and the backfill — two genuine spine items — landed. Good work, and the
+part of yesterday's plan that moved is the part that mattered second-most.
+
+### Routes: real vs. still a stub *(checked file by file this morning)*
+
+- **Real:** `/` (renders `MonthCalendar`), `/day/[date]` (renders `DayView`),
+  `/catch/[id]` (renders `CatchDetailClient`), `/log`, `/tides`, `/tackle`, `/setup`,
+  `/settings`, and all 8 `/fish-legal` routes.
+- **Still placeholder text:** `/trip/[id]` (12 lines), `/spots` (12 lines),
+  `/spots/[id]`.
+
+That second list matters more than it looks. **`/trip/[id]` being a stub means trip
+start/end still does not exist, which means `analytics.trip_effort` still has no rows
+under it.** `biostat`'s single loudest point yesterday — *"we are recording numerators
+with no denominator; every catch we log is statistically inert"* — is unchanged this
+morning. The product's stated differentiator is still the one thing not built.
+
+---
+
+## 2. The one genuinely new fact: `main` is red
+
+This was not true yesterday and nobody knows it yet.
+
+```
+$ npm run verify
+tripwires: 10 problem(s)
+```
+
+All ten are in one file, `src/features/fish-legal/components/boundary-leaflet.tsx`: raw
+colour literals in a component, which ADR 005 §2 forbids (`#0b2a3a`, `#7dd3fc`, `#f59e0b`,
+`#ef4444`, `#a78bfa`, `#111827`, `#fb923c`). The rest of the suite is healthy —
+**412 tests passing across 37 files, `tsc --noEmit` clean, lint 3 warnings / 0 errors** —
+which is precisely why this slipped through: the tests were never the gap.
+
+Two things follow, and they are the whole argument for today.
+
+1. **The project's own definition of done is failing on `main`, and it failed silently for
+   a day.** Vercel builds every PR, so a broken build would have been caught. Tokens and
+   tripwires run on nobody's machine.
+2. **This is the bill for shipping a large surface at full speed with no gate.** Not lost
+   design hours — an undetected red `main`, in exactly the newest code. `test-agent` and
+   `head-dev` both asked for CI yesterday and were sequenced behind other work. Twenty-four
+   hours later the predicted failure arrived, in the predicted place.
+
+Also still missing from yesterday's own workflow fixes: **`docs/team/STATUS.md` was never
+created** (two meetings running), `.github/workflows/` still does not exist, `docs/legal/`
+still does not exist, no Playwright, and `docs/team/BACKLOG.md` is stale — refreshed
+2026-08-28, its **Now** still lists the calendar work that shipped yesterday.
+
+---
+
+## 3. `coo` — the direction, stated plainly
+
+**Failure mode 7(b) tripped a second time, in the same week it was first flagged.** A
+founder-directed surface (Fish Legal, ~8 routes, 3 PRs, 6 migrations) arrived and shipped
+fast and well, while none of the three durability priorities moved. Scope is the owner's
+call and this is not a request to reverse it — Fish Legal is real, useful work. But the
+pattern is now the pattern twice, and yesterday it cost design hours where today it cost a
+red `main`.
+
+**Today's direction: stop adding surfaces and make the thing durable.** Nothing in today's
+list is a new feature. The fish-legal work does not re-sequence the product thesis — it
+added surface area to a foundation that still leaks data, still has no safety net, and
+still cannot record the denominator.
+
+The tide fixture decides the ordering. It expires **2026-09-04 23:00 UTC**. Today is the
+last day with a full buffer day behind it.
+
+---
+
+## 4. Today's to-do
+
+| # | Item | Owner | Tier | Dependency | Why it is today |
+|---|---|---|---|---|---|
+| 1 | ~~Fix the 10 tripwire violations in `boundary-leaflet.tsx` — tokens per ADR 005 §2~~ **DONE in this session** | `head-dev` | LOW | none | `main` was red; every merge on top of it was an undetectable regression |
+| 2 | `.github/workflows/verify.yml` — `npm run verify` on every PR, then required on `main` | `test-agent` | LOW | merge after #1 | The exact gap that let #1 happen silently. Not a background item any more |
+| 3 | Live NOAA CO-OPS fetch replacing the fixture | `head-dev` + `biostat` | MEDIUM | none — single swap point, `tide-series.ts` (ADR 006 §2) | Fixture dies 2026-09-04. Must be in a near-mergeable PR by end of day |
+| 4 | `readBackupState()` — stop asserting "Backed up"; say "Saved on this device" | `head-dev` | LOW | none | Flagged as the most serious defect in the repo two meetings running. Four lines |
+| 5 | Close or re-scope PR #26 (regulations, design-only) | `git-integrator` | LOW | diff vs. #23/#24/#25 | Almost certainly superseded by the code that already merged |
+| 6 | Close PR #17, folded into #4's fresh fix | `git-integrator` | LOW | #4 merged | Open since 2026-09-01 19:41Z; don't resurrect a day-stale branch |
+
+**Explicitly waiting — do not start today:** Supabase provisioning, auth wiring, the
+flusher, trip start/end, day journal, spot picking, tackle-on-offline-store,
+tackle-linked-to-catch, pressure capture, Playwright, privacy policy, `HANDOFF.md`
+correction. All still Next. None moot.
+
+**First in line tomorrow:** `docs/team/STATUS.md` (`coo`, ~40 lines) and a `BACKLOG.md`
+refresh — both are now two meetings overdue and both exist to stop precisely the drift
+this meeting is documenting.
+
+### Process change, effective now
+
+1. **CI lands today**, not as a "running alongside" item.
+2. **Once green, `verify` — not `test` — is the required check on `main`.** No exceptions
+   for "it's just a new surface, the tests still pass." The tests did still pass. That was
+   the problem.
+
+---
+
+## 5. `ceo` — thinking outside the box: features that add real value
+
+Constraint applied throughout: the parking lot already holds the obvious ideas (bite score,
+alerts, photos, export, widget, heat map, personal bests, solunar, swell). None are
+re-served here unless materially reframed. The bias is **compound an asset we already own
+rather than add a noun** — four of the five below are joins on things already built.
+
+> **The finding underneath this section:** two of these are not new features at all. They
+> are read surfaces for write-side work that already shipped and currently has **zero**
+> payoff.
+
+### #1 — "The season, by the numbers the law would ask for" · **build this first** · FREE
+*"How many keepers this season, how many I had to release by size, and was anything out of
+season — without me looking it up."*
+
+Fish Legal answers one question at a time, at the moment of the catch. Nobody has asked it
+the question anglers actually carry: *am I generally clean, and did I mess up?* That is
+unanswerable today **even though the app has been recording the answer since yesterday.**
+
+Verified this morning: `src/features/fish-legal/regulation-snapshot.ts` stamps a frozen
+legal verdict — pack id/version, verdict, size and bag numbers, `evaluated_date` — onto
+every catch at log time (`src/features/catches/create.ts:409`), into the
+`catch.regulation_snapshot jsonb` column live since migration `20260902090000`. **Pure
+write-side cost, no read side.** This is a `GROUP BY` over rows that already exist, in a
+panel inside an existing screen — not a new route, not a nav item, no new data collection.
+
+- **Cost:** small. **Risk:** the wording must stay strictly *"what the record shows"* and
+  never *"proof of compliance"* — the snapshot design is "what did we know then," not
+  "what is true now." Counsel signs off on wording; it computes nothing new, so the
+  liability surface is narrower than the regulations feature already shipped.
+
+### #2 — "What's actually working" — rig/lure catch report · FREE (rate version: see below)
+*"The Tady 45 has produced 4 fish this trip; the dropper loop none."*
+
+Yesterday's #3 join (tackle ↔ catch), sharpened: **do not build a gear-picker at all.**
+`trip_rig` / `trip_rig_gear` (core schema, append-only per D21a) already model gear as a
+standing configuration a catch *inherits*. Zero extra taps with wet hands, which beats any
+report screen. Only the read side is missing.
+
+- **Cost:** medium. Raw counts are cheap today; a **rate** (fish per hour) needs
+  `analytics.trip_effort` populated, which needs trip start/end — the item that keeps not
+  getting built. **Risk:** shipping the counts version as a fourth screen repeats this
+  week's mistake. It is a panel, not a surface.
+
+### #3 — "On this day, in past years" — calendar recall card · FREE
+*"Last September 2nd you caught yellowtail at West End on an incoming tide. This year,
+nothing yet."*
+
+A deliberate collapse of two parking-lot items — "find days like today" (C1) and
+"season calendar across years" (C3) — with none of their cost or risk. C1 needs the
+correlation engine (V2, gated on P6 and the O4 evidence threshold) because it searches
+*similar conditions*. A same-calendar-day lookup **makes no statistical claim at all**: it
+is a join on month-day across years, shown as a memory, not a prediction. Anglers already
+think this way; the product cannot currently answer even that.
+
+- **Cost:** small, and near-zero marginally now the calendar exists. **Risk:** it is one
+  scope-creep step from becoming C1. Keep it literally date-based or it silently turns into
+  the paid feature it was designed to avoid.
+
+### #4 — Within-trip tide/catch pattern (not cross-trip correlation) · **free/paid unresolved**
+*"All three fish today came within 40 minutes of the tide turning"* — shown only for trips
+that happened, never predicted forward.
+
+Bite score is V2 and gated on O4 precisely because cross-trip correlation at small n is
+easy to get honestly wrong. A **within-one-trip** statement sidesteps that: n = this trip's
+own catches against this trip's own tide curve (`condition_snapshot_tide_curve`, already
+schema'd), verifiable by the angler on the spot, no aggregation, no confidence interval to
+misrepresent.
+
+- **Cost:** medium; needs a trip boundary, so it sequences *behind* trip start/end.
+- **Flagged, not resolved:** this is `ceo`'s own reframe of an explicitly parked idea, and
+  reframes of parked ideas deserve suspicion. **`biostat` owns whether the within-trip
+  framing is honestly different, and D14 free/paid here is a founder call.**
+
+### #5 — MPA / closed-water check at *trip start*, not just at the catch · FREE if built
+*"You're inside a marine protected area — nothing you catch here can be kept."*
+
+Fish Legal only fires when a species is picked at catch time. **A blank trip fished
+entirely inside a closed zone is invisible to the app** — the denominator blind spot,
+applied to legal risk. Repoints the Leaflet boundary map from decorating a spot page to
+gating a trip.
+
+- **Cost:** medium-high — needs trip start UI, point-in-polygon against boundaries whose
+  authority nobody has verified for this purpose, and counsel review before the app claims
+  "you are in a closed zone." A false negative is worse here than for size/bag, because
+  presence is not something the angler chose to log. **Later, counsel-gated.**
+
+### Trap, named so nobody proposes it in month two
+
+**Gear-legality cross-checking** — "is this rig legal here": barbless-only zones,
+hook-count limits, treble bans. It is the obvious next step from #1 + `catch_gear`, and it
+is a trap. The packs are modelled around species/size/bag; a wrong *"your rig is legal
+here"* is worse than no claim, exactly as ROADMAP Part 3 warns for fish ID. It would also
+mean expanding the regulations data model itself. **Not without a dedicated `counsel` +
+pack-authoring pass.**
+
+### Free vs. paid (D14)
+
+Free: #1, #3, #5, and #2 in its raw-count form. Unresolved and needing the founder: **#2 as
+a rate** and **#4** — both edge toward "condition matching" under D14's letter while staying
+"your own history" under its spirit. #5 should never be paywalled on principle.
+
+---
+
+## 6. Decisions needed from the owner
+
+Trimmed from yesterday's eight — three are moot or overtaken.
+
+1. **Scope freeze: yes or no, in writing.** Asked for yesterday, understood, and two
+   surfaces shipped anyway. Recommendation: freeze new top-level surfaces until the flusher
+   and trip start/end are both done. *"Understood" is what happened yesterday.*
+2. **Provision Supabase, or authorise `head-dev` to create it and hand back keys.** Still
+   the single biggest unblock. Not today's task; decide this week so tomorrow is not spent
+   waiting.
+3. **The D15 fork** — (a) hold native-only, or (b) reposition the web app as an installable
+   beta. Unchanged, still open, still drifting.
+4. **New:** free/paid boundary for the rig **rate** report and the within-trip tide pattern
+   (§5 #2, #4).
+5. **New:** greenlight the legal-snapshot rollup (§5 #1) as the next feature after the
+   durability work — it is the one idea that needs none of the blocked spine.
+
+**Now moot / dropped from active tracking:** Quick Mark 88px vs 68px (PR #14 merged);
+Apple Developer Program (no Phase 2 code exists — revisit at Phase 2); ontology vocabulary
+red-pen (real, but a standing LOW item, not a decision).
+
+---
+
+## 7. Carried forward unchanged, and worth saying once
+
+- **The denominator is still not built.** `/trip/[id]` is placeholder text.
+  `analytics.trip_effort` has no rows. Every catch logged so far is still statistically
+  inert.
+- **Nothing has ever left the device.** No sync store, no auth, no server round-trip.
+- **Nothing has ever been held in a hand.** Zero real-phone testing, on anything, still.
+- **Evidence in PR bodies is still not reproducible.** No Playwright harness committed.
+
+---
+
+---
+
+## 8. Done during this meeting — item 1, with reproducible evidence
+
+`main` is green again.
+
+Seven design tokens were added to `src/core/design/tokens.json`, named for what they mean
+on the map rather than for their hex value — `map-ocean`, `map-boundary-gma`,
+`map-boundary-rca`, `map-area-closed`, `map-area-protected`, `map-position-stroke`,
+`map-position-fill` — and `boundary-leaflet.tsx` now draws from them. Rendered appearance
+is unchanged: every substitution is the identical colour, and no weight, opacity or
+`dashArray` was touched.
+
+```
+$ npm run verify   →  exit code 0
+tripwires: clean.
+lint: 3 warnings, 0 errors (all pre-existing)
+tsc --noEmit: clean
+Test Files 37 passed (37) · Tests 412 passed (412)
+```
+
+**One thing was checked rather than assumed, which is the point of §2.** The first version
+of this fix passed `var(--color-…)` straight into Leaflet's path options. Leaflet styles
+paths with `setAttribute('stroke', …)`, i.e. SVG *presentation attributes*, and whether
+`var()` resolves there is not obvious. It was tested in the repo's Chromium rather than
+argued about:
+
+```
+path stroke   = rgb(125, 211, 252)   (--color-map-boundary-gma  = #7dd3fc)  ✓
+circle fill   = rgb(251, 146, 60)    (--color-map-position-fill = #fb923c)  ✓
+control fill  = rgb(251, 146, 60)    (literal #fb923c, for comparison)      ✓
+```
+
+It works in Chromium. **It was still changed**, because Chromium is not the engine this
+product is aimed at and WebKit could not be tested here. Leaflet path colours now go
+through a small `tokenColor()` helper that resolves the custom property with
+`getComputedStyle` before Leaflet ever sees it — engine-independent, `tokens.json` still
+the single source of truth. Plain CSS properties (`style.background`) keep `var()`, which
+is safe everywhere.
+
+**Still not verified, and stated plainly per the rule from §2:** nobody has looked at this
+map in a browser. The colours are proven to resolve; the map has not been seen. That check
+belongs with the field protocol and Playwright work, not to an assertion in this document.
+
+---
+
+**Meeting closed.** Next review: end of day today on items 2–4, or at Phase 1's exit test.

--- a/docs/team/worklog/2026-09-02-01-coo.md
+++ b/docs/team/worklog/2026-09-02-01-coo.md
@@ -1,0 +1,34 @@
+### 2026-09-02 | coo (with ceo, head-dev) | ~1h
+
+- Ran the Wednesday morning meeting and wrote it up against yesterday's, marking
+  yesterday's plan as a scorecard instead of re-agreeing with it. Record:
+  `docs/team/meetings/2026-09-02-wednesday-team-meeting.md`.
+- The honest headline: yesterday's top three (Supabase, the flusher, live tide) are all
+  still not started, while 27 commits and seven merged pull requests landed — the calendar
+  and the backfill, which were on the list, plus a whole Fish Legal area with eight new
+  pages, which was not.
+- Found something nobody knew: **the project's own check was failing on `main`.** Ten
+  hard-coded colours in the new boundary map broke a rule we wrote ourselves. All 412 tests
+  passed the whole time, which is exactly why it went unnoticed for a day — the tests were
+  never the gap. There is still no automatic check on a pull request, so nothing caught it.
+- Fixed it. The map now takes its colours from the shared design list instead of
+  hard-coded ones, named for what they mean on the map — ocean, closed area, protected
+  area, your position. The map looks exactly the same; nothing was restyled.
+- Checked one thing instead of assuming it. The first version of the fix handed a
+  stylesheet reference straight to the map library, and it was not obvious that would work.
+  Tested it in a real browser: it does work. Changed it anyway, because the browser we can
+  test here is not the one on an iPhone, and the new version does not depend on the answer.
+- Also corrected two of my own facts from earlier this morning: `/trip/[id]` and `/spots`
+  are still placeholder pages, not real ones. That matters — it means trip start and end
+  still do not exist, so we still cannot record that someone fished and caught nothing,
+  which is the one thing this product is supposed to do better than anyone.
+- `ceo` brought five feature ideas, four of which are joins on things already built rather
+  than new screens. The strongest: we have been stamping a frozen legal verdict onto every
+  catch since yesterday and never showing it back to anyone.
+- Files: `docs/team/meetings/2026-09-02-wednesday-team-meeting.md`,
+  `src/core/design/tokens.json`, `src/app/tokens.generated.css`,
+  `src/features/fish-legal/components/boundary-leaflet.tsx`
+- Next, and still broken: no automatic check on pull requests (today's item 2); the tide
+  screen's data runs out on 2026-09-04, two days away; every screen still tells the angler
+  their data is "Backed up" and it has never left the phone; `docs/team/STATUS.md` still
+  does not exist, two meetings running. Nobody has looked at the boundary map in a browser.

--- a/src/app/tokens.generated.css
+++ b/src/app/tokens.generated.css
@@ -21,6 +21,13 @@
   --color-error-red: #FF8A80;
   --color-error-red-fill: #C1443A;
   --color-focus-ring: #3FC7E0;
+  --color-map-ocean: #0b2a3a;
+  --color-map-boundary-gma: #7dd3fc;
+  --color-map-boundary-rca: #f59e0b;
+  --color-map-area-closed: #ef4444;
+  --color-map-area-protected: #a78bfa;
+  --color-map-position-stroke: #111827;
+  --color-map-position-fill: #fb923c;
 
   --font-ui: var(--font-archivo), 'Helvetica Neue', sans-serif;
   --font-mono: var(--font-ibm-plex-mono), ui-monospace, monospace;
@@ -101,6 +108,13 @@
     --color-error-red: #FF8A80;
     --color-error-red-fill: #C1443A;
     --color-focus-ring: #3FC7E0;
+    --color-map-ocean: #0b2a3a;
+    --color-map-boundary-gma: #7dd3fc;
+    --color-map-boundary-rca: #f59e0b;
+    --color-map-area-closed: #ef4444;
+    --color-map-area-protected: #a78bfa;
+    --color-map-position-stroke: #111827;
+    --color-map-position-fill: #fb923c;
   }
 }
 

--- a/src/core/design/tokens.json
+++ b/src/core/design/tokens.json
@@ -72,6 +72,34 @@
     "focus-ring": {
       "light": "#3FC7E0",
       "dark": "#3FC7E0"
+    },
+    "map-ocean": {
+      "light": "#0b2a3a",
+      "dark": "#0b2a3a"
+    },
+    "map-boundary-gma": {
+      "light": "#7dd3fc",
+      "dark": "#7dd3fc"
+    },
+    "map-boundary-rca": {
+      "light": "#f59e0b",
+      "dark": "#f59e0b"
+    },
+    "map-area-closed": {
+      "light": "#ef4444",
+      "dark": "#ef4444"
+    },
+    "map-area-protected": {
+      "light": "#a78bfa",
+      "dark": "#a78bfa"
+    },
+    "map-position-stroke": {
+      "light": "#111827",
+      "dark": "#111827"
+    },
+    "map-position-fill": {
+      "light": "#fb923c",
+      "dark": "#fb923c"
     }
   },
   "fontSize": {

--- a/src/features/fish-legal/components/boundary-leaflet.tsx
+++ b/src/features/fish-legal/components/boundary-leaflet.tsx
@@ -8,6 +8,23 @@ import { RCA_50FM_LINE, REG_AREAS } from "../reg-data";
 import type { RegArea } from "../types";
 
 /**
+ * Resolve a design token to a concrete colour before handing it to Leaflet.
+ *
+ * Leaflet styles paths with `setAttribute('stroke', …)` / `setAttribute('fill', …)`,
+ * i.e. SVG *presentation attributes*. Chromium resolves `var()` there (checked), but
+ * that is not a safe assumption on WebKit, and WebKit is the engine this product is
+ * aimed at. Resolving here keeps `tokens.json` the single source of truth (ADR 005 §2)
+ * without betting the map's legibility on presentation-attribute `var()` support.
+ *
+ * Plain CSS properties are unaffected — `style.background = "var(--…)"` is safe
+ * everywhere and is left as-is below.
+ */
+function tokenColor(name: string): string {
+  const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  return value || `var(${name})`;
+}
+
+/**
  * The actual Leaflet surface for BoundaryMap — split out so Next can `ssr:false` it
  * (Leaflet reads `window`). No tile layer**: the pack carries its own geometry, and
  * offshore means no network. An ocean-blue panel with the simplified lines is honest
@@ -53,13 +70,13 @@ export default function BoundaryLeaflet({
     // A plain ocean panel instead of tiles. This is a boundary map, not a chart.
     map.createPane("ocean");
     const oceanPane = map.getPane("ocean")!;
-    oceanPane.style.background = "#0b2a3a";
-    hostRef.current.style.background = "#0b2a3a";
+    oceanPane.style.background = "var(--color-map-ocean)";
+    hostRef.current.style.background = "var(--color-map-ocean)";
 
     const gmaArea = areas.find((a) => a.kind === "groundfish_management_area") ?? areas[0];
     layerRefs.current.gma = L.polygon(
       (gmaArea.polygon ?? []).map(([lng, lat]) => [lat, lng] as [number, number]),
-      { color: "#7dd3fc", weight: 2, fillOpacity: 0.08, dashArray: "4 6" },
+      { color: tokenColor("--color-map-boundary-gma"), weight: 2, fillOpacity: 0.08, dashArray: "4 6" },
     )
       .addTo(map)
       .bindTooltip("Southern Management Area (simplified)", { sticky: true });
@@ -67,7 +84,7 @@ export default function BoundaryLeaflet({
     if (showRca) {
       layerRefs.current.rca = L.polyline(
         RCA_50FM_LINE.points.map(([lng, lat]) => [lat, lng] as [number, number]),
-        { color: "#f59e0b", weight: 3, dashArray: "8 6" },
+        { color: tokenColor("--color-map-boundary-rca"), weight: 3, dashArray: "8 6" },
       )
         .addTo(map)
         .bindTooltip("50-fm RCA boundary — simplified waypoints", { sticky: true });
@@ -78,7 +95,7 @@ export default function BoundaryLeaflet({
       .map((area) =>
         L.polygon(
           (area.polygon ?? []).map(([lng, lat]) => [lat, lng] as [number, number]),
-          { color: "#ef4444", weight: 2, fillOpacity: 0.18 },
+          { color: tokenColor("--color-map-area-closed"), weight: 2, fillOpacity: 0.18 },
         )
           .addTo(map)
           .bindTooltip(`${area.name} (simplified)`, { sticky: true }),
@@ -88,7 +105,7 @@ export default function BoundaryLeaflet({
     if (mpa?.polygon) {
       layerRefs.current.mpa = L.polygon(
         (mpa.polygon ?? []).map(([lng, lat]) => [lat, lng] as [number, number]),
-        { color: "#a78bfa", weight: 2, fillOpacity: 0.2 },
+        { color: tokenColor("--color-map-area-protected"), weight: 2, fillOpacity: 0.2 },
       ).bindTooltip(`${mpa.name} (simplified inset)`, { sticky: true });
     }
 
@@ -127,16 +144,16 @@ export default function BoundaryLeaflet({
     if (position) {
       const marker = L.circleMarker([position.lat, position.lng], {
         radius: 7,
-        color: "#111827",
+        color: tokenColor("--color-map-position-stroke"),
         weight: 2,
-        fillColor: "#fb923c",
+        fillColor: tokenColor("--color-map-position-fill"),
         fillOpacity: 1,
       })
         .addTo(map)
         .bindTooltip("YOU ARE HERE", { sticky: true });
       const ring = L.circle([position.lat, position.lng], {
         radius: position.accuracy,
-        color: "#fb923c",
+        color: tokenColor("--color-map-position-fill"),
         weight: 1,
         fillOpacity: 0.06,
       }).addTo(map);
@@ -149,7 +166,7 @@ export default function BoundaryLeaflet({
     <div
       ref={hostRef}
       className="h-72 w-full rounded-lg"
-      style={{ background: "#0b2a3a" }}
+      style={{ background: "var(--color-map-ocean)" }}
       aria-label="Boundary map: management area, RCA line, conservation areas, and your position when GPS is on"
     />
   );


### PR DESCRIPTION
**`main` is currently red.** `npm run verify` fails on it: the Fish Legal boundary map ships ten raw colour literals, which the ADR 005 §2 tripwire rejects.

```
tripwires: 10 problem(s)
  src/features/fish-legal/components/boundary-leaflet.tsx:56   "#0b2a3a"
  src/features/fish-legal/components/boundary-leaflet.tsx:62   "#7dd3fc"
  … 8 more
```

This branch already contained the fix and had no PR open, so it was sitting unmerged while `main` stayed broken. Opening and merging it as-is rather than writing a second fix.

## What it does

- Adds seven map colours to `tokens.json` (`map-ocean`, `map-boundary-gma`, `map-boundary-rca`, `map-area-closed`, `map-area-protected`, `map-position-stroke`, `map-position-fill`), so the map's palette lives where every other colour does.
- Adds a `tokenColor()` resolver in `boundary-leaflet.tsx`. Leaflet styles paths via SVG *presentation attributes*, where `var()` support is not something to bet on in WebKit — the engine this product targets. Resolving the token to a concrete value keeps `tokens.json` the single source of truth without gambling on that. Plain CSS properties are left using `var()`, where it is safe everywhere.
- Also carries the 2026-09-02 team meeting notes and the accompanying COO worklog.

## Verified

Trial-merged onto current `main` (`87ea99d`) locally before opening this:

- `npm run verify` — **green, 412 tests**, tripwires clean (was 10 problems).
- `npm run build` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SN8zV9RF1J5qXXzgzbEru

---
_Generated by [Claude Code](https://claude.ai/code/session_012SN8zV9RF1J5qXXzgzbEru)_