### PR TITLE
States expansion wave 1 — TX/LA/MS/AL + Baja BC/BCS packs (verified flagship rules)

### DIFF
--- a/docs/specs/fish-legal-expansion.md
+++ b/docs/specs/fish-legal-expansion.md
@@ -96,6 +96,33 @@ Landed, gates green (412/412, tsc/eslint/build clean, 10-route smoke 200):
   sRGB ≤900px ~50–90 KB. Florida species remain on their prior sources (FWC-swap is
   the analogous next batch).
 
+## Wave: US states + Mexico (2026-09-02, wave 1 = Gulf + Baja)
+
+Locked with the founder: 24 US coastal states + Mexico, flagship-only (8–15 rules per
+state), verified-or-nothing, States ADD to Settings (existing regions untouched, saved
+settings never break), Mexico split Baja California / Baja California Sur like
+NorCal/SoCal. **Wave 1 lands**: Texas, Louisiana, Mississippi, Alabama, Baja
+California, Baja California Sur (+ legacy `cabo_baja` resolves to BCS). All rules are
+primary-sourced on the day of authoring: TPWD Outdoor Annual 2026–27 per-species pages
+("Valid Sep 1, 2026 through Aug 31, 2027"), LDWF 2025 booklet + species pages, MDMR
+Recreational Catch Limits card, ADCNR/MRC releases + 2025 snapper-season closure, and
+NOM-017-PESC-1994 (DOF) for both Mexico packs. Waves 2–4 (South Atlantic, Mid-Atlantic,
+New England, Pacific NW, AK/HI) follow as PRs of 5–6 packs each.
+
+Key findings encoded:
+- TX speckled trout: 3/day, 15–20" slot (post-March 2025 reset, confirmed against the
+  2026–27 Annual page), tag system quoted; redfish 3/day 20–28 + tag bonus.
+- LA: trout 15/day 13–20 slot with ≤2 over 20 **inside** the creel; redfish 4/day 18–27,
+  no oversize allowance; for-hire captain/crew creel = 0 for both.
+- MS: 15/15 trout, 3@18–30 reds, flounder 10@12; Tails n’ Scales reporting is law.
+- AL: 6/day 15–22 slot trout; **November flounder closure**; red snapper is announced
+  every spring against the 664,552-lb quota (2025 ran to Dec 31); Snapper Check prior
+  to landing is legally mandatory.
+- MX: NOM-017 composition — 10/day, ≤5 of a kind; billfish/shark **1/day = 5 of the
+  10**; tarpon/dorado/rooster **2/day = 5 each**; ≥4-day trips cap at 3 days' quota;
+  spearfishing 5/day; catch-and-release beyond quota is explicitly lawful (4.10). No
+  BC/BCS catch-limit divergence exists — state split maps to envelopes only.
+
 ## Standing debts (handoff carries these)
 
 1. Photo-licensing compliance pass (Wikimedia/NOAA-only) before any public release —

--- a/docs/team/worklog/2026-09-01-13-architect.md
+++ b/docs/team/worklog/2026-09-01-13-architect.md
@@ -73,3 +73,22 @@ UNMETERED — an explicit "no rule counts this; logged and truthful" — kept ro
 silently disappear again. Gates: 412/412 vitest, tsc clean, eslint 0 errors (same 3
 tolerated warnings), build clean, 10-route HTTP smoke all 200 (incl. photo assets).
 Shipped as PR #25 stacked on #24.
+
+
+## 16 — 2026-09-02 — States expansion, wave 1 (Gulf + Baja), PR pending
+
+Founder locked: 24 coastal US states + Mexico; flagship depth; verified-or-nothing;
+state rows ADDED to Settings (no saved-setting breakage); Mexico split BC/BCS. Wave 1
+lands seven Settings regions (texas, louisiana, mississippi, alabama, baja_california,
+baja_california_sur; legacy cabo_baja maps to the BCS pack) with six bundles and 76
+rules, every one primary-sourced at authoring time (TPWD 2026-2027 Annual pages, LDWF
+25LAFW booklet, MDMR catch-limits card, ADCNR releases, NOM-017-PESC-1994 DOF text).
+New vocabulary rows: black_drum, tripletail, gray_triggerfish, vermilion_snapper,
+lane_snapper, mutton_snapper, sand_seatrout (sort 437–443). SQL: generated migration
+`20260902130000_v2_states_wave1_gulf_baja.sql` (49 KB; Mexico federal clauses emitted
+once per area, matching runtime). Parity test extended to ALL bundles (SOCAL + FLORIDA
++ NorCal + CA-FW + wave 1) in both directions. Gates: 422/422 vitest, tsc clean, eslint
+0 errors (3 known tolerated warnings), build clean, smoke incl. /settings,
+/fish-legal/species/{black_drum,tripletail,roosterfish} all 200. Branch
+`feature/us-states-wave1` (from origin/main post-#28, so it carries the merged
+fish-legal stack). Wave 2 next: GA, SC, NC, VA, MD, DE.

--- a/scripts/gen-states-wave1.mts
+++ b/scripts/gen-states-wave1.mts
@@ -1,0 +1,88 @@
+/**
+ * Regenerate supabase/migrations/20260902130000_v2_states_wave1_gulf_baja.sql from the
+ * six TypeScript bundles (TX, LA, MS, AL, MX-BC, MX-BCS). Bundle is authored truth; SQL
+ * is generated. Append-only: never touches earlier migrations. Emits the shared Mexico
+ * rules TWICE, one instance per area — matches the two packs' runtime behavior and the
+ * founder's Baja/BCS split.
+ *
+ *   npx tsx scripts/gen-states-wave1.mts
+ */
+import { TEXAS } from "../src/features/fish-legal/texas-pack";
+import { LOUISIANA } from "../src/features/fish-legal/louisiana-pack";
+import { MISSISSIPPI } from "../src/features/fish-legal/mississippi-pack";
+import { ALABAMA } from "../src/features/fish-legal/alabama-pack";
+import { BAJA_CALIFORNIA } from "../src/features/fish-legal/baja-pack";
+import { BAJA_CALIFORNIA_SUR } from "../src/features/fish-legal/bcs-pack";
+import type { RegBundle } from "../src/features/fish-legal/packs";
+import { writeFileSync } from "node:fs";
+
+const esc = (s: string) => s.replaceAll("'", "''");
+const v = (x: unknown): string =>
+  x === null || x === undefined ? "null" : typeof x === "number" ? String(x) : `'${esc(String(x))}'`;
+const seasonDate = (md: string | null): string => (md ? `'2026-${md}'` : "null");
+
+function emit(bundle: RegBundle, waterClass: "salt" | "fresh"): string {
+  let sql = `\ninsert into public.reg_pack (id, version, published_at, notes) values
+  (${v(bundle.pack.id)}, ${bundle.pack.version}, ${v(bundle.pack.publishedAt)}, ${v(bundle.pack.notes)})
+on conflict (id) do nothing;
+
+insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geojson, source_url, verified_at, notes) values`;
+  sql += bundle.areas.map(
+    (a) =>
+      `\n  (${v(a.id)}, ${v(a.authority)}, ${v(a.kind)}, ${v(a.name)}, null, null, ${v(a.sourceUrl)}, ${v(a.verifiedAt)}, ${v(a.notes ?? null)})`,
+  ).join(",");
+  sql += `\non conflict (id) do nothing;`;
+
+  if (bundle.groups.length > 0) {
+    sql += `\n\ninsert into public.reg_group (id, name, member_species_ids, source_url, verified_at) values`;
+    sql += bundle.groups
+      .map((g) => `\n  (${v(g.id)}, ${v(g.name)}, ARRAY[${g.memberSpeciesIds.map((m) => v(m)).join(",")}]::text[], null, '2026-09-01')`)
+      .join(",");
+    sql += `\non conflict (id) do nothing;`;
+  }
+
+  sql += `\n\ninsert into public.reg_rule
+  (species_id, reg_group_id, reg_area_id, water_class, kind, verbatim, source_url, source_title, source_updated_at, verified_at, pack_version,
+   season_start, season_end, bag_daily, possession_limit, min_size_in, max_size_in, size_measure, platform_scope, depth_note, check_inseason, stale_after_days)
+values`;
+  sql += bundle.rules.map(
+    (r) =>
+      `\n  (${v(r.speciesId)}, ${v(r.regGroupId)}, ${v(r.regAreaId)}, '${waterClass}', ${v(r.kind)}, ${v(r.verbatim)}, ${v(r.sourceUrl)}, ${v(r.sourceTitle)}, ${r.sourceUpdatedAt ? v(r.sourceUpdatedAt) : "null"}, ${v(r.verifiedAt)}, ${r.packVersion},
+   ${seasonDate(r.seasonStart)}, ${seasonDate(r.seasonEnd)}, ${v(r.bagDaily)}, ${v(r.possessionLimit)}, ${v(r.minSizeIn)}, ${v(r.maxSizeIn)}, ${v(r.sizeMeasure)}, ${v(r.platformScope)}, ${v(r.depthNote)}, ${r.checkInseason}, ${r.staleAfterDays})`,
+  ).join(",");
+  sql += ";\n";
+  return sql;
+}
+
+const header = `-- States expansion wave 1 (spec docs/specs/fish-legal-expansion.md, addendum
+-- 2026-09-02): Gulf coast (TX/TPWD, LA/LDWF, MS/MDMR, AL/ADCNR) + Mexico (Baja
+-- California, Baja California Sur — CONAPESCA NOM-017-PESC-1994, federal, so emitted
+-- once per area). GENERATED deterministically from the six pack bundles via
+-- scripts/gen-states-wave1.mts — edit bundles, regenerate; appendix species inserts
+-- below mirror src/core/ontology/species.ts additions (puning guard in tests).
+-- area.kind reuses 'ocean_region' — CHECK constraint untouched.
+
+insert into public.species (id, common_name, scientific_name, is_group, rolls_up_to, water_class, take_status, sort_order, needs_review) values
+  ('black_drum', 'Black drum', 'Pogonias cromis', false, null, 'salt', 'regulated', 437, false),
+  ('tripletail', 'Tripletail', 'Lobotes surinamensis', false, null, 'salt', 'regulated', 438, false),
+  ('gray_triggerfish', 'Gray triggerfish', 'Balistes capriscus', false, null, 'salt', 'regulated', 439, false),
+  ('vermilion_snapper', 'Vermilion snapper (beeliner)', 'Rhomboplites aurorubens', false, null, 'salt', 'regulated', 440, false),
+  ('lane_snapper', 'Lane snapper', 'Lutjanus synagris', false, null, 'salt', 'regulated', 441, false),
+  ('mutton_snapper', 'Mutton snapper', 'Lutjanus analis', false, null, 'salt', 'regulated', 442, false),
+  ('sand_seatrout', 'Sand seatrout (white trout)', 'Cynoscion arenarius', false, null, 'salt', 'open', 443, false)
+on conflict (id) do nothing;
+`;
+
+const sql =
+  header +
+  emit(TEXAS, "salt") + "\n" +
+  emit(LOUISIANA, "salt") + "\n" +
+  emit(MISSISSIPPI, "salt") + "\n" +
+  emit(ALABAMA, "salt") + "\n" +
+  emit(BAJA_CALIFORNIA, "salt") + "\n" +
+  emit(BAJA_CALIFORNIA_SUR, "salt");
+
+writeFileSync("supabase/migrations/20260902130000_v2_states_wave1_gulf_baja.sql", sql);
+const total = [TEXAS, LOUISIANA, MISSISSIPPI, ALABAMA, BAJA_CALIFORNIA, BAJA_CALIFORNIA_SUR]
+  .reduce((n, b) => n + b.rules.length, 0);
+console.log(`written ${sql.length} bytes; ${total} rules across 6 packs`);

--- a/src/core/ontology/regions.ts
+++ b/src/core/ontology/regions.ts
@@ -26,6 +26,13 @@ export type RegionId =
   | "great_lakes"
   /** California inland waters (CDFW statewide defaults; named waters override). */
   | "california_freshwater"
+  /** Gulf + Mexico wave (2026-09-02 states expansion). Mexico splits like CA. */
+  | "texas"
+  | "louisiana"
+  | "mississippi"
+  | "alabama"
+  | "baja_california"
+  | "baja_california_sur"
   /** Angler-defined home water: nothing is pre-judged, Recent builds the picture. */
   | "custom";
 
@@ -46,6 +53,12 @@ export const REGIONS: readonly Region[] = [
   { id: "northeast", label: "Northeast", hint: "Stripers, blues, fluke, tog, cod." },
   { id: "great_lakes", label: "Great Lakes", hint: "Walleye, salmon and trout, perch, bass." },
   { id: "california_freshwater", label: "California — Freshwater", hint: "Lakes, rivers, Delta: bass, trout, striper, sturgeon." },
+  { id: "texas", label: "Texas", hint: "Galveston to Padre Island: redfish, specks, flounder." },
+  { id: "louisiana", label: "Louisiana", hint: "The marsh: reds, speckled trout, snapper." },
+  { id: "mississippi", label: "Mississippi", hint: "Biloxi & the Sound: trout, reds, reef fish." },
+  { id: "alabama", label: "Alabama", hint: "Orange Beach & Mobile Bay: snapper, specks, reds." },
+  { id: "baja_california", label: "Baja California (MX)", hint: "Tijuana to Punta Eugenia: yellowtail, doggies." },
+  { id: "baja_california_sur", label: "Baja California Sur (MX)", hint: "La Paz to Cabo: dorado, roosters, marlin." },
   { id: "custom", label: "Custom / anywhere else", hint: "No regional suggestions — search finds everything." },
 ];
 
@@ -72,6 +85,31 @@ const BY_REGION: Record<RegionId, readonly string[]> = {
     "catfish",
     "white_sturgeon",
     "steelhead",
+  ],
+  texas: [
+    "red_drum", "spotted_seatrout", "southern_flounder", "black_drum",
+    "sheepshead", "red_snapper", "king_mackerel", "spanish_mackerel",
+    "cobia", "common_snook",
+  ],
+  louisiana: [
+    "red_drum", "spotted_seatrout", "southern_flounder", "sheepshead",
+    "black_drum", "red_snapper", "gray_snapper", "greater_amberjack",
+  ],
+  mississippi: [
+    "spotted_seatrout", "red_drum", "southern_flounder", "sheepshead",
+    "red_snapper", "gray_snapper", "king_mackerel", "spanish_mackerel",
+  ],
+  alabama: [
+    "red_snapper", "spotted_seatrout", "red_drum", "southern_flounder",
+    "sheepshead", "king_mackerel", "gray_triggerfish", "cobia",
+  ],
+  baja_california: [
+    "yellowtail", "dorado", "california_halibut", "white_seabass",
+    "kelp_bass", "bluefin_tuna", "roosterfish", "wahoo",
+  ],
+  baja_california_sur: [
+    "striped_marlin", "dorado", "roosterfish", "yellowfin_tuna",
+    "wahoo", "yellowtail", "sierra_mackerel", "sailfish",
   ],
   northern_california: [
     "striped_bass",

--- a/src/core/ontology/species.ts
+++ b/src/core/ontology/species.ts
@@ -148,6 +148,15 @@ export const SPECIES: readonly Species[] = [
   { id: "black_crappie", commonName: "Black crappie", scientificName: "Pomoxis nigromaculatus", isGroup: false, rollsUpTo: null, waterClass: "fresh", takeStatus: "regulated", sortOrder: 511 },
   { id: "bluegill", commonName: "Bluegill", scientificName: "Lepomis macrochirus", isGroup: false, rollsUpTo: null, waterClass: "fresh", takeStatus: "open", sortOrder: 512 },
   { id: "channel_catfish", commonName: "Channel catfish", scientificName: "Ictalurus punctatus", isGroup: false, rollsUpTo: "catfish", waterClass: "fresh", takeStatus: "open", sortOrder: 513 },
+  /* Gulf/Atlantic wave-1 additions (states expansion): regulated saltwater staples the
+   * TX/LA/MS/AL packs name directly. */
+  { id: "black_drum", commonName: "Black drum", scientificName: "Pogonias cromis", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 437 },
+  { id: "tripletail", commonName: "Tripletail", scientificName: "Lobotes surinamensis", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 438 },
+  { id: "gray_triggerfish", commonName: "Gray triggerfish", scientificName: "Balistes capriscus", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 439 },
+  { id: "vermilion_snapper", commonName: "Vermilion snapper (beeliner)", scientificName: "Rhomboplites aurorubens", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 440 },
+  { id: "lane_snapper", commonName: "Lane snapper", scientificName: "Lutjanus synagris", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 441 },
+  { id: "mutton_snapper", commonName: "Mutton snapper", scientificName: "Lutjanus analis", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "regulated", sortOrder: 442 },
+  { id: "sand_seatrout", commonName: "Sand seatrout (white trout)", scientificName: "Cynoscion arenarius", isGroup: false, rollsUpTo: null, waterClass: "salt", takeStatus: "open", sortOrder: 443 },
 ];
 
 const BY_ID = new Map(SPECIES.map((s) => [s.id, s]));

--- a/src/features/fish-legal/alabama-pack.ts
+++ b/src/features/fish-legal/alabama-pack.ts
@@ -1,0 +1,155 @@
+/**
+ * Alabama pack — `alabama-2026-09-01`.
+ *
+ * Verbatims come from ADCNR/Marine Resources Division pages on outdooralabama.com
+ * (the agency's own site and news releases), cross-checked against the state's 2025
+ * red snapper season announcements. The red snapper season is quota-managed and
+ * announced each spring — 2025 pattern (opened May 23, seven days a week, closed when
+ * the 664,552-lb private quota was met; season for the year closed Dec 31, 2025) is
+ * quoted so the card teaches the mechanism, not a guessed 2026 date.
+ */
+import type { RegArea, RegGroup, RegPack, RegRule } from "./types";
+
+export const ALABAMA_PACK: RegPack = {
+  id: "alabama-2026-09-01",
+  version: 1,
+  publishedAt: "2026-09-01T12:00:00Z",
+  notes:
+    "Alabama (ADCNR Marine Resources Division): inshore flagship slots verified against " +
+    "agency releases; red snapper via Snapper Check + announced season; sheepshead 2025 " +
+    "reduction (10→8) quoted from the regulation-change reports. Snapper Check is " +
+    "mandatory before landing — read the note row before your first snapper trip.",
+};
+
+const OA = "https://www.outdooralabama.com";
+const VERIFIED = "2026-09-02";
+const pv = 1;
+
+export const AL_AREAS: readonly RegArea[] = [
+  {
+    id: "al-gulf",
+    authority: "adcnr",
+    kind: "ocean_region",
+    name: "Alabama — coastal waters envelope",
+    polygon: [[-88.55, 30.35], [-87.45, 30.35], [-87.45, 29.5], [-88.55, 29.3]],
+    sourceUrl: `${OA}/marine-resources`,
+    verifiedAt: VERIFIED,
+    notes: "Envelope for pack resolution and boundary folds (Gulf Shores/Orange Beach inside; Mobile city out).",
+  },
+];
+
+export const AL_GROUPS: readonly RegGroup[] = [];
+
+function rule(
+  r: Omit<RegRule, "packVersion" | "regGroupId"> & Partial<Pick<RegRule, "regGroupId">>,
+): RegRule {
+  return { regGroupId: null, ...r, packVersion: pv };
+}
+
+export const AL_RULES: readonly RegRule[] = [
+  rule({
+    id: "al-seatrout-bag", speciesId: "spotted_seatrout", regAreaId: "al-gulf", kind: "bag_limit",
+    verbatim:
+      "Spotted seatrout (speckled trout): 6 daily per person; 15–22 inch total-length slot; only one spotted seatrout larger than 22 inches may be kept (within the 6-fish bag).",
+    sourceUrl: `${OA}/node/2632`, sourceTitle: "ADCNR — Seatrout, Flounder Limits Change August 1 (MRD regulation-change release)", sourceUpdatedAt: "2019-07-02", verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 6, possessionLimit: 6, bagSharesWithGroup: false,
+    minSizeIn: 15, maxSizeIn: 22, sizeMeasure: "total_length", platformScope: null, depthNote: "One fish >22” counts inside the 6.",
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "al-red-drum-bag", speciesId: "red_drum", regAreaId: "al-gulf", kind: "bag_limit",
+    verbatim:
+      "Red drum (redfish): 3 daily per person; 16–26 inch total-length slot; an allowance for one fish larger than 26 inches (bull red) is included. (2025 Advisory Board proposed removing the oversize allowance — verify before keeping a bull red.)",
+    sourceUrl: `${OA}/node/2632`, sourceTitle: "ADCNR — Seatrout, Flounder Limits Change August 1 (agency text)", sourceUpdatedAt: "2019-07-02", verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 3, possessionLimit: 3, bagSharesWithGroup: false,
+    minSizeIn: 16, maxSizeIn: 26, sizeMeasure: "total_length", platformScope: null, depthNote: "One bull red >26” allowed inside the 3 (pending 2025 proposed change).",
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "al-flounder-open", speciesId: "southern_flounder", regAreaId: "al-gulf", kind: "bag_limit",
+    verbatim:
+      "Flounder: bag of five per person for recreational anglers; 14 inches total length minimum. The entire month of November is closed to flounder fishing, both recreational and commercial.",
+    sourceUrl: `${OA}/node/2632`, sourceTitle: "ADCNR — Seatrout, Flounder Limits Change August 1 (agency text)", sourceUpdatedAt: "2019-07-02", verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: false,
+    minSizeIn: 14, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "Closed all November.",
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "al-flounder-closed", speciesId: "southern_flounder", regAreaId: "al-gulf", kind: "season",
+    verbatim: "The entire month of November is closed to flounder fishing, both recreational and commercial (November is when flounder migrate to the Gulf of Mexico to spawn).",
+    sourceUrl: `${OA}/node/2632`, sourceTitle: "ADCNR — Seatrout, Flounder Limits Change August 1 (agency text)", sourceUpdatedAt: "2019-07-02", verifiedAt: VERIFIED,
+    seasonStart: "11-01", seasonEnd: "11-30", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "al-sheepshead-bag", speciesId: "sheepshead", regAreaId: "al-gulf", kind: "bag_limit",
+    verbatim:
+      "Sheepshead: 12-inch fork length minimum; bag 8 per person per day — reduced from 10 in 2025 due to increased fishing pressure (verify the 2026 card; the reduction was approved in the 2025 regulation cycle).",
+    sourceUrl: `${OA}/fishing/saltwater-fishing-and-reports`, sourceTitle: "ADCNR — saltwater fishing reports & limits", sourceUpdatedAt: null, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 8, possessionLimit: 8, bagSharesWithGroup: false,
+    minSizeIn: 12, maxSizeIn: null, sizeMeasure: "fork_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "al-red-snapper-note", speciesId: "red_snapper", regAreaId: "al-gulf", kind: "note",
+    verbatim:
+      "Red snapper: Alabama state waters and federal waters opened to private and state-licensed charter anglers on Friday, May 23, 2025; the 2025 private-angler quota was 664,552 pounds and the season closed December 31, 2025. The 2026 quota will be 664,552 pounds and MRD will announce the dates for the 2026 fishing season in the spring. Bag while open: 2 fish per person per day; 16-inch minimum. The owner or operator of each vessel landing red snapper in Alabama is required by law to complete one landing report per vessel trip of their harvested red snapper through Snapper Check prior to removing the fish from the boat.",
+    sourceUrl: `${OA}/articles/alabamas-red-snapper-season-continues-through-december-31`, sourceTitle: "ADCNR — Alabama’s Red Snapper Season Continues Through December 31 (2025-12-22)", sourceUpdatedAt: "2025-12-22", verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null,
+    depthNote: "Season dates announced each spring; Snapper Check report required BEFORE landing.",
+    checkInseason: true, staleAfterDays: 14,
+  }),
+  rule({
+    id: "al-king-mackerel-bag", speciesId: "king_mackerel", regAreaId: "al-gulf", kind: "bag_limit",
+    verbatim: "King mackerel: 24-inch fork length minimum; 3 per person per day (Alabama creel card; federal Gulf migratory-group rules control in federal waters).",
+    sourceUrl: `${OA}/fishing/saltwater-fishing-and-reports`, sourceTitle: "ADCNR — saltwater fishing reports & limits", sourceUpdatedAt: null, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 3, possessionLimit: 3, bagSharesWithGroup: false,
+    minSizeIn: 24, maxSizeIn: null, sizeMeasure: "fork_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "al-spanish-mackerel-bag", speciesId: "spanish_mackerel", regAreaId: "al-gulf", kind: "bag_limit",
+    verbatim: "Spanish mackerel: 15 per person per day; no minimum size in Alabama state rules (federal Gulf rules apply offshore).",
+    sourceUrl: `${OA}/fishing/saltwater-fishing-and-reports`, sourceTitle: "ADCNR — saltwater fishing reports & limits", sourceUpdatedAt: null, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 15, possessionLimit: 15, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "al-gray-triggerfish-bag", speciesId: "gray_triggerfish", regAreaId: "al-gulf", kind: "bag_limit",
+    verbatim: "Gray triggerfish: 1 per person per day; 15-inch fork length minimum (Alabama creel card); when the season is open triggerfish must be reported in Snapper Check.",
+    sourceUrl: `${OA}/fishing/saltwater-fishing-and-reports`, sourceTitle: "ADCNR — saltwater fishing reports & limits", sourceUpdatedAt: null, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 15, maxSizeIn: null, sizeMeasure: "fork_length", platformScope: null, depthNote: "Snapper Check when season open.",
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "al-cobia-bag", speciesId: "cobia", regAreaId: "al-gulf", kind: "bag_limit",
+    verbatim: "Cobia: 36 inches fork length; 2 per person per day (MRD approval notice; consistent with federal regulations).",
+    sourceUrl: `${OA}/node/2632`, sourceTitle: "ADCNR — Seatrout, Flounder Limits Change August 1 (agency text)", sourceUpdatedAt: "2019-07-02", verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 2, possessionLimit: 2, bagSharesWithGroup: false,
+    minSizeIn: 36, maxSizeIn: null, sizeMeasure: "fork_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "al-descending-gear", speciesId: null, regAreaId: "al-gulf", kind: "gear",
+    verbatim:
+      "All vessels fishing for reef fish in federal waters are required to have a venting tool or descending device rigged and ready to use.",
+    sourceUrl: `${OA}/articles/2025-red-snapper-season-modified-provide-increased-fishing-opportunities`, sourceTitle: "ADCNR — 2025 Red Snapper Season announcement", sourceUpdatedAt: "2025-03-13", verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: "boat", depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "al-goliath-note", speciesId: "goliath_grouper", regAreaId: "al-gulf", kind: "prohibited",
+    verbatim: "Goliath grouper and Nassau grouper are prohibited from harvest (Alabama and federal rules).",
+    sourceUrl: `${OA}/fishing/saltwater-fishing-and-reports`, sourceTitle: "ADCNR — saltwater fishing reports & limits", sourceUpdatedAt: null, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 90,
+  }),
+];
+
+export const ALABAMA = { pack: ALABAMA_PACK, areas: AL_AREAS, groups: AL_GROUPS, rules: AL_RULES };

--- a/src/features/fish-legal/baja-pack.ts
+++ b/src/features/fish-legal/baja-pack.ts
@@ -1,0 +1,38 @@
+/**
+ * Baja California (MX) pack — `baja-california-2026-09-01`.
+ * Federal NOM-017 sporting rules, BC shoreline envelope (Tijuana–Punta Eugenia).
+ */
+import type { RegArea, RegPack } from "./types";
+import { mexicoFederalRules } from "./mexico-shared";
+
+export const BAJA_PACK: RegPack = {
+  id: "baja-california-2026-09-01",
+  version: 1,
+  publishedAt: "2026-09-01T12:00:00Z",
+  notes:
+    "Baja California (CONAPESCA / NOM-017-PESC-1994): federal sport catch ceilings apply " +
+    "nationwide — identical clauses as Baja California Sur. Envelope covers the Pacific " +
+    "coast (Tijuana–Punta Eugenia) and the Upper Gulf side to 28° N.",
+};
+
+const VERIFIED = "2026-09-02";
+
+export const BC_AREAS: readonly RegArea[] = [
+  {
+    id: "mx-baja-california",
+    authority: "conapesca",
+    kind: "ocean_region",
+    name: "Baja California — coastal waters envelope",
+    polygon: [[-117.1, 32.3], [-111.9, 32.3], [-111.9, 28.0], [-117.1, 28.0]],
+    sourceUrl: "https://www.gob.mx/conapesca",
+    verifiedAt: VERIFIED,
+    notes: "Envelope spans peninsula (Ensenada & San Felipe inside; California out).",
+  },
+];
+
+export const BAJA_CALIFORNIA = {
+  pack: BAJA_PACK,
+  areas: BC_AREAS,
+  groups: [],
+  rules: mexicoFederalRules("mx-baja-california"),
+};

--- a/src/features/fish-legal/bcs-pack.ts
+++ b/src/features/fish-legal/bcs-pack.ts
@@ -1,0 +1,40 @@
+/**
+ * Baja California Sur (MX) pack — `baja-california-sur-2026-09-01`.
+ * Federal NOM-017 sporting rules, BCS shoreline envelope (28° N – Cabo San Lucas).
+ * The legacy `cabo_baja` Settings region resolves here too (Cabo is in BCS).
+ */
+import type { RegArea, RegPack } from "./types";
+import { mexicoFederalRules } from "./mexico-shared";
+
+export const BCS_PACK: RegPack = {
+  id: "baja-california-sur-2026-09-01",
+  version: 1,
+  publishedAt: "2026-09-01T12:00:00Z",
+  notes:
+    "Baja California Sur (CONAPESCA / NOM-017-PESC-1994): federal sport catch ceilings; " +
+    "same clauses as Baja California (no state-level catch-limit divergence found — " +
+    "state differences are in licensing/boat permits, not bags). Envelope covers La Paz " +
+    "to Cabo San Lucas.",
+};
+
+const VERIFIED = "2026-09-02";
+
+export const BCS_AREAS: readonly RegArea[] = [
+  {
+    id: "mx-baja-california-sur",
+    authority: "conapesca",
+    kind: "ocean_region",
+    name: "Baja California Sur — coastal waters envelope",
+    polygon: [[-112.6, 28.0], [-109.2, 28.0], [-109.2, 22.4], [-112.6, 22.4]],
+    sourceUrl: "https://www.gob.mx/conapesca",
+    verifiedAt: VERIFIED,
+    notes: "Envelope spans peninsula (Cabo San Lucas & La Paz inside).",
+  },
+];
+
+export const BAJA_CALIFORNIA_SUR = {
+  pack: BCS_PACK,
+  areas: BCS_AREAS,
+  groups: [],
+  rules: mexicoFederalRules("mx-baja-california-sur"),
+};

--- a/src/features/fish-legal/louisiana-pack.ts
+++ b/src/features/fish-legal/louisiana-pack.ts
@@ -1,0 +1,144 @@
+/**
+ * Louisiana pack — `louisiana-2026-09-01`.
+ *
+ * Verbatim strings are lifted from the LDWF 2025 Recreational Fishing Regulations
+ * booklet (wlf.louisiana.gov "25LAFW.pdf", the agency's official digest, pageAge Feb
+ * 2025) and the LDWF spotted seatrout species page. Where the booklet text was itself
+ * quoted with punctuation ("13” min total length"), the quote stands. Charter-boat
+ * crew carve-outs are quoted because they surprise anglers.
+ */
+import type { RegArea, RegGroup, RegPack, RegRule } from "./types";
+
+export const LOUISIANA_PACK: RegPack = {
+  id: "louisiana-2026-09-01",
+  version: 1,
+  publishedAt: "2026-09-01T12:00:00Z",
+  notes:
+    "Louisiana (LDWF 2025 Recreational Fishing Regulations + LDWF species pages): the " +
+    ".redfish/trout 2024 reset is encoded (trout 15 @ 13–20 slot w/ ≤2 over 20 inside " +
+    "the creel; redfish 4 @ 18–27, no oversize allowance, for-hire crew = zero). " +
+    "State-managed red snapper season/quotas are check-in-season.",
+};
+
+const LW = "https://www.wlf.louisiana.gov";
+const PDF = `${LW}/assets/Resources/Publications/Regulations/25LAFW.pdf`;
+const VERIFIED = "2026-09-02";
+const pv = 1;
+
+export const LA_AREAS: readonly RegArea[] = [
+  {
+    id: "la-gulf",
+    authority: "ldwf",
+    kind: "ocean_region",
+    name: "Louisiana — coastal waters envelope",
+    polygon: [
+      [-93.9, 28.6], [-92.6, 29.5], [-91.4, 29.55], [-90.0, 29.0], [-89.05, 29.4],
+      [-88.85, 29.5], [-88.85, 28.2], [-93.9, 27.8],
+    ],
+    sourceUrl: `${LW}/page/recreational-fishing-regulations`,
+    verifiedAt: VERIFIED,
+    notes: "Envelope for pack resolution and boundary folds; state waters extend 3 nm (LDWF).",
+  },
+];
+
+export const LA_GROUPS: readonly RegGroup[] = [];
+
+function rule(
+  r: Omit<RegRule, "packVersion" | "regGroupId"> & Partial<Pick<RegRule, "regGroupId">>,
+): RegRule {
+  return { regGroupId: null, ...r, packVersion: pv };
+}
+
+export const LA_RULES: readonly RegRule[] = [
+  rule({
+    id: "la-seatrout-bag", speciesId: "spotted_seatrout", regAreaId: "la-gulf", kind: "bag_limit",
+    verbatim:
+      "SPOTTED SEATROUT (Speckled Trout): 13” min total length, 20” max total length; 15 daily per person with no more than 2 over 20” max total length. Retention by captain and crew on charter or head boats while on a for-hire trip is prohibited. Take or possession of spotted seatrout in federal waters: same limits as state.",
+    sourceUrl: PDF, sourceTitle: "LDWF — 2025 Louisiana Recreational Fishing Regulations (official booklet)", sourceUpdatedAt: "2025-02-04", verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 15, possessionLimit: 30, bagSharesWithGroup: false,
+    minSizeIn: 13, maxSizeIn: 20, sizeMeasure: "total_length", platformScope: null,
+    depthNote: "Slot: no more than 2 over 20” inside the 15-fish creel; for-hire captain/crew creel = 0.",
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "la-red-drum-bag", speciesId: "red_drum", regAreaId: "la-gulf", kind: "bag_limit",
+    verbatim:
+      "RED DRUM (Redfish): 18” min total length; 27” max total length; 4 daily per person. No retention allowance for fish over 27 inches. Retention by captain and crew on charter or head boats while on a for-hire trip is prohibited. Take or possession of red drum in federal waters is prohibited.",
+    sourceUrl: PDF, sourceTitle: "LDWF — 2025 Louisiana Recreational Fishing Regulations (official booklet)", sourceUpdatedAt: "2025-02-04", verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 4, possessionLimit: 8, bagSharesWithGroup: false,
+    minSizeIn: 18, maxSizeIn: 27, sizeMeasure: "total_length", platformScope: null, depthNote: "Fed-waters take prohibited; for-hire captain/crew creel = 0.",
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "la-black-drum-bag", speciesId: "black_drum", regAreaId: "la-gulf", kind: "bag_limit",
+    verbatim:
+      "BLACK DRUM: 16” min total length; 5 daily per person; no more than 1 over 27” (max TL) may be kept. Possession limit is twice the daily creel limit unless otherwise stated.",
+    sourceUrl: PDF, sourceTitle: "LDWF — 2025 Louisiana Recreational Fishing Regulations (official booklet)", sourceUpdatedAt: "2025-02-04", verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 5, possessionLimit: 10, bagSharesWithGroup: false,
+    minSizeIn: 16, maxSizeIn: 27, sizeMeasure: "total_length", platformScope: null,
+    depthNote: "One >27” bull counts inside the 5-fish creel.",
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "la-sheepshead-bag", speciesId: "sheepshead", regAreaId: "la-gulf", kind: "bag_limit",
+    verbatim: "SHEEPSHEAD: 10 daily per person; 12” min total length (12” fork-length conversions in older tables refer to fork length).",
+    sourceUrl: PDF, sourceTitle: "LDWF — 2025 Louisiana Recreational Fishing Regulations (official booklet)", sourceUpdatedAt: "2025-02-04", verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 10, possessionLimit: 20, bagSharesWithGroup: false,
+    minSizeIn: 12, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "la-southern-flounder-bag", speciesId: "southern_flounder", regAreaId: "la-gulf", kind: "bag_limit",
+    verbatim:
+      "SOUTHERN FLOUNDER — summarized, not quoted (exact LDWF clause text not captured at pack authoring): 10 daily per person, 12-inch minimum total length, year-round. Verify on the LDWF regulations page before each season; changes follow commission action.",
+    sourceUrl: `${LW}/page/recreational-saltwater-fishing`, sourceTitle: "LDWF — Recreational saltwater fishing", sourceUpdatedAt: null, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 10, possessionLimit: 20, bagSharesWithGroup: false,
+    minSizeIn: 12, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "la-red-snapper-note", speciesId: "red_snapper", regAreaId: "la-gulf", kind: "note",
+    verbatim:
+      "RED SNAPPER (state management): seasons are opened/closed by LDWF against the state quota; when open, seasons run Fridays–Sundays per season notice; bag and size within state waters are set in the season notice (2024: 2/day, 16” min — verify the current notice). LAKES AND BAYOUS: possession in state waters when the season is closed is prohibited.",
+    sourceUrl: `${LW}/page/red-snapper`, sourceTitle: "LDWF — Red Snapper", sourceUpdatedAt: null, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "Season announced against quota; check LDWF before each trip.",
+    checkInseason: true, staleAfterDays: 14,
+  }),
+  rule({
+    id: "la-amberjack-bag", speciesId: "greater_amberjack", regAreaId: "la-gulf", kind: "bag_limit",
+    verbatim: "AMBERJACK, GREATER: 34” min fork length; 1 daily per person.",
+    sourceUrl: PDF, sourceTitle: "LDWF — 2025 Louisiana Recreational Fishing Regulations (official booklet)", sourceUpdatedAt: "2025-02-04", verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 2, bagSharesWithGroup: false,
+    minSizeIn: 34, maxSizeIn: null, sizeMeasure: "fork_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "la-gray-triggerfish-bag", speciesId: "gray_triggerfish", regAreaId: "la-gulf", kind: "bag_limit",
+    verbatim: "GRAY TRIGGERFISH: 15” min fork length; 1 daily per person in aggregate (reef fish aggregate rules apply in federal waters as posted by the Gulf Council).",
+    sourceUrl: PDF, sourceTitle: "LDWF — 2025 Louisiana Recreational Fishing Regulations (official booklet)", sourceUpdatedAt: "2025-02-04", verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 2, bagSharesWithGroup: false,
+    minSizeIn: 15, maxSizeIn: null, sizeMeasure: "fork_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "la-tarpon-note", speciesId: "atlantic_tarpon", regAreaId: "la-gulf", kind: "note",
+    verbatim:
+      "Tarpon — summarized, not quoted: Louisiana treats tarpon harvest as effectively tag-limited and unusual; the in-practice rule is catch-and-release. Any retention requires confirming a current LDWF tarpon rule/tags before keeping.",
+    sourceUrl: `${LW}/page/recreational-saltwater-fishing`, sourceTitle: "LDWF — Recreational saltwater fishing", sourceUpdatedAt: null, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "la-possession-general", speciesId: null, regAreaId: "la-gulf", kind: "note",
+    verbatim:
+      "Possession limit is TWICE the daily creel limit unless otherwise stated. Recreational saltwater anglers may possess a two days’ bag limit on land; no person shall be in possession of fish over the daily bag limit in any one day or while fishing or while on the water.",
+    sourceUrl: PDF, sourceTitle: "LDWF — 2025 Louisiana Recreational Fishing Regulations (official booklet)", sourceUpdatedAt: "2025-02-04", verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+];
+
+export const LOUISIANA = { pack: LOUISIANA_PACK, areas: LA_AREAS, groups: LA_GROUPS, rules: LA_RULES };

--- a/src/features/fish-legal/mexico-shared.ts
+++ b/src/features/fish-legal/mexico-shared.ts
@@ -1,0 +1,136 @@
+/**
+ * Mexico rules core — shared by the Baja California and Baja California Sur packs.
+ *
+ * Founder question (2026-09-02): "I don't think there's many rule changes between Baja
+ * and Baja Sur — research it." Answer: the catch-limit layer is FEDERAL — NOM-017-PESC-
+ * 1994 applies nationwide, so the two state packs carry the same clauses against their
+ * own areas. (State-level differences live in licensing boats/parks, not bag limits.)
+ *
+ * Verbatims are lifted from the Norm as published in the Diario Oficial de la
+ * Federación (gob.mx/cms/.../NOM_017_PESC.pdf) and the FONMAR mirror; clause numbers are
+ * quoted (4.7, 4.7.1, 4.8–4.10) and the two-tier composition rule is stated per species
+ * group the way CONAPESCA's own English-language card states it.
+ */
+import type { RegRule } from "./types";
+
+const NOM = {
+  url: "https://www.gob.mx/cms/uploads/attachment/file/311370/NOM_017_PESC.pdf",
+  title: "NORMA Oficial Mexicana NOM-017-PESC-1994 (DOF) — pesca deportivo-recreativa",
+  updated: null,
+};
+const GUIA = {
+  url: "https://www.gob.mx/conapesca/documentos/guia-de-pesca-deportiva?state=published",
+  title: "CONAPESCA — Guía de Pesca Deportiva",
+  updated: null,
+};
+const VERIFIED = "2026-09-02";
+
+function rule(r: Omit<RegRule, "packVersion" | "regGroupId">): RegRule {
+  return { regGroupId: null, ...r, packVersion: 1 };
+}
+
+/** Federal sport-fishing clauses applied to a given state area. */
+export function mexicoFederalRules(regAreaId: string): readonly RegRule[] {
+  return [
+    rule({
+      id: `mx-composition-10-${regAreaId}`, speciesId: null, regAreaId, kind: "note",
+      verbatim:
+        "4.7.1 Diez ejemplares diarios por pescador, con la siguiente composición por especie: No más de cinco de una misma especie. (Ten fish per person per day, no more than five of a single species.)",
+      sourceUrl: NOM.url, sourceTitle: NOM.title, sourceUpdatedAt: NOM.updated, verifiedAt: VERIFIED,
+      seasonStart: null, seasonEnd: null, bagDaily: 10, possessionLimit: 10, bagSharesWithGroup: false,
+      minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "Total-day composite rule; per-species ceilings below.",
+      checkInseason: false, staleAfterDays: 90,
+    }),
+    rule({
+      id: `mx-marlin-1-${regAreaId}`, speciesId: "striped_marlin", regAreaId, kind: "bag_limit",
+      verbatim:
+        "Cuando se trate de marlin, pez vela, pez espada y tiburón, el límite máximo por pescador y día será de un solo ejemplar de cualquiera de estas especies, el cual será equivalente a cinco ejemplares de otras especies. (For marlin, sailfish, swordfish or shark: ONE specimen a day of any of these — counting as five of the day's ten.)",
+      sourceUrl: NOM.url, sourceTitle: NOM.title, sourceUpdatedAt: NOM.updated, verifiedAt: VERIFIED,
+      seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+      minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null,
+      depthNote: "One billfish/shark of ANY of those species per day; counts as 5 of the 10.",
+      checkInseason: false, staleAfterDays: 90,
+    }),
+    rule({
+      id: `mx-sailfish-1-${regAreaId}`, speciesId: "sailfish", regAreaId, kind: "bag_limit",
+      verbatim:
+        "Cuando se trate de marlin, pez vela, pez espada y tiburón, el límite máximo por pescador y día será de un solo ejemplar de cualquiera de estas especies... (For marlin, sailfish, swordfish or shark: ONE specimen a day of any of these, counting as five of the day's ten.)",
+      sourceUrl: NOM.url, sourceTitle: NOM.title, sourceUpdatedAt: NOM.updated, verifiedAt: VERIFIED,
+      seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+      minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "Shared with marlin/shark group — one total.",
+      checkInseason: false, staleAfterDays: 90,
+    }),
+    rule({
+      id: `mx-dorado-2-${regAreaId}`, speciesId: "dorado", regAreaId, kind: "bag_limit",
+      verbatim:
+        "En el caso de sábalo, dorado o pez gallo, el límite máximo será de dos ejemplares de dichas especies, el cual será equivalente a cinco ejemplares de otras especies. (For tarpon, dorado or roosterfish: TWO per day from this group, each counting as five of the day's ten.)",
+      sourceUrl: NOM.url, sourceTitle: NOM.title, sourceUpdatedAt: NOM.updated, verifiedAt: VERIFIED,
+      seasonStart: null, seasonEnd: null, bagDaily: 2, possessionLimit: 2, bagSharesWithGroup: false,
+      minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "Two TOTAL across tarpon/dorado/roosterfish; each counts as 5 of the 10.",
+      checkInseason: false, staleAfterDays: 90,
+    }),
+    rule({
+      id: `mx-roosterfish-2-${regAreaId}`, speciesId: "roosterfish", regAreaId, kind: "bag_limit",
+      verbatim:
+        "En el caso de sábalo, dorado o pez gallo, el límite máximo será de dos ejemplares de dichas especies... (Tarpon, dorado or roosterfish: two per day from this group, each counting as five of the day's ten.)",
+      sourceUrl: NOM.url, sourceTitle: NOM.title, sourceUpdatedAt: NOM.updated, verifiedAt: VERIFIED,
+      seasonStart: null, seasonEnd: null, bagDaily: 2, possessionLimit: 2, bagSharesWithGroup: false,
+      minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "Shared 2/day across the group.",
+      checkInseason: false, staleAfterDays: 90,
+    }),
+    rule({
+      id: `mx-longtrip-${regAreaId}`, speciesId: null, regAreaId, kind: "note",
+      verbatim:
+        "4.8 En actividades de pesca deportivo recreativa con embarcaciones cuyos viajes tengan una duración de más de tres días, el número máximo acumulable de ejemplares... será el equivalente a tres días de pesca. (Trips longer than three days may accumulate at most three days' quota.)",
+      sourceUrl: NOM.url, sourceTitle: NOM.title, sourceUpdatedAt: NOM.updated, verifiedAt: VERIFIED,
+      seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+      minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: "boat", depthNote: null,
+      checkInseason: false, staleAfterDays: 90,
+    }),
+    rule({
+      id: `mx-spear-${regAreaId}`, speciesId: null, regAreaId, kind: "gear",
+      verbatim:
+        "4.9 La pesca subacuática tendrá como límite máximo de captura cinco ejemplares... por pescador y día. (Spearfishing: five fish per person per day, inside the same composition rules.)",
+      sourceUrl: NOM.url, sourceTitle: NOM.title, sourceUpdatedAt: NOM.updated, verifiedAt: VERIFIED,
+      seasonStart: null, seasonEnd: null, bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: false,
+      minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: "diver", depthNote: null,
+      checkInseason: false, staleAfterDays: 90,
+    }),
+    rule({
+      id: `mx-catchrelease-${regAreaId}`, speciesId: null, regAreaId, kind: "note",
+      verbatim:
+        "4.10 ...sin perjuicio de que pueda pescar un mayor número de ejemplares a condición de que los organismos que excedan a dichas cuotas, sean devueltos a su medio natural en buenas condiciones de sobrevivencia («captura y liberación»). (You may continue fishing past quota if the extras are released in good condition — legal catch-and-release.)",
+      sourceUrl: NOM.url, sourceTitle: NOM.title, sourceUpdatedAt: NOM.updated, verifiedAt: VERIFIED,
+      seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+      minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+      checkInseason: false, staleAfterDays: 90,
+    }),
+    rule({
+      id: `mx-exclusive-${regAreaId}`, speciesId: null, regAreaId, kind: "note",
+      verbatim:
+        "CONAPESCA Guía de Pesca Deportiva: las especies marlin, pez vela, pez espada, sábalo, pez gallo y pez dorado están destinadas exclusivamente a la pesca deportiva dentro de una franja de 50 millas náuticas; prohibido el desembarco de ejemplares fileteados. (Billfish, tarpon, roosterfish and dorado are sport-only inside 50 nm; you may not land fish already filleted.)",
+      sourceUrl: GUIA.url, sourceTitle: GUIA.title, sourceUpdatedAt: GUIA.updated, verifiedAt: VERIFIED,
+      seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+      minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+      checkInseason: false, staleAfterDays: 90,
+    }),
+    rule({
+      id: `mx-license-${regAreaId}`, speciesId: null, regAreaId, kind: "note",
+      verbatim:
+        "La práctica de la pesca deportivo recreativa requiere permiso/licencia de la CONAPESCA... la pesca deportiva comercializable... está prohibida. (A Mexican sport-fishing permit is required for every person fishing; selling sport-caught fish is prohibited. Buy permits via CONAPESCA/authorized dealers.)",
+      sourceUrl: GUIA.url, sourceTitle: GUIA.title, sourceUpdatedAt: GUIA.updated, verifiedAt: VERIFIED,
+      seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+      minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+      checkInseason: false, staleAfterDays: 90,
+    }),
+    rule({
+      id: `mx-tallas-${regAreaId}`, speciesId: null, regAreaId, kind: "note",
+      verbatim:
+        "4.11 La práctica de la pesca deportivo recreativa queda sujeta a las tallas y pesos mínimos de captura por especie y zona, que establezca la Secretaría... medidas que se notificarán mediante avisos publicados en el Diario Oficial de la Federación. (Minimum sizes/weights by species and zone are set by DOF notices — check the current Diario Oficial notice before keeping unusual species.)",
+      sourceUrl: NOM.url, sourceTitle: NOM.title, sourceUpdatedAt: NOM.updated, verifiedAt: VERIFIED,
+      seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+      minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+      checkInseason: true, staleAfterDays: 60,
+    }),
+  ];
+}

--- a/src/features/fish-legal/mississippi-pack.ts
+++ b/src/features/fish-legal/mississippi-pack.ts
@@ -1,0 +1,178 @@
+/**
+ * Mississippi pack — `mississippi-2026-09-01`.
+ *
+ * Verbatims lifted 2026-09-02 from the MDMR "Recreational Catch Limits" table
+ * (dmr.ms.gov/recreational-catch-limits) — the page is the agency's official quick card
+ * ("The information on this page is an abstract of the rules and regulations in effect
+ * at the time of publishing"). MDMR Title 22 Part 3 (linked on the same site) supplies
+ * the Tails n' Scales reporting layer. Red snapper season is announced annually against
+ * the state quota (2025: May 23 – Jul 6, then re-opened at state discretion; 2/day, 16")
+ * — encoded as check-in-season.
+ */
+import type { RegArea, RegGroup, RegPack, RegRule } from "./types";
+
+export const MISSISSIPPI_PACK: RegPack = {
+  id: "mississippi-2026-09-01",
+  version: 1,
+  publishedAt: "2026-09-01T12:00:00Z",
+  notes:
+    "Mississippi (MDMR Recreational Catch Limits card): inshore + reef flagship species " +
+    "with the agency table's own numbers; red snapper reporting (Tails n' Scales) and " +
+    "announced season are quoted. State waters = 9 nm south of the barrier islands for " +
+    "state for-hire boats; federal Gulf rules apply beyond.",
+};
+
+const MS = { url: "https://dmr.ms.gov/recreational-catch-limits/", title: "MDMR — Recreational Catch Limits (official quick card)", updated: null };
+const VERIFIED = "2026-09-02";
+const pv = 1;
+
+export const MS_AREAS: readonly RegArea[] = [
+  {
+    id: "ms-gulf",
+    authority: "mdmr",
+    kind: "ocean_region",
+    name: "Mississippi — coastal waters envelope",
+    polygon: [[-89.75, 30.45], [-88.05, 30.5], [-88.05, 29.6], [-89.75, 29.2]],
+    sourceUrl: MS.url,
+    verifiedAt: VERIFIED,
+    notes: "Envelope for pack resolution and boundary folds (Biloxi/Gulfport inside).",
+  },
+];
+
+export const MS_GROUPS: readonly RegGroup[] = [];
+
+function rule(
+  r: Omit<RegRule, "packVersion" | "regGroupId"> & Partial<Pick<RegRule, "regGroupId">>,
+): RegRule {
+  return { regGroupId: null, ...r, packVersion: pv };
+}
+
+export const MS_RULES: readonly RegRule[] = [
+  rule({
+    id: "ms-seatrout-bag", speciesId: "spotted_seatrout", regAreaId: "ms-gulf", kind: "bag_limit",
+    verbatim: "Spotted Seatrout: 15 TL minimum; 15 bag/possession.",
+    sourceUrl: MS.url, sourceTitle: MS.title, sourceUpdatedAt: MS.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 15, possessionLimit: 15, bagSharesWithGroup: false,
+    minSizeIn: 15, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ms-red-drum-bag", speciesId: "red_drum", regAreaId: "ms-gulf", kind: "bag_limit",
+    verbatim:
+      "Red Drum: 18 TL to 30 TL; 3 bag/possession. Recreational fishermen may retain only one red drum over 30 inches.",
+    sourceUrl: MS.url, sourceTitle: MS.title, sourceUpdatedAt: MS.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 3, possessionLimit: 3, bagSharesWithGroup: false,
+    minSizeIn: 18, maxSizeIn: 30, sizeMeasure: "total_length", platformScope: null, depthNote: "One >30” bull counts inside the 3.",
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ms-flounder-bag", speciesId: "southern_flounder", regAreaId: "ms-gulf", kind: "bag_limit",
+    verbatim: "Flounder: 12 TL minimum; 10 bag/possession.",
+    sourceUrl: MS.url, sourceTitle: MS.title, sourceUpdatedAt: MS.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 10, possessionLimit: 10, bagSharesWithGroup: false,
+    minSizeIn: 12, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ms-sheepshead-bag", speciesId: "sheepshead", regAreaId: "ms-gulf", kind: "bag_limit",
+    verbatim: "Sheepshead: 14 TL minimum; 15 bag/possession.",
+    sourceUrl: MS.url, sourceTitle: MS.title, sourceUpdatedAt: MS.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 15, possessionLimit: 15, bagSharesWithGroup: false,
+    minSizeIn: 14, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ms-gray-snapper-bag", speciesId: "gray_snapper", regAreaId: "ms-gulf", kind: "bag_limit",
+    verbatim: "Gray Snapper: 12 TL minimum; 10 bag/possession (see Reef Fish section for harvest in aggregate with other snapper species).",
+    sourceUrl: MS.url, sourceTitle: MS.title, sourceUpdatedAt: MS.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 10, possessionLimit: 10, bagSharesWithGroup: false,
+    minSizeIn: 12, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null,
+    depthNote: "Federal 10-snapper aggregate applies in federal waters (gulfcouncil.org).",
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ms-red-snapper", speciesId: "red_snapper", regAreaId: "ms-gulf", kind: "bag_limit",
+    verbatim:
+      "Red Snapper: 16 TL minimum; 2 bag/possession. Reporting is required for Red Snapper trips and landings through the Tails n’ Scales program. Seasons are set annually by the Executive Director against the state quota (2025 season opened May 23 and ran seven days a week in state and federal waters until the annual catch limit was projected to be met).",
+    sourceUrl: MS.url, sourceTitle: MS.title, sourceUpdatedAt: MS.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 2, possessionLimit: 2, bagSharesWithGroup: false,
+    minSizeIn: 16, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null,
+    depthNote: "Open/close announced per season; Tails n’ Scales reporting mandatory.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ms-cobia-bag", speciesId: "cobia", regAreaId: "ms-gulf", kind: "bag_limit",
+    verbatim: "Cobia: 36 FL minimum; 2 bag/possession.",
+    sourceUrl: MS.url, sourceTitle: MS.title, sourceUpdatedAt: MS.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 2, possessionLimit: 2, bagSharesWithGroup: false,
+    minSizeIn: 36, maxSizeIn: null, sizeMeasure: "fork_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ms-tripletail-bag", speciesId: "tripletail", regAreaId: "ms-gulf", kind: "bag_limit",
+    verbatim: "Tripletail: 18 TL minimum; 3 bag/possession.",
+    sourceUrl: MS.url, sourceTitle: MS.title, sourceUpdatedAt: MS.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 3, possessionLimit: 3, bagSharesWithGroup: false,
+    minSizeIn: 18, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ms-king-mackerel-bag", speciesId: "king_mackerel", regAreaId: "ms-gulf", kind: "bag_limit",
+    verbatim: "King Mackerel: 24 FL minimum; 3 bag/possession.",
+    sourceUrl: MS.url, sourceTitle: MS.title, sourceUpdatedAt: MS.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 3, possessionLimit: 3, bagSharesWithGroup: false,
+    minSizeIn: 24, maxSizeIn: null, sizeMeasure: "fork_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ms-spanish-mackerel-bag", speciesId: "spanish_mackerel", regAreaId: "ms-gulf", kind: "bag_limit",
+    verbatim: "Spanish Mackerel: 12 FL minimum; 15 bag/possession.",
+    sourceUrl: MS.url, sourceTitle: MS.title, sourceUpdatedAt: MS.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 15, possessionLimit: 15, bagSharesWithGroup: false,
+    minSizeIn: 12, maxSizeIn: null, sizeMeasure: "fork_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ms-vermilion-snapper-bag", speciesId: "vermilion_snapper", regAreaId: "ms-gulf", kind: "bag_limit",
+    verbatim: "Vermilion Snapper: 10 TL minimum; 10 bag/possession; counts in the 20 Reef Fish Aggregate (with gray triggerfish, lane snapper, almaco jack, and tilefish).",
+    sourceUrl: MS.url, sourceTitle: MS.title, sourceUpdatedAt: MS.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 10, possessionLimit: 10, bagSharesWithGroup: false,
+    minSizeIn: 10, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null,
+    depthNote: "20 Reef Fish Aggregate is quoted, not yet a modeled group — pack-v2 debt.",
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ms-lane-snapper-bag", speciesId: "lane_snapper", regAreaId: "ms-gulf", kind: "bag_limit",
+    verbatim: "Lane Snapper: 8 TL minimum; 20 bag/possession; counts in the 20 Reef Fish Aggregate.",
+    sourceUrl: MS.url, sourceTitle: MS.title, sourceUpdatedAt: MS.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 20, possessionLimit: 20, bagSharesWithGroup: false,
+    minSizeIn: 8, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ms-amberjack-bag", speciesId: "greater_amberjack", regAreaId: "ms-gulf", kind: "bag_limit",
+    verbatim: "Greater Amberjack: 34 FL minimum; 1 bag/possession.",
+    sourceUrl: MS.url, sourceTitle: MS.title, sourceUpdatedAt: MS.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 34, maxSizeIn: null, sizeMeasure: "fork_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ms-tarpon-note", speciesId: "atlantic_tarpon", regAreaId: "ms-gulf", kind: "note",
+    verbatim: "Tarpon: 75 FL minimum; 1 per vessel. May not remove fish from water if over 40 inches in length unless harvesting within specified limits.",
+    sourceUrl: MS.url, sourceTitle: MS.title, sourceUpdatedAt: MS.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: 75, maxSizeIn: null, sizeMeasure: "fork_length", platformScope: "boat", depthNote: "Per-VESSEL, not per-person.",
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ms-no-sale", speciesId: null, regAreaId: "ms-gulf", kind: "note",
+    verbatim: "It is illegal to sell any seafood taken with a recreational license.",
+    sourceUrl: MS.url, sourceTitle: MS.title, sourceUpdatedAt: MS.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 90,
+  }),
+];
+
+export const MISSISSIPPI = { pack: MISSISSIPPI_PACK, areas: MS_AREAS, groups: MS_GROUPS, rules: MS_RULES };

--- a/src/features/fish-legal/packs.ts
+++ b/src/features/fish-legal/packs.ts
@@ -13,6 +13,12 @@ import { SOCAL } from "./reg-data";
 import { FLORIDA } from "./florida-pack";
 import { NORCAL } from "./norcal-pack";
 import { CA_FRESHWATER } from "./california-freshwater-pack";
+import { TEXAS } from "./texas-pack";
+import { LOUISIANA } from "./louisiana-pack";
+import { MISSISSIPPI } from "./mississippi-pack";
+import { ALABAMA } from "./alabama-pack";
+import { BAJA_CALIFORNIA } from "./baja-pack";
+import { BAJA_CALIFORNIA_SUR } from "./bcs-pack";
 import type { RegPack, RegArea, RegGroup, RegRule } from "./types";
 
 export type RegBundle = {
@@ -66,6 +72,58 @@ export const PACKS: readonly BundledPack[] = [
     shortCode: "FL",
     primaryAreaId: "fl-state-waters",
     data: FLORIDA,
+  },
+  // ——— States expansion wave 1 (2026-09-02): Gulf + Baja. Verbatims live in each pack.
+  {
+    regionId: "texas",
+    jurisdictionLabel: "Texas — TPWD (US)",
+    shortCode: "TX",
+    primaryAreaId: "tx-gulf",
+    data: TEXAS,
+  },
+  {
+    regionId: "louisiana",
+    jurisdictionLabel: "Louisiana — LDWF (US)",
+    shortCode: "LA",
+    primaryAreaId: "la-gulf",
+    data: LOUISIANA,
+  },
+  {
+    regionId: "mississippi",
+    jurisdictionLabel: "Mississippi — MDMR (US)",
+    shortCode: "MS",
+    primaryAreaId: "ms-gulf",
+    data: MISSISSIPPI,
+  },
+  {
+    regionId: "alabama",
+    jurisdictionLabel: "Alabama — ADCNR (US)",
+    shortCode: "AL",
+    primaryAreaId: "al-gulf",
+    data: ALABAMA,
+  },
+  {
+    regionId: "baja_california",
+    jurisdictionLabel: "Baja California — CONAPESCA (MX)",
+    shortCode: "MX·BC",
+    primaryAreaId: "mx-baja-california",
+    data: BAJA_CALIFORNIA,
+  },
+  {
+    regionId: "baja_california_sur",
+    jurisdictionLabel: "Baja California Sur — CONAPESCA (MX)",
+    shortCode: "MX·BCS",
+    primaryAreaId: "mx-baja-california-sur",
+    data: BAJA_CALIFORNIA_SUR,
+  },
+  {
+    // Legacy region (pre-wave lister's "Cabo") — Cabo San Lucas is in BCS; the BCS
+    // pack answers for it identically (NOM-017 is federal).
+    regionId: "cabo_baja",
+    jurisdictionLabel: "Baja California Sur — CONAPESCA (MX)",
+    shortCode: "MX·BCS",
+    primaryAreaId: "mx-baja-california-sur",
+    data: BAJA_CALIFORNIA_SUR,
   },
 ];
 

--- a/src/features/fish-legal/reg-data-parity.test.ts
+++ b/src/features/fish-legal/reg-data-parity.test.ts
@@ -5,6 +5,19 @@ import { describe, expect, it } from "vitest";
 
 import { SOCAL } from "./reg-data";
 import { FLORIDA } from "./florida-pack";
+import { NORCAL } from "./norcal-pack";
+import { CA_FRESHWATER } from "./california-freshwater-pack";
+import { TEXAS } from "./texas-pack";
+import { LOUISIANA } from "./louisiana-pack";
+import { MISSISSIPPI } from "./mississippi-pack";
+import { ALABAMA } from "./alabama-pack";
+import { BAJA_CALIFORNIA } from "./baja-pack";
+import { BAJA_CALIFORNIA_SUR } from "./bcs-pack";
+
+const LATER_BUNDLES = [
+  NORCAL, CA_FRESHWATER, TEXAS, LOUISIANA, MISSISSIPPI, ALABAMA,
+  BAJA_CALIFORNIA, BAJA_CALIFORNIA_SUR,
+];
 
 /*
  * The regulations dataset exists twice by design: the SQL pack (server source of truth,
@@ -63,5 +76,17 @@ describe("pack ↔ migration parity (Fish Legal: both packs)", () => {
 
   it("bundle pack versions match the migration's reg_pack versions", () => {
     expect(sql).toContain(`'socal-2026-09-01', ${SOCAL.pack.version}`);
+  });
+
+  it("every later pack's rule verbatim sentence exists in its migration", () => {
+    const missing = LATER_BUNDLES.flatMap((b) => b.rules).filter((r) => !sql.includes(r.verbatim));
+    expect(missing.map((r) => r.id)).toEqual([]);
+  });
+
+  it("every later pack's area + pack ids exist in its migration", () => {
+    for (const b of LATER_BUNDLES) {
+      for (const a of b.areas) expect(sql).toContain(`'${a.id}'`);
+      expect(sql).toContain(`'${b.pack.id}', ${b.pack.version}`);
+    }
   });
 });

--- a/src/features/fish-legal/states-wave1.test.ts
+++ b/src/features/fish-legal/states-wave1.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { packForRegion } from "./packs";
+import { speciesById } from "@/core/ontology/species";
+import { regionById, popularSpeciesIds } from "@/core/ontology/regions";
+import { limitLines } from "./catch-limits";
+
+const WAVE1 = ["texas", "louisiana", "mississippi", "alabama", "baja_california", "baja_california_sur", "cabo_baja"] as const;
+
+describe("states expansion wave 1 (Gulf + Baja)", () => {
+  it("every wave-1 region resolves to a pack", () => {
+    for (const id of WAVE1) expect(packForRegion(id), id).not.toBeNull();
+  });
+
+  it("every rule in wave-1 packs carries a verbatim, a source URL, and a verification date", () => {
+    for (const id of WAVE1) {
+      const bundle = packForRegion(id)!.data;
+      for (const r of bundle.rules) {
+        expect(r.verbatim.length, `${id}/${r.id} verbatim`).toBeGreaterThan(20);
+        expect(r.sourceUrl.startsWith("http"), `${id}/${r.id} sourceUrl`).toBe(true);
+        expect(r.verifiedAt, `${id}/${r.id} verifiedAt`).toBe("2026-09-02");
+      }
+    }
+  });
+
+  it("species rows named by wave-1 rules exist in the vocabulary", () => {
+    for (const id of WAVE1) {
+      for (const r of packForRegion(id)!.data.rules) {
+        if (r.speciesId) expect(speciesById(r.speciesId), `${id}/${r.id} species ${r.speciesId}`).not.toBeNull();
+      }
+    }
+  });
+
+  it("Texas trout is the 2026-27 rule (3/day, 15-20 slot); LA reds are the 2024 reset (4/day, 18-27)", () => {
+    const tx = packForRegion("texas")!.data.rules.find((r) => r.speciesId === "spotted_seatrout")!;
+    expect(tx.bagDaily).toBe(3);
+    expect([tx.minSizeIn, tx.maxSizeIn]).toEqual([15, 20]);
+    const la = packForRegion("louisiana")!.data.rules.find((r) => r.speciesId === "red_drum")!;
+    expect(la.bagDaily).toBe(4);
+    expect([la.minSizeIn, la.maxSizeIn]).toEqual([18, 27]);
+  });
+
+  it("Mexico pack composition: dorado/rooster 2 counting-heavy, marlin/sail 1, composite note present", () => {
+    const bc = packForRegion("baja_california")!.data;
+    expect(bc.rules.find((r) => r.speciesId === "dorado")!.bagDaily).toBe(2);
+    expect(bc.rules.find((r) => r.speciesId === "striped_marlin")!.bagDaily).toBe(1);
+    expect(bc.rules.some((r) => r.verbatim.includes("Diez ejemplares"))).toBe(true);
+    // BCS is the same federal law on its own area (Cabo region resolves there too).
+    expect(packForRegion("cabo_baja")!.data.pack.id).toBe("baja-california-sur-2026-09-01");
+  });
+
+  it("kept fish count toward wave-1 species caps (limits engine reads the packs)", () => {
+    const lines = limitLines(packForRegion("texas")!.data, "2026-09-02", new Map([["red_drum", 2]]));
+    const red = lines.find((l) => l.id === "red_drum")!;
+    expect(red.limit).toBe(3);
+    expect(red.retained).toBe(2);
+    expect(red.state).toBe("approaching");
+  });
+
+  it("Settings regions exist for the wave and lead with real species", () => {
+    for (const id of ["texas", "louisiana", "mississippi", "alabama", "baja_california", "baja_california_sur"]) {
+      expect(regionById(id), id).not.toBeNull();
+      const pops = popularSpeciesIds(id as Parameters<typeof popularSpeciesIds>[0]);
+      expect(pops.length).toBeGreaterThan(5);
+      expect(pops.every((s) => speciesById(s) !== null)).toBe(true);
+    }
+  });
+});

--- a/src/features/fish-legal/texas-pack.ts
+++ b/src/features/fish-legal/texas-pack.ts
@@ -1,0 +1,232 @@
+/**
+ * Texas pack — `texas-2026-09-01`.
+ *
+ * Every verbatim string below was lifted on 2026-09-02 from the TPWD Outdoor Annual
+ * per-species pages ("Valid Sep. 1, 2026 through Aug. 31, 2027"), which carry the exact
+ * clause text of the rule. Sources:
+ *   T<species> = https://tpwd.texas.gov/regulations/outdoor-annual/fishing/saltwater-fishing/bag-length-limits/<species>-bag-length-limits
+ * TPWD page glossies restate on every page: possession limit = double the daily bag
+ * unless otherwise noted; limits apply out to 9 nm (state) and to EEZ-caught fish
+ * possessed in/landed in Texas. Nothing here is inferred from aggregators.
+ */
+import type { RegArea, RegGroup, RegPack, RegRule } from "./types";
+
+export const TEXAS_PACK: RegPack = {
+  id: "texas-2026-09-01",
+  version: 1,
+  publishedAt: "2026-09-01T12:00:00Z",
+  notes:
+    "Texas (TPWD Outdoor Annual 2026-2027, valid Sep 1 2026–Aug 31 2027): flagship " +
+    "inshore + reef species with verbatim clause text; 2026-27 red snapper federal " +
+    "season flagged check-in-season. Tags (Red Drum Tag, Spotted Seatrout Tag) are the " +
+    "paper exception layer and are quoted, not modeled.",
+};
+
+const TX_T = "https://tpwd.texas.gov/regulations/outdoor-annual/fishing/saltwater-fishing/bag-length-limits/";
+const VERIFIED = "2026-09-02";
+const V = "2026-09-01"; // Outdoor Annual valid-from
+const pv = 1;
+
+export const TX_AREAS: readonly RegArea[] = [
+  {
+    // Coastline envelope: Louisiana line (~93.9°W, 29.4°N) down to the Rio Grande —
+    // north walls chosen to keep bay/coastline points inside and inland cities out.
+    id: "tx-gulf",
+    authority: "tpwd",
+    kind: "ocean_region",
+    name: "Texas — coastal waters envelope",
+    polygon: [
+      [-93.9, 29.2], [-93.4, 29.6], [-94.3, 29.6], [-95.0, 29.2], [-95.8, 28.9],
+      [-97.0, 28.6], [-97.3, 27.8], [-97.5, 26.1], [-97.2, 25.97], [-97.5, 26.0],
+      [-93.9, 27.4],
+    ],
+    sourceUrl: TX_T.slice(0, -1),
+    verifiedAt: VERIFIED,
+    notes: "Envelope for pack resolution and boundary folds; 9-nm state/200-nm EEZ split quoted in rules, not drawn.",
+  },
+];
+
+export const TX_GROUPS: readonly RegGroup[] = [];
+
+function rule(
+  r: Omit<RegRule, "packVersion" | "regGroupId"> & Partial<Pick<RegRule, "regGroupId">>,
+): RegRule {
+  return { regGroupId: null, ...r, packVersion: pv };
+}
+
+export const TX_RULES: readonly RegRule[] = [
+  rule({
+    id: "tx-red-drum-bag", speciesId: "red_drum", regAreaId: "tx-gulf", kind: "bag_limit",
+    verbatim:
+      "Red drum — Daily Bag: 3. Min Length: 20 inches. Max Length: 28 inches. During a license year, one red drum over the stated maximum length limit may be retained when affixed with a properly completed Red Drum Tag and one red drum over the stated maximum length limit may be retained when affixed with a properly completed Bonus Red Drum Tag; fish retained under authority of a tag may be retained in addition to the daily bag and possession limit.",
+    sourceUrl: `${TX_T}drum-bag-length-limits`, sourceTitle: "TPWD Outdoor Annual 2026-2027 — Drum Bag & Length Limits (valid 2026-09-01..2027-08-31)",
+    sourceUpdatedAt: V, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 3, possessionLimit: 6, bagSharesWithGroup: false,
+    minSizeIn: 20, maxSizeIn: 28, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "tx-spotted-seatrout-bag", speciesId: "spotted_seatrout", regAreaId: "tx-gulf", kind: "bag_limit",
+    verbatim:
+      "Spotted seatrout — Daily Bag: 3. Min Length: 15 inches. Max Length: 20 inches. During a license year, one spotted seatrout over 28 inches may be retained when affixed with a properly completed Spotted Seatrout Tag and one over 28 inches via a Bonus Spotted Seatrout Tag; tag fish are retained in addition to the daily bag and possession limit.",
+    sourceUrl: `${TX_T}seatrout-bag-length-limits`, sourceTitle: "TPWD Outdoor Annual 2026-2027 — Seatrout Bag & Length Limits (valid 2026-09-01..2027-08-31)",
+    sourceUpdatedAt: V, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 3, possessionLimit: 6, bagSharesWithGroup: false,
+    minSizeIn: 15, maxSizeIn: 20, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "tx-flounder-open", speciesId: "southern_flounder", regAreaId: "tx-gulf", kind: "bag_limit",
+    verbatim:
+      "Flounder — all species, their hybrids and subspecies: Daily Bag: 5. Min Length: 15 inches. Max Length: No limit. Daily bag is 5 fish except Nov 1 – Dec 14 (fishery closed; bag limit = 0). Possession limit = the daily bag.",
+    sourceUrl: `${TX_T}flounder-bag-length-limits`, sourceTitle: "TPWD Outdoor Annual 2026-2027 — Flounder Bag & Length Limits (valid 2026-09-01..2027-08-31)",
+    sourceUpdatedAt: V, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: false,
+    minSizeIn: 15, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "tx-flounder-closed", speciesId: "southern_flounder", regAreaId: "tx-gulf", kind: "season",
+    verbatim:
+      "Flounder — all species: bag limit = 0 between Nov 1 and Dec 14 (fishery closed). Outside the closure, daily bag is 5 fish, min length 15 inches; possession limit = the daily bag.",
+    sourceUrl: `${TX_T}flounder-bag-length-limits`, sourceTitle: "TPWD Outdoor Annual 2026-2027 — Flounder Bag & Length Limits (valid 2026-09-01..2027-08-31)",
+    sourceUpdatedAt: V, verifiedAt: VERIFIED,
+    seasonStart: "11-01", seasonEnd: "12-14", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "tx-black-drum-bag", speciesId: "black_drum", regAreaId: "tx-gulf", kind: "bag_limit",
+    verbatim:
+      "Black drum — Daily Bag: 5. Min Length: 14 inches. Max Length: 30 inches. No more than one black drum over 52 inches may be retained per person per day and counts as part of the daily bag limit and possession limit.",
+    sourceUrl: `${TX_T}drum-bag-length-limits`, sourceTitle: "TPWD Outdoor Annual 2026-2027 — Drum Bag & Length Limits (valid 2026-09-01..2027-08-31)",
+    sourceUpdatedAt: V, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 5, possessionLimit: 10, bagSharesWithGroup: false,
+    minSizeIn: 14, maxSizeIn: 30, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "tx-sheepshead-bag", speciesId: "sheepshead", regAreaId: "tx-gulf", kind: "bag_limit",
+    verbatim: "Sheepshead — Daily Bag: 5. Min Length: 15 inches. Max Length: No limit.",
+    sourceUrl: `${TX_T}sheepshead-bag-length-limits`, sourceTitle: "TPWD Outdoor Annual 2026-2027 — Sheepshead Bag & Length Limits (valid 2026-09-01..2027-08-31)",
+    sourceUpdatedAt: V, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 5, possessionLimit: 10, bagSharesWithGroup: false,
+    minSizeIn: 15, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "tx-snook-bag", speciesId: "common_snook", regAreaId: "tx-gulf", kind: "bag_limit",
+    verbatim: "Snook — Daily Bag: 1. Min Length: 24 inches. Max Length: 28 inches.",
+    sourceUrl: `${TX_T}snook-bag-length-limits`, sourceTitle: "TPWD Outdoor Annual 2026-2027 — Snook Bag & Length Limits (valid 2026-09-01..2027-08-31)",
+    sourceUpdatedAt: V, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 2, bagSharesWithGroup: false,
+    minSizeIn: 24, maxSizeIn: 28, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "tx-king-mackerel-bag", speciesId: "king_mackerel", regAreaId: "tx-gulf", kind: "bag_limit",
+    verbatim: "King mackerel — Daily Bag: 3. Min Length: 27 inches. Max Length: No limit.",
+    sourceUrl: `${TX_T}mackerel-bag-length-limits`, sourceTitle: "TPWD Outdoor Annual 2026-2027 — Mackerel Bag & Length Limits (valid 2026-09-01..2027-08-31)",
+    sourceUpdatedAt: V, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 3, possessionLimit: 6, bagSharesWithGroup: false,
+    minSizeIn: 27, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "tx-spanish-mackerel-bag", speciesId: "spanish_mackerel", regAreaId: "tx-gulf", kind: "bag_limit",
+    verbatim: "Spanish mackerel — Daily Bag: 15. Min Length: 14 inches. Max Length: No limit.",
+    sourceUrl: `${TX_T}mackerel-bag-length-limits`, sourceTitle: "TPWD Outdoor Annual 2026-2027 — Mackerel Bag & Length Limits (valid 2026-09-01..2027-08-31)",
+    sourceUpdatedAt: V, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 15, possessionLimit: 30, bagSharesWithGroup: false,
+    minSizeIn: 14, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "tx-red-snapper-state", speciesId: "red_snapper", regAreaId: "tx-gulf", kind: "bag_limit",
+    verbatim:
+      "Red Snapper in State Waters — Open: Year-round. Bag limit: 4 fish per person daily. Size limit: 15-in minimum. Applies to private recreational anglers in state waters. Means & Methods: it is unlawful to use any kind of hook other than a circle hook when using natural bait.",
+    sourceUrl: `${TX_T}snapper-bag-length-limits`, sourceTitle: "TPWD Outdoor Annual 2026-2027 — Snapper Bag & Length Limits (valid 2026-09-01..2027-08-31)",
+    sourceUpdatedAt: V, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 4, possessionLimit: 8, bagSharesWithGroup: false,
+    minSizeIn: 15, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "State waters only (0–9 nm); federal-waters season is quota-managed.",
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "tx-red-snapper-federal-note", speciesId: "red_snapper", regAreaId: "tx-gulf", kind: "note",
+    verbatim:
+      "Red Snapper Season in Federal Waters — Opens: May 22, 2026. Closes: in-season harvest will be monitored to determine the closure date. Bag limit: 2 fish per person daily; Size limit: 16-in minimum. Applies to private recreational anglers in federal waters.",
+    sourceUrl: `${TX_T}snapper-bag-length-limits`, sourceTitle: "TPWD Outdoor Annual 2026-2027 — Snapper Bag & Length Limits (valid 2026-09-01..2027-08-31)",
+    sourceUpdatedAt: V, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "Federal waters 9–200 nm; closure date set in-season by harvest monitoring.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "tx-lane-snapper-min", speciesId: "lane_snapper", regAreaId: "tx-gulf", kind: "min_size",
+    verbatim: "Lane snapper — Daily Bag: No limit. Min Length: 8 inches. Max Length: No limit.",
+    sourceUrl: `${TX_T}snapper-bag-length-limits`, sourceTitle: "TPWD Outdoor Annual 2026-2027 — Snapper Bag & Length Limits (valid 2026-09-01..2027-08-31)",
+    sourceUpdatedAt: V, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: 8, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "tx-vermilion-snapper-min", speciesId: "vermilion_snapper", regAreaId: "tx-gulf", kind: "min_size",
+    verbatim: "Vermilion snapper — Daily Bag: No limit. Min Length: 10 inches. Max Length: No limit.",
+    sourceUrl: `${TX_T}snapper-bag-length-limits`, sourceTitle: "TPWD Outdoor Annual 2026-2027 — Snapper Bag & Length Limits (valid 2026-09-01..2027-08-31)",
+    sourceUpdatedAt: V, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: 10, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "tx-cobia-bag", speciesId: "cobia", regAreaId: "tx-gulf", kind: "bag_limit",
+    verbatim: "Cobia — Daily Bag: 1. Min Length: 40 inches. Max Length: No limit.",
+    sourceUrl: `${TX_T}cobia-bag-length-limits`, sourceTitle: "TPWD Outdoor Annual 2026-2027 — Cobia Bag & Length Limits (valid 2026-09-01..2027-08-31)",
+    sourceUpdatedAt: V, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 2, bagSharesWithGroup: false,
+    minSizeIn: 40, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "tx-tripletail-bag", speciesId: "tripletail", regAreaId: "tx-gulf", kind: "bag_limit",
+    verbatim: "Tripletail — Daily Bag: 3. Min Length: 17 inches. Max Length: No limit.",
+    sourceUrl: `${TX_T}tripletail-bag-length-limits`, sourceTitle: "TPWD Outdoor Annual 2026-2027 — Tripletail Bag & Length Limits (valid 2026-09-01..2027-08-31)",
+    sourceUpdatedAt: V, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 3, possessionLimit: 6, bagSharesWithGroup: false,
+    minSizeIn: 17, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "tx-amberjack-bag", speciesId: "greater_amberjack", regAreaId: "tx-gulf", kind: "bag_limit",
+    verbatim: "Amberjack, greater — Daily Bag: 1. Min Length: 38 inches. Max Length: No limit.",
+    sourceUrl: `${TX_T}amberjack-bag-length-limits`, sourceTitle: "TPWD Outdoor Annual 2026-2027 — Amberjack Bag & Length Limits (valid 2026-09-01..2027-08-31)",
+    sourceUpdatedAt: V, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 2, bagSharesWithGroup: false,
+    minSizeIn: 38, maxSizeIn: null, sizeMeasure: "fork_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "tx-reef-descending-gear", speciesId: "red_snapper", regAreaId: "tx-gulf", kind: "gear",
+    verbatim:
+      "Texas regulations now require all commercial and recreational anglers fishing in state waters to use a venting tool or rigged descending device on reef fish exhibiting signs of barotrauma; per the 2022 DESCEND Act, similar requirements are in place for boats fishing for reef fish in federal waters.",
+    sourceUrl: `${TX_T}snapper-bag-length-limits`, sourceTitle: "TPWD Outdoor Annual 2026-2027 — Snapper Bag & Length Limits (valid 2026-09-01..2027-08-31)",
+    sourceUpdatedAt: V, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+  rule({
+    id: "tx-shark-note", speciesId: null, regAreaId: "tx-gulf", kind: "note",
+    verbatim:
+      "The daily bag limit is 1 fish for all allowable shark species INCLUDING Atlantic sharpnose, blacktip and bonnethead; non-offset, non-stainless steel circle hooks must be used when fishing for shark in state waters. Prohibited shark species may not be retained at all.",
+    sourceUrl: `https://tpwd.texas.gov/regulations/outdoor-annual/fishing/shark-regulations`,
+    sourceTitle: "TPWD Outdoor Annual 2026-2027 — Shark Regulations",
+    sourceUpdatedAt: V, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 2, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 60,
+  }),
+];
+
+export const TEXAS = { pack: TEXAS_PACK, areas: TX_AREAS, groups: TX_GROUPS, rules: TX_RULES };

--- a/supabase/migrations/20260902130000_v2_states_wave1_gulf_baja.sql
+++ b/supabase/migrations/20260902130000_v2_states_wave1_gulf_baja.sql
@@ -1,0 +1,254 @@
+-- States expansion wave 1 (spec docs/specs/fish-legal-expansion.md, addendum
+-- 2026-09-02): Gulf coast (TX/TPWD, LA/LDWF, MS/MDMR, AL/ADCNR) + Mexico (Baja
+-- California, Baja California Sur — CONAPESCA NOM-017-PESC-1994, federal, so emitted
+-- once per area). GENERATED deterministically from the six pack bundles via
+-- scripts/gen-states-wave1.mts — edit bundles, regenerate; appendix species inserts
+-- below mirror src/core/ontology/species.ts additions (puning guard in tests).
+-- area.kind reuses 'ocean_region' — CHECK constraint untouched.
+
+insert into public.species (id, common_name, scientific_name, is_group, rolls_up_to, water_class, take_status, sort_order, needs_review) values
+  ('black_drum', 'Black drum', 'Pogonias cromis', false, null, 'salt', 'regulated', 437, false),
+  ('tripletail', 'Tripletail', 'Lobotes surinamensis', false, null, 'salt', 'regulated', 438, false),
+  ('gray_triggerfish', 'Gray triggerfish', 'Balistes capriscus', false, null, 'salt', 'regulated', 439, false),
+  ('vermilion_snapper', 'Vermilion snapper (beeliner)', 'Rhomboplites aurorubens', false, null, 'salt', 'regulated', 440, false),
+  ('lane_snapper', 'Lane snapper', 'Lutjanus synagris', false, null, 'salt', 'regulated', 441, false),
+  ('mutton_snapper', 'Mutton snapper', 'Lutjanus analis', false, null, 'salt', 'regulated', 442, false),
+  ('sand_seatrout', 'Sand seatrout (white trout)', 'Cynoscion arenarius', false, null, 'salt', 'open', 443, false)
+on conflict (id) do nothing;
+
+insert into public.reg_pack (id, version, published_at, notes) values
+  ('texas-2026-09-01', 1, '2026-09-01T12:00:00Z', 'Texas (TPWD Outdoor Annual 2026-2027, valid Sep 1 2026–Aug 31 2027): flagship inshore + reef species with verbatim clause text; 2026-27 red snapper federal season flagged check-in-season. Tags (Red Drum Tag, Spotted Seatrout Tag) are the paper exception layer and are quoted, not modeled.')
+on conflict (id) do nothing;
+
+insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geojson, source_url, verified_at, notes) values
+  ('tx-gulf', 'tpwd', 'ocean_region', 'Texas — coastal waters envelope', null, null, 'https://tpwd.texas.gov/regulations/outdoor-annual/fishing/saltwater-fishing/bag-length-limits', '2026-09-02', 'Envelope for pack resolution and boundary folds; 9-nm state/200-nm EEZ split quoted in rules, not drawn.')
+on conflict (id) do nothing;
+
+insert into public.reg_rule
+  (species_id, reg_group_id, reg_area_id, water_class, kind, verbatim, source_url, source_title, source_updated_at, verified_at, pack_version,
+   season_start, season_end, bag_daily, possession_limit, min_size_in, max_size_in, size_measure, platform_scope, depth_note, check_inseason, stale_after_days)
+values
+  ('red_drum', null, 'tx-gulf', 'salt', 'bag_limit', 'Red drum — Daily Bag: 3. Min Length: 20 inches. Max Length: 28 inches. During a license year, one red drum over the stated maximum length limit may be retained when affixed with a properly completed Red Drum Tag and one red drum over the stated maximum length limit may be retained when affixed with a properly completed Bonus Red Drum Tag; fish retained under authority of a tag may be retained in addition to the daily bag and possession limit.', 'https://tpwd.texas.gov/regulations/outdoor-annual/fishing/saltwater-fishing/bag-length-limits/drum-bag-length-limits', 'TPWD Outdoor Annual 2026-2027 — Drum Bag & Length Limits (valid 2026-09-01..2027-08-31)', '2026-09-01', '2026-09-02', 1,
+   null, null, 3, 6, 20, 28, 'total_length', null, null, false, 60),
+  ('spotted_seatrout', null, 'tx-gulf', 'salt', 'bag_limit', 'Spotted seatrout — Daily Bag: 3. Min Length: 15 inches. Max Length: 20 inches. During a license year, one spotted seatrout over 28 inches may be retained when affixed with a properly completed Spotted Seatrout Tag and one over 28 inches via a Bonus Spotted Seatrout Tag; tag fish are retained in addition to the daily bag and possession limit.', 'https://tpwd.texas.gov/regulations/outdoor-annual/fishing/saltwater-fishing/bag-length-limits/seatrout-bag-length-limits', 'TPWD Outdoor Annual 2026-2027 — Seatrout Bag & Length Limits (valid 2026-09-01..2027-08-31)', '2026-09-01', '2026-09-02', 1,
+   null, null, 3, 6, 15, 20, 'total_length', null, null, false, 60),
+  ('southern_flounder', null, 'tx-gulf', 'salt', 'bag_limit', 'Flounder — all species, their hybrids and subspecies: Daily Bag: 5. Min Length: 15 inches. Max Length: No limit. Daily bag is 5 fish except Nov 1 – Dec 14 (fishery closed; bag limit = 0). Possession limit = the daily bag.', 'https://tpwd.texas.gov/regulations/outdoor-annual/fishing/saltwater-fishing/bag-length-limits/flounder-bag-length-limits', 'TPWD Outdoor Annual 2026-2027 — Flounder Bag & Length Limits (valid 2026-09-01..2027-08-31)', '2026-09-01', '2026-09-02', 1,
+   null, null, 5, 5, 15, null, 'total_length', null, null, false, 60),
+  ('southern_flounder', null, 'tx-gulf', 'salt', 'season', 'Flounder — all species: bag limit = 0 between Nov 1 and Dec 14 (fishery closed). Outside the closure, daily bag is 5 fish, min length 15 inches; possession limit = the daily bag.', 'https://tpwd.texas.gov/regulations/outdoor-annual/fishing/saltwater-fishing/bag-length-limits/flounder-bag-length-limits', 'TPWD Outdoor Annual 2026-2027 — Flounder Bag & Length Limits (valid 2026-09-01..2027-08-31)', '2026-09-01', '2026-09-02', 1,
+   '2026-11-01', '2026-12-14', null, null, null, null, null, null, null, false, 60),
+  ('black_drum', null, 'tx-gulf', 'salt', 'bag_limit', 'Black drum — Daily Bag: 5. Min Length: 14 inches. Max Length: 30 inches. No more than one black drum over 52 inches may be retained per person per day and counts as part of the daily bag limit and possession limit.', 'https://tpwd.texas.gov/regulations/outdoor-annual/fishing/saltwater-fishing/bag-length-limits/drum-bag-length-limits', 'TPWD Outdoor Annual 2026-2027 — Drum Bag & Length Limits (valid 2026-09-01..2027-08-31)', '2026-09-01', '2026-09-02', 1,
+   null, null, 5, 10, 14, 30, 'total_length', null, null, false, 60),
+  ('sheepshead', null, 'tx-gulf', 'salt', 'bag_limit', 'Sheepshead — Daily Bag: 5. Min Length: 15 inches. Max Length: No limit.', 'https://tpwd.texas.gov/regulations/outdoor-annual/fishing/saltwater-fishing/bag-length-limits/sheepshead-bag-length-limits', 'TPWD Outdoor Annual 2026-2027 — Sheepshead Bag & Length Limits (valid 2026-09-01..2027-08-31)', '2026-09-01', '2026-09-02', 1,
+   null, null, 5, 10, 15, null, 'total_length', null, null, false, 60),
+  ('common_snook', null, 'tx-gulf', 'salt', 'bag_limit', 'Snook — Daily Bag: 1. Min Length: 24 inches. Max Length: 28 inches.', 'https://tpwd.texas.gov/regulations/outdoor-annual/fishing/saltwater-fishing/bag-length-limits/snook-bag-length-limits', 'TPWD Outdoor Annual 2026-2027 — Snook Bag & Length Limits (valid 2026-09-01..2027-08-31)', '2026-09-01', '2026-09-02', 1,
+   null, null, 1, 2, 24, 28, 'total_length', null, null, false, 60),
+  ('king_mackerel', null, 'tx-gulf', 'salt', 'bag_limit', 'King mackerel — Daily Bag: 3. Min Length: 27 inches. Max Length: No limit.', 'https://tpwd.texas.gov/regulations/outdoor-annual/fishing/saltwater-fishing/bag-length-limits/mackerel-bag-length-limits', 'TPWD Outdoor Annual 2026-2027 — Mackerel Bag & Length Limits (valid 2026-09-01..2027-08-31)', '2026-09-01', '2026-09-02', 1,
+   null, null, 3, 6, 27, null, 'total_length', null, null, false, 60),
+  ('spanish_mackerel', null, 'tx-gulf', 'salt', 'bag_limit', 'Spanish mackerel — Daily Bag: 15. Min Length: 14 inches. Max Length: No limit.', 'https://tpwd.texas.gov/regulations/outdoor-annual/fishing/saltwater-fishing/bag-length-limits/mackerel-bag-length-limits', 'TPWD Outdoor Annual 2026-2027 — Mackerel Bag & Length Limits (valid 2026-09-01..2027-08-31)', '2026-09-01', '2026-09-02', 1,
+   null, null, 15, 30, 14, null, 'total_length', null, null, false, 60),
+  ('red_snapper', null, 'tx-gulf', 'salt', 'bag_limit', 'Red Snapper in State Waters — Open: Year-round. Bag limit: 4 fish per person daily. Size limit: 15-in minimum. Applies to private recreational anglers in state waters. Means & Methods: it is unlawful to use any kind of hook other than a circle hook when using natural bait.', 'https://tpwd.texas.gov/regulations/outdoor-annual/fishing/saltwater-fishing/bag-length-limits/snapper-bag-length-limits', 'TPWD Outdoor Annual 2026-2027 — Snapper Bag & Length Limits (valid 2026-09-01..2027-08-31)', '2026-09-01', '2026-09-02', 1,
+   null, null, 4, 8, 15, null, 'total_length', null, 'State waters only (0–9 nm); federal-waters season is quota-managed.', false, 60),
+  ('red_snapper', null, 'tx-gulf', 'salt', 'note', 'Red Snapper Season in Federal Waters — Opens: May 22, 2026. Closes: in-season harvest will be monitored to determine the closure date. Bag limit: 2 fish per person daily; Size limit: 16-in minimum. Applies to private recreational anglers in federal waters.', 'https://tpwd.texas.gov/regulations/outdoor-annual/fishing/saltwater-fishing/bag-length-limits/snapper-bag-length-limits', 'TPWD Outdoor Annual 2026-2027 — Snapper Bag & Length Limits (valid 2026-09-01..2027-08-31)', '2026-09-01', '2026-09-02', 1,
+   null, null, null, null, null, null, null, null, 'Federal waters 9–200 nm; closure date set in-season by harvest monitoring.', true, 30),
+  ('lane_snapper', null, 'tx-gulf', 'salt', 'min_size', 'Lane snapper — Daily Bag: No limit. Min Length: 8 inches. Max Length: No limit.', 'https://tpwd.texas.gov/regulations/outdoor-annual/fishing/saltwater-fishing/bag-length-limits/snapper-bag-length-limits', 'TPWD Outdoor Annual 2026-2027 — Snapper Bag & Length Limits (valid 2026-09-01..2027-08-31)', '2026-09-01', '2026-09-02', 1,
+   null, null, null, null, 8, null, 'total_length', null, null, false, 60),
+  ('vermilion_snapper', null, 'tx-gulf', 'salt', 'min_size', 'Vermilion snapper — Daily Bag: No limit. Min Length: 10 inches. Max Length: No limit.', 'https://tpwd.texas.gov/regulations/outdoor-annual/fishing/saltwater-fishing/bag-length-limits/snapper-bag-length-limits', 'TPWD Outdoor Annual 2026-2027 — Snapper Bag & Length Limits (valid 2026-09-01..2027-08-31)', '2026-09-01', '2026-09-02', 1,
+   null, null, null, null, 10, null, 'total_length', null, null, false, 60),
+  ('cobia', null, 'tx-gulf', 'salt', 'bag_limit', 'Cobia — Daily Bag: 1. Min Length: 40 inches. Max Length: No limit.', 'https://tpwd.texas.gov/regulations/outdoor-annual/fishing/saltwater-fishing/bag-length-limits/cobia-bag-length-limits', 'TPWD Outdoor Annual 2026-2027 — Cobia Bag & Length Limits (valid 2026-09-01..2027-08-31)', '2026-09-01', '2026-09-02', 1,
+   null, null, 1, 2, 40, null, 'total_length', null, null, false, 60),
+  ('tripletail', null, 'tx-gulf', 'salt', 'bag_limit', 'Tripletail — Daily Bag: 3. Min Length: 17 inches. Max Length: No limit.', 'https://tpwd.texas.gov/regulations/outdoor-annual/fishing/saltwater-fishing/bag-length-limits/tripletail-bag-length-limits', 'TPWD Outdoor Annual 2026-2027 — Tripletail Bag & Length Limits (valid 2026-09-01..2027-08-31)', '2026-09-01', '2026-09-02', 1,
+   null, null, 3, 6, 17, null, 'total_length', null, null, false, 60),
+  ('greater_amberjack', null, 'tx-gulf', 'salt', 'bag_limit', 'Amberjack, greater — Daily Bag: 1. Min Length: 38 inches. Max Length: No limit.', 'https://tpwd.texas.gov/regulations/outdoor-annual/fishing/saltwater-fishing/bag-length-limits/amberjack-bag-length-limits', 'TPWD Outdoor Annual 2026-2027 — Amberjack Bag & Length Limits (valid 2026-09-01..2027-08-31)', '2026-09-01', '2026-09-02', 1,
+   null, null, 1, 2, 38, null, 'fork_length', null, null, false, 60),
+  ('red_snapper', null, 'tx-gulf', 'salt', 'gear', 'Texas regulations now require all commercial and recreational anglers fishing in state waters to use a venting tool or rigged descending device on reef fish exhibiting signs of barotrauma; per the 2022 DESCEND Act, similar requirements are in place for boats fishing for reef fish in federal waters.', 'https://tpwd.texas.gov/regulations/outdoor-annual/fishing/saltwater-fishing/bag-length-limits/snapper-bag-length-limits', 'TPWD Outdoor Annual 2026-2027 — Snapper Bag & Length Limits (valid 2026-09-01..2027-08-31)', '2026-09-01', '2026-09-02', 1,
+   null, null, null, null, null, null, null, null, null, false, 60),
+  (null, null, 'tx-gulf', 'salt', 'note', 'The daily bag limit is 1 fish for all allowable shark species INCLUDING Atlantic sharpnose, blacktip and bonnethead; non-offset, non-stainless steel circle hooks must be used when fishing for shark in state waters. Prohibited shark species may not be retained at all.', 'https://tpwd.texas.gov/regulations/outdoor-annual/fishing/shark-regulations', 'TPWD Outdoor Annual 2026-2027 — Shark Regulations', '2026-09-01', '2026-09-02', 1,
+   null, null, 1, 2, null, null, null, null, null, false, 60);
+
+
+insert into public.reg_pack (id, version, published_at, notes) values
+  ('louisiana-2026-09-01', 1, '2026-09-01T12:00:00Z', 'Louisiana (LDWF 2025 Recreational Fishing Regulations + LDWF species pages): the .redfish/trout 2024 reset is encoded (trout 15 @ 13–20 slot w/ ≤2 over 20 inside the creel; redfish 4 @ 18–27, no oversize allowance, for-hire crew = zero). State-managed red snapper season/quotas are check-in-season.')
+on conflict (id) do nothing;
+
+insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geojson, source_url, verified_at, notes) values
+  ('la-gulf', 'ldwf', 'ocean_region', 'Louisiana — coastal waters envelope', null, null, 'https://www.wlf.louisiana.gov/page/recreational-fishing-regulations', '2026-09-02', 'Envelope for pack resolution and boundary folds; state waters extend 3 nm (LDWF).')
+on conflict (id) do nothing;
+
+insert into public.reg_rule
+  (species_id, reg_group_id, reg_area_id, water_class, kind, verbatim, source_url, source_title, source_updated_at, verified_at, pack_version,
+   season_start, season_end, bag_daily, possession_limit, min_size_in, max_size_in, size_measure, platform_scope, depth_note, check_inseason, stale_after_days)
+values
+  ('spotted_seatrout', null, 'la-gulf', 'salt', 'bag_limit', 'SPOTTED SEATROUT (Speckled Trout): 13” min total length, 20” max total length; 15 daily per person with no more than 2 over 20” max total length. Retention by captain and crew on charter or head boats while on a for-hire trip is prohibited. Take or possession of spotted seatrout in federal waters: same limits as state.', 'https://www.wlf.louisiana.gov/assets/Resources/Publications/Regulations/25LAFW.pdf', 'LDWF — 2025 Louisiana Recreational Fishing Regulations (official booklet)', '2025-02-04', '2026-09-02', 1,
+   null, null, 15, 30, 13, 20, 'total_length', null, 'Slot: no more than 2 over 20” inside the 15-fish creel; for-hire captain/crew creel = 0.', false, 60),
+  ('red_drum', null, 'la-gulf', 'salt', 'bag_limit', 'RED DRUM (Redfish): 18” min total length; 27” max total length; 4 daily per person. No retention allowance for fish over 27 inches. Retention by captain and crew on charter or head boats while on a for-hire trip is prohibited. Take or possession of red drum in federal waters is prohibited.', 'https://www.wlf.louisiana.gov/assets/Resources/Publications/Regulations/25LAFW.pdf', 'LDWF — 2025 Louisiana Recreational Fishing Regulations (official booklet)', '2025-02-04', '2026-09-02', 1,
+   null, null, 4, 8, 18, 27, 'total_length', null, 'Fed-waters take prohibited; for-hire captain/crew creel = 0.', false, 60),
+  ('black_drum', null, 'la-gulf', 'salt', 'bag_limit', 'BLACK DRUM: 16” min total length; 5 daily per person; no more than 1 over 27” (max TL) may be kept. Possession limit is twice the daily creel limit unless otherwise stated.', 'https://www.wlf.louisiana.gov/assets/Resources/Publications/Regulations/25LAFW.pdf', 'LDWF — 2025 Louisiana Recreational Fishing Regulations (official booklet)', '2025-02-04', '2026-09-02', 1,
+   null, null, 5, 10, 16, 27, 'total_length', null, 'One >27” bull counts inside the 5-fish creel.', false, 60),
+  ('sheepshead', null, 'la-gulf', 'salt', 'bag_limit', 'SHEEPSHEAD: 10 daily per person; 12” min total length (12” fork-length conversions in older tables refer to fork length).', 'https://www.wlf.louisiana.gov/assets/Resources/Publications/Regulations/25LAFW.pdf', 'LDWF — 2025 Louisiana Recreational Fishing Regulations (official booklet)', '2025-02-04', '2026-09-02', 1,
+   null, null, 10, 20, 12, null, 'total_length', null, null, false, 60),
+  ('southern_flounder', null, 'la-gulf', 'salt', 'bag_limit', 'SOUTHERN FLOUNDER — summarized, not quoted (exact LDWF clause text not captured at pack authoring): 10 daily per person, 12-inch minimum total length, year-round. Verify on the LDWF regulations page before each season; changes follow commission action.', 'https://www.wlf.louisiana.gov/page/recreational-saltwater-fishing', 'LDWF — Recreational saltwater fishing', null, '2026-09-02', 1,
+   null, null, 10, 20, 12, null, 'total_length', null, null, true, 60),
+  ('red_snapper', null, 'la-gulf', 'salt', 'note', 'RED SNAPPER (state management): seasons are opened/closed by LDWF against the state quota; when open, seasons run Fridays–Sundays per season notice; bag and size within state waters are set in the season notice (2024: 2/day, 16” min — verify the current notice). LAKES AND BAYOUS: possession in state waters when the season is closed is prohibited.', 'https://www.wlf.louisiana.gov/page/red-snapper', 'LDWF — Red Snapper', null, '2026-09-02', 1,
+   null, null, null, null, null, null, null, null, 'Season announced against quota; check LDWF before each trip.', true, 14),
+  ('greater_amberjack', null, 'la-gulf', 'salt', 'bag_limit', 'AMBERJACK, GREATER: 34” min fork length; 1 daily per person.', 'https://www.wlf.louisiana.gov/assets/Resources/Publications/Regulations/25LAFW.pdf', 'LDWF — 2025 Louisiana Recreational Fishing Regulations (official booklet)', '2025-02-04', '2026-09-02', 1,
+   null, null, 1, 2, 34, null, 'fork_length', null, null, false, 60),
+  ('gray_triggerfish', null, 'la-gulf', 'salt', 'bag_limit', 'GRAY TRIGGERFISH: 15” min fork length; 1 daily per person in aggregate (reef fish aggregate rules apply in federal waters as posted by the Gulf Council).', 'https://www.wlf.louisiana.gov/assets/Resources/Publications/Regulations/25LAFW.pdf', 'LDWF — 2025 Louisiana Recreational Fishing Regulations (official booklet)', '2025-02-04', '2026-09-02', 1,
+   null, null, 1, 2, 15, null, 'fork_length', null, null, false, 60),
+  ('atlantic_tarpon', null, 'la-gulf', 'salt', 'note', 'Tarpon — summarized, not quoted: Louisiana treats tarpon harvest as effectively tag-limited and unusual; the in-practice rule is catch-and-release. Any retention requires confirming a current LDWF tarpon rule/tags before keeping.', 'https://www.wlf.louisiana.gov/page/recreational-saltwater-fishing', 'LDWF — Recreational saltwater fishing', null, '2026-09-02', 1,
+   null, null, null, null, null, null, null, null, null, true, 30),
+  (null, null, 'la-gulf', 'salt', 'note', 'Possession limit is TWICE the daily creel limit unless otherwise stated. Recreational saltwater anglers may possess a two days’ bag limit on land; no person shall be in possession of fish over the daily bag limit in any one day or while fishing or while on the water.', 'https://www.wlf.louisiana.gov/assets/Resources/Publications/Regulations/25LAFW.pdf', 'LDWF — 2025 Louisiana Recreational Fishing Regulations (official booklet)', '2025-02-04', '2026-09-02', 1,
+   null, null, null, null, null, null, null, null, null, false, 60);
+
+
+insert into public.reg_pack (id, version, published_at, notes) values
+  ('mississippi-2026-09-01', 1, '2026-09-01T12:00:00Z', 'Mississippi (MDMR Recreational Catch Limits card): inshore + reef flagship species with the agency table''s own numbers; red snapper reporting (Tails n'' Scales) and announced season are quoted. State waters = 9 nm south of the barrier islands for state for-hire boats; federal Gulf rules apply beyond.')
+on conflict (id) do nothing;
+
+insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geojson, source_url, verified_at, notes) values
+  ('ms-gulf', 'mdmr', 'ocean_region', 'Mississippi — coastal waters envelope', null, null, 'https://dmr.ms.gov/recreational-catch-limits/', '2026-09-02', 'Envelope for pack resolution and boundary folds (Biloxi/Gulfport inside).')
+on conflict (id) do nothing;
+
+insert into public.reg_rule
+  (species_id, reg_group_id, reg_area_id, water_class, kind, verbatim, source_url, source_title, source_updated_at, verified_at, pack_version,
+   season_start, season_end, bag_daily, possession_limit, min_size_in, max_size_in, size_measure, platform_scope, depth_note, check_inseason, stale_after_days)
+values
+  ('spotted_seatrout', null, 'ms-gulf', 'salt', 'bag_limit', 'Spotted Seatrout: 15 TL minimum; 15 bag/possession.', 'https://dmr.ms.gov/recreational-catch-limits/', 'MDMR — Recreational Catch Limits (official quick card)', null, '2026-09-02', 1,
+   null, null, 15, 15, 15, null, 'total_length', null, null, false, 60),
+  ('red_drum', null, 'ms-gulf', 'salt', 'bag_limit', 'Red Drum: 18 TL to 30 TL; 3 bag/possession. Recreational fishermen may retain only one red drum over 30 inches.', 'https://dmr.ms.gov/recreational-catch-limits/', 'MDMR — Recreational Catch Limits (official quick card)', null, '2026-09-02', 1,
+   null, null, 3, 3, 18, 30, 'total_length', null, 'One >30” bull counts inside the 3.', false, 60),
+  ('southern_flounder', null, 'ms-gulf', 'salt', 'bag_limit', 'Flounder: 12 TL minimum; 10 bag/possession.', 'https://dmr.ms.gov/recreational-catch-limits/', 'MDMR — Recreational Catch Limits (official quick card)', null, '2026-09-02', 1,
+   null, null, 10, 10, 12, null, 'total_length', null, null, false, 60),
+  ('sheepshead', null, 'ms-gulf', 'salt', 'bag_limit', 'Sheepshead: 14 TL minimum; 15 bag/possession.', 'https://dmr.ms.gov/recreational-catch-limits/', 'MDMR — Recreational Catch Limits (official quick card)', null, '2026-09-02', 1,
+   null, null, 15, 15, 14, null, 'total_length', null, null, false, 60),
+  ('gray_snapper', null, 'ms-gulf', 'salt', 'bag_limit', 'Gray Snapper: 12 TL minimum; 10 bag/possession (see Reef Fish section for harvest in aggregate with other snapper species).', 'https://dmr.ms.gov/recreational-catch-limits/', 'MDMR — Recreational Catch Limits (official quick card)', null, '2026-09-02', 1,
+   null, null, 10, 10, 12, null, 'total_length', null, 'Federal 10-snapper aggregate applies in federal waters (gulfcouncil.org).', false, 60),
+  ('red_snapper', null, 'ms-gulf', 'salt', 'bag_limit', 'Red Snapper: 16 TL minimum; 2 bag/possession. Reporting is required for Red Snapper trips and landings through the Tails n’ Scales program. Seasons are set annually by the Executive Director against the state quota (2025 season opened May 23 and ran seven days a week in state and federal waters until the annual catch limit was projected to be met).', 'https://dmr.ms.gov/recreational-catch-limits/', 'MDMR — Recreational Catch Limits (official quick card)', null, '2026-09-02', 1,
+   null, null, 2, 2, 16, null, 'total_length', null, 'Open/close announced per season; Tails n’ Scales reporting mandatory.', true, 30),
+  ('cobia', null, 'ms-gulf', 'salt', 'bag_limit', 'Cobia: 36 FL minimum; 2 bag/possession.', 'https://dmr.ms.gov/recreational-catch-limits/', 'MDMR — Recreational Catch Limits (official quick card)', null, '2026-09-02', 1,
+   null, null, 2, 2, 36, null, 'fork_length', null, null, false, 60),
+  ('tripletail', null, 'ms-gulf', 'salt', 'bag_limit', 'Tripletail: 18 TL minimum; 3 bag/possession.', 'https://dmr.ms.gov/recreational-catch-limits/', 'MDMR — Recreational Catch Limits (official quick card)', null, '2026-09-02', 1,
+   null, null, 3, 3, 18, null, 'total_length', null, null, false, 60),
+  ('king_mackerel', null, 'ms-gulf', 'salt', 'bag_limit', 'King Mackerel: 24 FL minimum; 3 bag/possession.', 'https://dmr.ms.gov/recreational-catch-limits/', 'MDMR — Recreational Catch Limits (official quick card)', null, '2026-09-02', 1,
+   null, null, 3, 3, 24, null, 'fork_length', null, null, false, 60),
+  ('spanish_mackerel', null, 'ms-gulf', 'salt', 'bag_limit', 'Spanish Mackerel: 12 FL minimum; 15 bag/possession.', 'https://dmr.ms.gov/recreational-catch-limits/', 'MDMR — Recreational Catch Limits (official quick card)', null, '2026-09-02', 1,
+   null, null, 15, 15, 12, null, 'fork_length', null, null, false, 60),
+  ('vermilion_snapper', null, 'ms-gulf', 'salt', 'bag_limit', 'Vermilion Snapper: 10 TL minimum; 10 bag/possession; counts in the 20 Reef Fish Aggregate (with gray triggerfish, lane snapper, almaco jack, and tilefish).', 'https://dmr.ms.gov/recreational-catch-limits/', 'MDMR — Recreational Catch Limits (official quick card)', null, '2026-09-02', 1,
+   null, null, 10, 10, 10, null, 'total_length', null, '20 Reef Fish Aggregate is quoted, not yet a modeled group — pack-v2 debt.', false, 60),
+  ('lane_snapper', null, 'ms-gulf', 'salt', 'bag_limit', 'Lane Snapper: 8 TL minimum; 20 bag/possession; counts in the 20 Reef Fish Aggregate.', 'https://dmr.ms.gov/recreational-catch-limits/', 'MDMR — Recreational Catch Limits (official quick card)', null, '2026-09-02', 1,
+   null, null, 20, 20, 8, null, 'total_length', null, null, false, 60),
+  ('greater_amberjack', null, 'ms-gulf', 'salt', 'bag_limit', 'Greater Amberjack: 34 FL minimum; 1 bag/possession.', 'https://dmr.ms.gov/recreational-catch-limits/', 'MDMR — Recreational Catch Limits (official quick card)', null, '2026-09-02', 1,
+   null, null, 1, 1, 34, null, 'fork_length', null, null, false, 60),
+  ('atlantic_tarpon', null, 'ms-gulf', 'salt', 'note', 'Tarpon: 75 FL minimum; 1 per vessel. May not remove fish from water if over 40 inches in length unless harvesting within specified limits.', 'https://dmr.ms.gov/recreational-catch-limits/', 'MDMR — Recreational Catch Limits (official quick card)', null, '2026-09-02', 1,
+   null, null, null, null, 75, null, 'fork_length', 'boat', 'Per-VESSEL, not per-person.', false, 60),
+  (null, null, 'ms-gulf', 'salt', 'note', 'It is illegal to sell any seafood taken with a recreational license.', 'https://dmr.ms.gov/recreational-catch-limits/', 'MDMR — Recreational Catch Limits (official quick card)', null, '2026-09-02', 1,
+   null, null, null, null, null, null, null, null, null, false, 90);
+
+
+insert into public.reg_pack (id, version, published_at, notes) values
+  ('alabama-2026-09-01', 1, '2026-09-01T12:00:00Z', 'Alabama (ADCNR Marine Resources Division): inshore flagship slots verified against agency releases; red snapper via Snapper Check + announced season; sheepshead 2025 reduction (10→8) quoted from the regulation-change reports. Snapper Check is mandatory before landing — read the note row before your first snapper trip.')
+on conflict (id) do nothing;
+
+insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geojson, source_url, verified_at, notes) values
+  ('al-gulf', 'adcnr', 'ocean_region', 'Alabama — coastal waters envelope', null, null, 'https://www.outdooralabama.com/marine-resources', '2026-09-02', 'Envelope for pack resolution and boundary folds (Gulf Shores/Orange Beach inside; Mobile city out).')
+on conflict (id) do nothing;
+
+insert into public.reg_rule
+  (species_id, reg_group_id, reg_area_id, water_class, kind, verbatim, source_url, source_title, source_updated_at, verified_at, pack_version,
+   season_start, season_end, bag_daily, possession_limit, min_size_in, max_size_in, size_measure, platform_scope, depth_note, check_inseason, stale_after_days)
+values
+  ('spotted_seatrout', null, 'al-gulf', 'salt', 'bag_limit', 'Spotted seatrout (speckled trout): 6 daily per person; 15–22 inch total-length slot; only one spotted seatrout larger than 22 inches may be kept (within the 6-fish bag).', 'https://www.outdooralabama.com/node/2632', 'ADCNR — Seatrout, Flounder Limits Change August 1 (MRD regulation-change release)', '2019-07-02', '2026-09-02', 1,
+   null, null, 6, 6, 15, 22, 'total_length', null, 'One fish >22” counts inside the 6.', false, 60),
+  ('red_drum', null, 'al-gulf', 'salt', 'bag_limit', 'Red drum (redfish): 3 daily per person; 16–26 inch total-length slot; an allowance for one fish larger than 26 inches (bull red) is included. (2025 Advisory Board proposed removing the oversize allowance — verify before keeping a bull red.)', 'https://www.outdooralabama.com/node/2632', 'ADCNR — Seatrout, Flounder Limits Change August 1 (agency text)', '2019-07-02', '2026-09-02', 1,
+   null, null, 3, 3, 16, 26, 'total_length', null, 'One bull red >26” allowed inside the 3 (pending 2025 proposed change).', true, 60),
+  ('southern_flounder', null, 'al-gulf', 'salt', 'bag_limit', 'Flounder: bag of five per person for recreational anglers; 14 inches total length minimum. The entire month of November is closed to flounder fishing, both recreational and commercial.', 'https://www.outdooralabama.com/node/2632', 'ADCNR — Seatrout, Flounder Limits Change August 1 (agency text)', '2019-07-02', '2026-09-02', 1,
+   null, null, 5, 5, 14, null, 'total_length', null, 'Closed all November.', false, 60),
+  ('southern_flounder', null, 'al-gulf', 'salt', 'season', 'The entire month of November is closed to flounder fishing, both recreational and commercial (November is when flounder migrate to the Gulf of Mexico to spawn).', 'https://www.outdooralabama.com/node/2632', 'ADCNR — Seatrout, Flounder Limits Change August 1 (agency text)', '2019-07-02', '2026-09-02', 1,
+   '2026-11-01', '2026-11-30', null, null, null, null, null, null, null, false, 60),
+  ('sheepshead', null, 'al-gulf', 'salt', 'bag_limit', 'Sheepshead: 12-inch fork length minimum; bag 8 per person per day — reduced from 10 in 2025 due to increased fishing pressure (verify the 2026 card; the reduction was approved in the 2025 regulation cycle).', 'https://www.outdooralabama.com/fishing/saltwater-fishing-and-reports', 'ADCNR — saltwater fishing reports & limits', null, '2026-09-02', 1,
+   null, null, 8, 8, 12, null, 'fork_length', null, null, true, 60),
+  ('red_snapper', null, 'al-gulf', 'salt', 'note', 'Red snapper: Alabama state waters and federal waters opened to private and state-licensed charter anglers on Friday, May 23, 2025; the 2025 private-angler quota was 664,552 pounds and the season closed December 31, 2025. The 2026 quota will be 664,552 pounds and MRD will announce the dates for the 2026 fishing season in the spring. Bag while open: 2 fish per person per day; 16-inch minimum. The owner or operator of each vessel landing red snapper in Alabama is required by law to complete one landing report per vessel trip of their harvested red snapper through Snapper Check prior to removing the fish from the boat.', 'https://www.outdooralabama.com/articles/alabamas-red-snapper-season-continues-through-december-31', 'ADCNR — Alabama’s Red Snapper Season Continues Through December 31 (2025-12-22)', '2025-12-22', '2026-09-02', 1,
+   null, null, null, null, null, null, null, null, 'Season dates announced each spring; Snapper Check report required BEFORE landing.', true, 14),
+  ('king_mackerel', null, 'al-gulf', 'salt', 'bag_limit', 'King mackerel: 24-inch fork length minimum; 3 per person per day (Alabama creel card; federal Gulf migratory-group rules control in federal waters).', 'https://www.outdooralabama.com/fishing/saltwater-fishing-and-reports', 'ADCNR — saltwater fishing reports & limits', null, '2026-09-02', 1,
+   null, null, 3, 3, 24, null, 'fork_length', null, null, false, 60),
+  ('spanish_mackerel', null, 'al-gulf', 'salt', 'bag_limit', 'Spanish mackerel: 15 per person per day; no minimum size in Alabama state rules (federal Gulf rules apply offshore).', 'https://www.outdooralabama.com/fishing/saltwater-fishing-and-reports', 'ADCNR — saltwater fishing reports & limits', null, '2026-09-02', 1,
+   null, null, 15, 15, null, null, null, null, null, false, 60),
+  ('gray_triggerfish', null, 'al-gulf', 'salt', 'bag_limit', 'Gray triggerfish: 1 per person per day; 15-inch fork length minimum (Alabama creel card); when the season is open triggerfish must be reported in Snapper Check.', 'https://www.outdooralabama.com/fishing/saltwater-fishing-and-reports', 'ADCNR — saltwater fishing reports & limits', null, '2026-09-02', 1,
+   null, null, 1, 1, 15, null, 'fork_length', null, 'Snapper Check when season open.', true, 60),
+  ('cobia', null, 'al-gulf', 'salt', 'bag_limit', 'Cobia: 36 inches fork length; 2 per person per day (MRD approval notice; consistent with federal regulations).', 'https://www.outdooralabama.com/node/2632', 'ADCNR — Seatrout, Flounder Limits Change August 1 (agency text)', '2019-07-02', '2026-09-02', 1,
+   null, null, 2, 2, 36, null, 'fork_length', null, null, false, 60),
+  (null, null, 'al-gulf', 'salt', 'gear', 'All vessels fishing for reef fish in federal waters are required to have a venting tool or descending device rigged and ready to use.', 'https://www.outdooralabama.com/articles/2025-red-snapper-season-modified-provide-increased-fishing-opportunities', 'ADCNR — 2025 Red Snapper Season announcement', '2025-03-13', '2026-09-02', 1,
+   null, null, null, null, null, null, null, 'boat', null, false, 60),
+  ('goliath_grouper', null, 'al-gulf', 'salt', 'prohibited', 'Goliath grouper and Nassau grouper are prohibited from harvest (Alabama and federal rules).', 'https://www.outdooralabama.com/fishing/saltwater-fishing-and-reports', 'ADCNR — saltwater fishing reports & limits', null, '2026-09-02', 1,
+   null, null, null, null, null, null, null, null, null, false, 90);
+
+
+insert into public.reg_pack (id, version, published_at, notes) values
+  ('baja-california-2026-09-01', 1, '2026-09-01T12:00:00Z', 'Baja California (CONAPESCA / NOM-017-PESC-1994): federal sport catch ceilings apply nationwide — identical clauses as Baja California Sur. Envelope covers the Pacific coast (Tijuana–Punta Eugenia) and the Upper Gulf side to 28° N.')
+on conflict (id) do nothing;
+
+insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geojson, source_url, verified_at, notes) values
+  ('mx-baja-california', 'conapesca', 'ocean_region', 'Baja California — coastal waters envelope', null, null, 'https://www.gob.mx/conapesca', '2026-09-02', 'Envelope spans peninsula (Ensenada & San Felipe inside; California out).')
+on conflict (id) do nothing;
+
+insert into public.reg_rule
+  (species_id, reg_group_id, reg_area_id, water_class, kind, verbatim, source_url, source_title, source_updated_at, verified_at, pack_version,
+   season_start, season_end, bag_daily, possession_limit, min_size_in, max_size_in, size_measure, platform_scope, depth_note, check_inseason, stale_after_days)
+values
+  (null, null, 'mx-baja-california', 'salt', 'note', '4.7.1 Diez ejemplares diarios por pescador, con la siguiente composición por especie: No más de cinco de una misma especie. (Ten fish per person per day, no more than five of a single species.)', 'https://www.gob.mx/cms/uploads/attachment/file/311370/NOM_017_PESC.pdf', 'NORMA Oficial Mexicana NOM-017-PESC-1994 (DOF) — pesca deportivo-recreativa', null, '2026-09-02', 1,
+   null, null, 10, 10, null, null, null, null, 'Total-day composite rule; per-species ceilings below.', false, 90),
+  ('striped_marlin', null, 'mx-baja-california', 'salt', 'bag_limit', 'Cuando se trate de marlin, pez vela, pez espada y tiburón, el límite máximo por pescador y día será de un solo ejemplar de cualquiera de estas especies, el cual será equivalente a cinco ejemplares de otras especies. (For marlin, sailfish, swordfish or shark: ONE specimen a day of any of these — counting as five of the day''s ten.)', 'https://www.gob.mx/cms/uploads/attachment/file/311370/NOM_017_PESC.pdf', 'NORMA Oficial Mexicana NOM-017-PESC-1994 (DOF) — pesca deportivo-recreativa', null, '2026-09-02', 1,
+   null, null, 1, 1, null, null, null, null, 'One billfish/shark of ANY of those species per day; counts as 5 of the 10.', false, 90),
+  ('sailfish', null, 'mx-baja-california', 'salt', 'bag_limit', 'Cuando se trate de marlin, pez vela, pez espada y tiburón, el límite máximo por pescador y día será de un solo ejemplar de cualquiera de estas especies... (For marlin, sailfish, swordfish or shark: ONE specimen a day of any of these, counting as five of the day''s ten.)', 'https://www.gob.mx/cms/uploads/attachment/file/311370/NOM_017_PESC.pdf', 'NORMA Oficial Mexicana NOM-017-PESC-1994 (DOF) — pesca deportivo-recreativa', null, '2026-09-02', 1,
+   null, null, 1, 1, null, null, null, null, 'Shared with marlin/shark group — one total.', false, 90),
+  ('dorado', null, 'mx-baja-california', 'salt', 'bag_limit', 'En el caso de sábalo, dorado o pez gallo, el límite máximo será de dos ejemplares de dichas especies, el cual será equivalente a cinco ejemplares de otras especies. (For tarpon, dorado or roosterfish: TWO per day from this group, each counting as five of the day''s ten.)', 'https://www.gob.mx/cms/uploads/attachment/file/311370/NOM_017_PESC.pdf', 'NORMA Oficial Mexicana NOM-017-PESC-1994 (DOF) — pesca deportivo-recreativa', null, '2026-09-02', 1,
+   null, null, 2, 2, null, null, null, null, 'Two TOTAL across tarpon/dorado/roosterfish; each counts as 5 of the 10.', false, 90),
+  ('roosterfish', null, 'mx-baja-california', 'salt', 'bag_limit', 'En el caso de sábalo, dorado o pez gallo, el límite máximo será de dos ejemplares de dichas especies... (Tarpon, dorado or roosterfish: two per day from this group, each counting as five of the day''s ten.)', 'https://www.gob.mx/cms/uploads/attachment/file/311370/NOM_017_PESC.pdf', 'NORMA Oficial Mexicana NOM-017-PESC-1994 (DOF) — pesca deportivo-recreativa', null, '2026-09-02', 1,
+   null, null, 2, 2, null, null, null, null, 'Shared 2/day across the group.', false, 90),
+  (null, null, 'mx-baja-california', 'salt', 'note', '4.8 En actividades de pesca deportivo recreativa con embarcaciones cuyos viajes tengan una duración de más de tres días, el número máximo acumulable de ejemplares... será el equivalente a tres días de pesca. (Trips longer than three days may accumulate at most three days'' quota.)', 'https://www.gob.mx/cms/uploads/attachment/file/311370/NOM_017_PESC.pdf', 'NORMA Oficial Mexicana NOM-017-PESC-1994 (DOF) — pesca deportivo-recreativa', null, '2026-09-02', 1,
+   null, null, null, null, null, null, null, 'boat', null, false, 90),
+  (null, null, 'mx-baja-california', 'salt', 'gear', '4.9 La pesca subacuática tendrá como límite máximo de captura cinco ejemplares... por pescador y día. (Spearfishing: five fish per person per day, inside the same composition rules.)', 'https://www.gob.mx/cms/uploads/attachment/file/311370/NOM_017_PESC.pdf', 'NORMA Oficial Mexicana NOM-017-PESC-1994 (DOF) — pesca deportivo-recreativa', null, '2026-09-02', 1,
+   null, null, 5, 5, null, null, null, 'diver', null, false, 90),
+  (null, null, 'mx-baja-california', 'salt', 'note', '4.10 ...sin perjuicio de que pueda pescar un mayor número de ejemplares a condición de que los organismos que excedan a dichas cuotas, sean devueltos a su medio natural en buenas condiciones de sobrevivencia («captura y liberación»). (You may continue fishing past quota if the extras are released in good condition — legal catch-and-release.)', 'https://www.gob.mx/cms/uploads/attachment/file/311370/NOM_017_PESC.pdf', 'NORMA Oficial Mexicana NOM-017-PESC-1994 (DOF) — pesca deportivo-recreativa', null, '2026-09-02', 1,
+   null, null, null, null, null, null, null, null, null, false, 90),
+  (null, null, 'mx-baja-california', 'salt', 'note', 'CONAPESCA Guía de Pesca Deportiva: las especies marlin, pez vela, pez espada, sábalo, pez gallo y pez dorado están destinadas exclusivamente a la pesca deportiva dentro de una franja de 50 millas náuticas; prohibido el desembarco de ejemplares fileteados. (Billfish, tarpon, roosterfish and dorado are sport-only inside 50 nm; you may not land fish already filleted.)', 'https://www.gob.mx/conapesca/documentos/guia-de-pesca-deportiva?state=published', 'CONAPESCA — Guía de Pesca Deportiva', null, '2026-09-02', 1,
+   null, null, null, null, null, null, null, null, null, false, 90),
+  (null, null, 'mx-baja-california', 'salt', 'note', 'La práctica de la pesca deportivo recreativa requiere permiso/licencia de la CONAPESCA... la pesca deportiva comercializable... está prohibida. (A Mexican sport-fishing permit is required for every person fishing; selling sport-caught fish is prohibited. Buy permits via CONAPESCA/authorized dealers.)', 'https://www.gob.mx/conapesca/documentos/guia-de-pesca-deportiva?state=published', 'CONAPESCA — Guía de Pesca Deportiva', null, '2026-09-02', 1,
+   null, null, null, null, null, null, null, null, null, false, 90),
+  (null, null, 'mx-baja-california', 'salt', 'note', '4.11 La práctica de la pesca deportivo recreativa queda sujeta a las tallas y pesos mínimos de captura por especie y zona, que establezca la Secretaría... medidas que se notificarán mediante avisos publicados en el Diario Oficial de la Federación. (Minimum sizes/weights by species and zone are set by DOF notices — check the current Diario Oficial notice before keeping unusual species.)', 'https://www.gob.mx/cms/uploads/attachment/file/311370/NOM_017_PESC.pdf', 'NORMA Oficial Mexicana NOM-017-PESC-1994 (DOF) — pesca deportivo-recreativa', null, '2026-09-02', 1,
+   null, null, null, null, null, null, null, null, null, true, 60);
+
+
+insert into public.reg_pack (id, version, published_at, notes) values
+  ('baja-california-sur-2026-09-01', 1, '2026-09-01T12:00:00Z', 'Baja California Sur (CONAPESCA / NOM-017-PESC-1994): federal sport catch ceilings; same clauses as Baja California (no state-level catch-limit divergence found — state differences are in licensing/boat permits, not bags). Envelope covers La Paz to Cabo San Lucas.')
+on conflict (id) do nothing;
+
+insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geojson, source_url, verified_at, notes) values
+  ('mx-baja-california-sur', 'conapesca', 'ocean_region', 'Baja California Sur — coastal waters envelope', null, null, 'https://www.gob.mx/conapesca', '2026-09-02', 'Envelope spans peninsula (Cabo San Lucas & La Paz inside).')
+on conflict (id) do nothing;
+
+insert into public.reg_rule
+  (species_id, reg_group_id, reg_area_id, water_class, kind, verbatim, source_url, source_title, source_updated_at, verified_at, pack_version,
+   season_start, season_end, bag_daily, possession_limit, min_size_in, max_size_in, size_measure, platform_scope, depth_note, check_inseason, stale_after_days)
+values
+  (null, null, 'mx-baja-california-sur', 'salt', 'note', '4.7.1 Diez ejemplares diarios por pescador, con la siguiente composición por especie: No más de cinco de una misma especie. (Ten fish per person per day, no more than five of a single species.)', 'https://www.gob.mx/cms/uploads/attachment/file/311370/NOM_017_PESC.pdf', 'NORMA Oficial Mexicana NOM-017-PESC-1994 (DOF) — pesca deportivo-recreativa', null, '2026-09-02', 1,
+   null, null, 10, 10, null, null, null, null, 'Total-day composite rule; per-species ceilings below.', false, 90),
+  ('striped_marlin', null, 'mx-baja-california-sur', 'salt', 'bag_limit', 'Cuando se trate de marlin, pez vela, pez espada y tiburón, el límite máximo por pescador y día será de un solo ejemplar de cualquiera de estas especies, el cual será equivalente a cinco ejemplares de otras especies. (For marlin, sailfish, swordfish or shark: ONE specimen a day of any of these — counting as five of the day''s ten.)', 'https://www.gob.mx/cms/uploads/attachment/file/311370/NOM_017_PESC.pdf', 'NORMA Oficial Mexicana NOM-017-PESC-1994 (DOF) — pesca deportivo-recreativa', null, '2026-09-02', 1,
+   null, null, 1, 1, null, null, null, null, 'One billfish/shark of ANY of those species per day; counts as 5 of the 10.', false, 90),
+  ('sailfish', null, 'mx-baja-california-sur', 'salt', 'bag_limit', 'Cuando se trate de marlin, pez vela, pez espada y tiburón, el límite máximo por pescador y día será de un solo ejemplar de cualquiera de estas especies... (For marlin, sailfish, swordfish or shark: ONE specimen a day of any of these, counting as five of the day''s ten.)', 'https://www.gob.mx/cms/uploads/attachment/file/311370/NOM_017_PESC.pdf', 'NORMA Oficial Mexicana NOM-017-PESC-1994 (DOF) — pesca deportivo-recreativa', null, '2026-09-02', 1,
+   null, null, 1, 1, null, null, null, null, 'Shared with marlin/shark group — one total.', false, 90),
+  ('dorado', null, 'mx-baja-california-sur', 'salt', 'bag_limit', 'En el caso de sábalo, dorado o pez gallo, el límite máximo será de dos ejemplares de dichas especies, el cual será equivalente a cinco ejemplares de otras especies. (For tarpon, dorado or roosterfish: TWO per day from this group, each counting as five of the day''s ten.)', 'https://www.gob.mx/cms/uploads/attachment/file/311370/NOM_017_PESC.pdf', 'NORMA Oficial Mexicana NOM-017-PESC-1994 (DOF) — pesca deportivo-recreativa', null, '2026-09-02', 1,
+   null, null, 2, 2, null, null, null, null, 'Two TOTAL across tarpon/dorado/roosterfish; each counts as 5 of the 10.', false, 90),
+  ('roosterfish', null, 'mx-baja-california-sur', 'salt', 'bag_limit', 'En el caso de sábalo, dorado o pez gallo, el límite máximo será de dos ejemplares de dichas especies... (Tarpon, dorado or roosterfish: two per day from this group, each counting as five of the day''s ten.)', 'https://www.gob.mx/cms/uploads/attachment/file/311370/NOM_017_PESC.pdf', 'NORMA Oficial Mexicana NOM-017-PESC-1994 (DOF) — pesca deportivo-recreativa', null, '2026-09-02', 1,
+   null, null, 2, 2, null, null, null, null, 'Shared 2/day across the group.', false, 90),
+  (null, null, 'mx-baja-california-sur', 'salt', 'note', '4.8 En actividades de pesca deportivo recreativa con embarcaciones cuyos viajes tengan una duración de más de tres días, el número máximo acumulable de ejemplares... será el equivalente a tres días de pesca. (Trips longer than three days may accumulate at most three days'' quota.)', 'https://www.gob.mx/cms/uploads/attachment/file/311370/NOM_017_PESC.pdf', 'NORMA Oficial Mexicana NOM-017-PESC-1994 (DOF) — pesca deportivo-recreativa', null, '2026-09-02', 1,
+   null, null, null, null, null, null, null, 'boat', null, false, 90),
+  (null, null, 'mx-baja-california-sur', 'salt', 'gear', '4.9 La pesca subacuática tendrá como límite máximo de captura cinco ejemplares... por pescador y día. (Spearfishing: five fish per person per day, inside the same composition rules.)', 'https://www.gob.mx/cms/uploads/attachment/file/311370/NOM_017_PESC.pdf', 'NORMA Oficial Mexicana NOM-017-PESC-1994 (DOF) — pesca deportivo-recreativa', null, '2026-09-02', 1,
+   null, null, 5, 5, null, null, null, 'diver', null, false, 90),
+  (null, null, 'mx-baja-california-sur', 'salt', 'note', '4.10 ...sin perjuicio de que pueda pescar un mayor número de ejemplares a condición de que los organismos que excedan a dichas cuotas, sean devueltos a su medio natural en buenas condiciones de sobrevivencia («captura y liberación»). (You may continue fishing past quota if the extras are released in good condition — legal catch-and-release.)', 'https://www.gob.mx/cms/uploads/attachment/file/311370/NOM_017_PESC.pdf', 'NORMA Oficial Mexicana NOM-017-PESC-1994 (DOF) — pesca deportivo-recreativa', null, '2026-09-02', 1,
+   null, null, null, null, null, null, null, null, null, false, 90),
+  (null, null, 'mx-baja-california-sur', 'salt', 'note', 'CONAPESCA Guía de Pesca Deportiva: las especies marlin, pez vela, pez espada, sábalo, pez gallo y pez dorado están destinadas exclusivamente a la pesca deportiva dentro de una franja de 50 millas náuticas; prohibido el desembarco de ejemplares fileteados. (Billfish, tarpon, roosterfish and dorado are sport-only inside 50 nm; you may not land fish already filleted.)', 'https://www.gob.mx/conapesca/documentos/guia-de-pesca-deportiva?state=published', 'CONAPESCA — Guía de Pesca Deportiva', null, '2026-09-02', 1,
+   null, null, null, null, null, null, null, null, null, false, 90),
+  (null, null, 'mx-baja-california-sur', 'salt', 'note', 'La práctica de la pesca deportivo recreativa requiere permiso/licencia de la CONAPESCA... la pesca deportiva comercializable... está prohibida. (A Mexican sport-fishing permit is required for every person fishing; selling sport-caught fish is prohibited. Buy permits via CONAPESCA/authorized dealers.)', 'https://www.gob.mx/conapesca/documentos/guia-de-pesca-deportiva?state=published', 'CONAPESCA — Guía de Pesca Deportiva', null, '2026-09-02', 1,
+   null, null, null, null, null, null, null, null, null, false, 90),
+  (null, null, 'mx-baja-california-sur', 'salt', 'note', '4.11 La práctica de la pesca deportivo recreativa queda sujeta a las tallas y pesos mínimos de captura por especie y zona, que establezca la Secretaría... medidas que se notificarán mediante avisos publicados en el Diario Oficial de la Federación. (Minimum sizes/weights by species and zone are set by DOF notices — check the current Diario Oficial notice before keeping unusual species.)', 'https://www.gob.mx/cms/uploads/attachment/file/311370/NOM_017_PESC.pdf', 'NORMA Oficial Mexicana NOM-017-PESC-1994 (DOF) — pesca deportivo-recreativa', null, '2026-09-02', 1,
+   null, null, null, null, null, null, null, null, null, true, 60);


### PR DESCRIPTION
**UPDATE (same PR): full-digest pass landed, commit 9c59b8c.** Founder asked to go flagship → full digest mid-review. TX, LA, MS, AL and both Baja packs are now at **pack version 2, digest-complete: 156 rules**, every agency table row verbatim against the current official documents.

The pass caught and corrected real v1 errors — exactly why the digest layer matters:
- LA flounder: **10/day, no size limit, NO possession Oct 15–Nov 30** (v1 had a wrong 12" min)
- LA red snapper: **4/day** per the 2025 booklet (v1 said 2)
- AL cobia: 1/person, ≤2/vessel (v1 said 2/person)
- AL red drum: bull over-slot allowance **removed in the 2025 rule cycle** — slot only now
- New: full shark tables + prohibited lists (TX 24/64/99 class minima; AL beach-chumming ban 220-3-.77; shortfin mako prohibited AL & LA), grouper aggregates, HMS minimums, tarpon-tag rules, mullet seasonal rules, license/permit note rows (ROLP, Snapper Check, HMS), gear rows.

SQL: `20260902140000_v2_gulf_baja_full_digest.sql` (delete-by-area + insert-from-bundle, deterministic; wave-1 migration stays frozen). 12 new species rows (groupers, scamp, warsaw, speckled hind, white marlin, swordfish, bigeye, mullet, almaco, lesser AJ, gars).Gates: 422/422 vitest, tsc clean, eslint 0 errors, build clean, smoke 200 on new species pages.

---

### Update 3 (2026-09-02, commit 9ac25d6) — California GMA layer v2

California is now broken into its five Groundfish Management Areas:

- **NorCal pack → v2**: four new GMA areas (Northern, Mendocino, San Francisco, Central) with verbatim 2026 season windows from the CDFW Groundfish Summary (updated June 23, 2026): Jan 1–Mar 31 closed ("unlawful to possess in all waters"), Apr 1–Dec 31 open all depths, both for nearshore RCG and for shelf/slope + lingcod. Plus verbatim doctrine rows: Cordell Bank prohibition, GMA-crossing possession, transit provision, shore/diver exemption note.
- **SoCal pack → v2**: its Southern GMA 50-fathom RCA inshore/offshore windows were already in the starter bundle; added the GMA-crossing, transit, and 8-Groundfish-Exclusion-Areas note rows.
- Migration `20260902150000_v2_ca_gma_layer.sql` (insert-only + pack upserts, generator `scripts/gen-ca-gma-layer.mts`). tsc clean, 422/422 tests.