### PR TITLE
Settings: California's five GMAs as selectable fishing regions

### DIFF
--- a/docs/team/worklog/2026-09-01-13-architect.md
+++ b/docs/team/worklog/2026-09-01-13-architect.md
@@ -115,3 +115,20 @@ Source: CDFW "Summary of Recreational Groundfish Fishing Regulations" **updated 
 - **NorCal → v2**: `latBand()` helper + four GMA areas (`ca-gma-northern` OR border→Cape Mendocino 40°10′N; `ca-gma-mendocino` →Point Arena 38°57.5′N; `ca-gma-san-francisco` →Pigeon Point 37°11′N; `ca-gma-central` →Point Conception 34°27′N). 2026 season windows identical across all four: Jan 1–Mar 31 CLOSED (possession unlawful in all waters) + Apr 1–Dec 31 open all depths × {nearshore RCG, shelf/slope+lingcod}. Doctrine rows verbatim: Cordell Bank all-groundfish prohibition, GMA-crossing possession, transit provision, shore/diver exemption. Bag-note rows carry the RCG 10-day / cabezon-greenling-surgeonfish sublimits pointer.
 - **SoCal → v2**: 3 note rows — `gma-crossing-possession`, `gma-transit-provision`, `gea-eight-note` (8 GEAs, §27.50, CDFW Cowcod page).
 - `scripts/gen-ca-gma-layer.mts` → `supabase/migrations/20260902150000_v2_ca_gma_layer.sql` (insert-only + `('norcal-…', 2)`/`('socal-2026-09-01', 2)` upserts). Gates: tsc clean, 422/422 vitest, eslint clean. Commit `9ac25d6`, pushed; PR #29 body updated (with an append-not-replace discipline this time).
+
+## 19 — 2026-09-02 (evening) — GMAs into Settings fishing-region picker
+
+Founder merged PR #30 then found the Settings **Fishing region** select still offered only
+Northern/Southern California. The GMA layer (#30) added areas + rules but no Settings
+entries — the picker's `REGIONS` enum is the pane of glass.
+
+- Five additive ids: `ca_gma_{northern,mendocino,san_francisco,central,southern}`, each with
+  hints, species leads, and a `BundledPack` row (NORCAL ×4 with GMA focus areas, SOCAL for
+  southern). Plain NorCal/SoCal entries untouched (standing constraint: additive only).
+- `regulationCard` companion-area fold generalized from the old `ca-ocean-southern`→
+  `ca-gma-southern` hard-code into a bidirectional table; without it a GMA-scoped region
+  would have hidden every size/bag row (they live on the ocean region).
+- Boundary map centers + RCa ribbon per CA subregion; GPS boundary watches now fold
+  `NORCAL.areas` too.
+- 423/423 vitest including a new pin test; tsc/eslint/build clean. Commit `a88d939` on
+  `feature/ca-gma-settings`, PR #31 opened — awaits founder merge.

--- a/src/core/ontology/regions.ts
+++ b/src/core/ontology/regions.ts
@@ -18,6 +18,14 @@ import { speciesById, SPECIES, type Species } from "./species";
 export type RegionId =
   | "southern_california"
   | "northern_california"
+  /** CDFW Groundfish Management Areas — the founder ask (2026-09-02): California
+   *  broken into its five real management units, not one "California". Additive:
+   *  the plain northern/southern entries stay for anglers who don't think in GMAs. */
+  | "ca_gma_northern"
+  | "ca_gma_mendocino"
+  | "ca_gma_san_francisco"
+  | "ca_gma_central"
+  | "ca_gma_southern"
   | "florida"
   | "hawaii"
   | "cabo_baja"
@@ -46,6 +54,11 @@ export interface Region {
 export const REGIONS: readonly Region[] = [
   { id: "southern_california", label: "Southern California", hint: "Kelp bed, reef and offshore staples." },
   { id: "northern_california", label: "Northern California", hint: "Salmon, stripers, halibut, rockfish." },
+  { id: "ca_gma_northern", label: "CA · Northern GMA", hint: "OR border to Cape Mendocino (40°10′ N): rockfish closed Jan–Mar, open all depths Apr–Dec." },
+  { id: "ca_gma_mendocino", label: "CA · Mendocino GMA", hint: "Cape Mendocino to Point Arena: rockfish closed Jan–Mar, open all depths Apr–Dec." },
+  { id: "ca_gma_san_francisco", label: "CA · San Francisco GMA", hint: "Point Arena to Pigeon Point: Cordell Bank closed to all groundfish." },
+  { id: "ca_gma_central", label: "CA · Central GMA", hint: "Pigeon Point to Point Conception: rockfish closed Jan–Mar, open all depths Apr–Dec." },
+  { id: "ca_gma_southern", label: "CA · Southern GMA", hint: "Point Conception to Mexico: 50-fm RCA split Jul–Dec for boat groundfish." },
   { id: "florida", label: "Florida", hint: "Snook, redfish, tarpon, reef and bluewater." },
   { id: "hawaii", label: "Hawaii", hint: "Ahi, ono, mahi, ulua, marlin." },
   { id: "cabo_baja", label: "Cabo / Baja", hint: "Marlin, dorado, tuna, roosterfish." },
@@ -63,6 +76,27 @@ export const REGIONS: readonly Region[] = [
 ];
 
 const BY_REGION: Record<RegionId, readonly string[]> = {
+  ca_gma_northern: [
+    "rockfish", "lingcod", "pacific_halibut", "chinook_salmon",
+    "coho_salmon", "california_halibut", "striped_bass", "leopard_shark",
+  ],
+  ca_gma_mendocino: [
+    "rockfish", "lingcod", "pacific_halibut", "chinook_salmon",
+    "coho_salmon", "california_halibut", "striped_bass", "leopard_shark",
+  ],
+  ca_gma_san_francisco: [
+    "rockfish", "lingcod", "striped_bass", "chinook_salmon",
+    "california_halibut", "leopard_shark", "barred_surfperch", "white_sturgeon",
+  ],
+  ca_gma_central: [
+    "rockfish", "lingcod", "california_halibut", "barred_surfperch",
+    "striped_bass", "leopard_shark", "chinook_salmon", "cabezon",
+  ],
+  ca_gma_southern: [
+    "kelp_bass", "barred_sand_bass", "california_halibut", "barred_surfperch",
+    "spotfin_croaker", "rockfish", "lingcod", "california_sheephead",
+    "yellowtail", "white_seabass", "pacific_bonito", "bluefin_tuna",
+  ],
   southern_california: [
     "kelp_bass",
     "barred_sand_bass",

--- a/src/features/fish-legal/components/boundary-map.tsx
+++ b/src/features/fish-legal/components/boundary-map.tsx
@@ -15,6 +15,7 @@ import { distanceToLineM, pointInRing, sideOfLine } from "../geospatial";
 import { regulationCard } from "../reg-engine";
 import { RCA_50FM_LINE, REG_AREAS, SOCAL } from "../reg-data";
 import { FLORIDA } from "../florida-pack";
+import { NORCAL } from "../norcal-pack";
 import { platformFor } from "../reg-engine";
 import { useFishingModePreference } from "../prefs";
 import { useRegionPreference } from "@/features/settings/region";
@@ -66,7 +67,29 @@ export function BoundaryMap() {
     return `${get("year")}-${get("month")}-${get("day")}`;
   }, [now, zone]);
 
-  const isCalifornia = region === "southern_california";
+  // Founder ask (2026-09-02): California fishes by Groundfish Management Area. The
+  // view config pairs each CA region (plain NorCal/SoCal and the five GMA entries)
+  // with its bundle, its focus area, and a map center. Regions with no verified
+  // California pack keep the Florida overview fallback. The 50-fm RCA ribbon is a
+  // Southern-GMA window, so it shows for the two southern reads only.
+  const caView = useMemo(() => {
+    const isSoCal = region === "southern_california" || region === "ca_gma_southern";
+    if (isSoCal) {
+      return { bundle: SOCAL, areaId: "ca-gma-southern", areas: REG_AREAS, center: [33.6, -118.8] as const, showRca: true };
+    }
+    const norcalCenters: Record<string, { areaId: string; center: readonly [number, number] }> = {
+      northern_california: { areaId: "ca-gma-northern", center: [39.5, -124.0] },
+      ca_gma_northern: { areaId: "ca-gma-northern", center: [40.6, -124.3] },
+      ca_gma_mendocino: { areaId: "ca-gma-mendocino", center: [39.5, -123.9] },
+      ca_gma_san_francisco: { areaId: "ca-gma-san-francisco", center: [38.0, -123.2] },
+      ca_gma_central: { areaId: "ca-gma-central", center: [35.8, -121.8] },
+    };
+    const nc = norcalCenters[region];
+    if (nc) return { bundle: NORCAL, ...nc, areas: NORCAL.areas, showRca: false };
+    return null;
+  }, [region]);
+  const isCalifornia = caView !== null;
+
   // Today's groundfish reading drives the ribbon — a generic rockfish member's card is
   // the complex's voice this day (boat/shore decides the exemption copy). CA-ONLY:
   // Florida's pack has no 50-fm RCA row, and a Florida page that renders a California
@@ -74,9 +97,9 @@ export function BoundaryMap() {
   const rcgCard = useMemo(
     () =>
       isCalifornia
-        ? regulationCard(SOCAL, "ca-gma-southern", "rockfish", dateKey, platform)
+        ? regulationCard(caView.bundle, caView.areaId, "rockfish", dateKey, platform)
         : null,
-    [isCalifornia, dateKey, platform],
+    [isCalifornia, caView, dateKey, platform],
   );
 
   const ribbon = useMemo(() => {
@@ -102,12 +125,12 @@ export function BoundaryMap() {
     const irlArea = FLORIDA.areas.find((a) => a.id === "fl-irl-cnr")!;
     const inIrl = irlArea.polygon ? pointInRing(pt, irlArea.polygon) : false;
     return {
-      rcaSide: isCalifornia ? sideOfLine(pt, RCA_50FM_LINE.points) : null,
-      rcaDistanceM: isCalifornia ? distanceToLineM(pt, RCA_50FM_LINE.points) : null,
+      rcaSide: caView?.showRca ? sideOfLine(pt, RCA_50FM_LINE.points) : null,
+      rcaDistanceM: caView?.showRca ? distanceToLineM(pt, RCA_50FM_LINE.points) : null,
       inCca: ccaHit,
       inIrl,
     };
-  }, [position, isCalifornia]);
+  }, [position, caView]);
 
   const watch = () => {
     if (!("geolocation" in navigator)) {
@@ -123,7 +146,7 @@ export function BoundaryMap() {
         // says GPS is jurisdiction-agnostic — "you're fishing in a Florida no-take" must
         // work even when Settings are still California).
         const folded = foldAcrossBundle(
-          [...SOCAL.areas, ...FLORIDA.areas],
+          [...SOCAL.areas, ...NORCAL.areas, ...FLORIDA.areas],
           zoneWatches.current,
           [pos.coords.longitude, pos.coords.latitude],
           new Date(pos.timestamp).toISOString(),
@@ -231,9 +254,9 @@ export function BoundaryMap() {
           <BoundaryLeaflet
             position={position}
             layers={layers}
-            areas={isCalifornia ? REG_AREAS : FLORIDA.areas}
-            center={isCalifornia ? [33.6, -118.8] : [26.5, -82.5]}
-            showRca={isCalifornia}
+            areas={caView ? caView.areas : FLORIDA.areas}
+            center={caView ? ([caView.center[0], caView.center[1]] as const) : ([26.5, -82.5] as const)}
+            showRca={caView?.showRca ?? false}
           />
         </div>
         <div className="mt-3 flex flex-wrap items-center gap-3">

--- a/src/features/fish-legal/packs.ts
+++ b/src/features/fish-legal/packs.ts
@@ -45,6 +45,45 @@ export interface BundledPack {
 }
 
 export const PACKS: readonly BundledPack[] = [
+  // ——— CDFW Groundfish Management Areas (founder ask 2026-09-02: California broken
+  // into its five management units). Each GMA region reads the same verified NorCal /
+  // SoCal bundle — the GMA season/depth rows live inside those packs — with the pack's
+  // focus narrowed to its own GMA area.
+  {
+    regionId: "ca_gma_northern",
+    jurisdictionLabel: "California — Northern GMA — CDFW (US)",
+    shortCode: "CA·N",
+    primaryAreaId: "ca-gma-northern",
+    data: NORCAL,
+  },
+  {
+    regionId: "ca_gma_mendocino",
+    jurisdictionLabel: "California — Mendocino GMA — CDFW (US)",
+    shortCode: "CA·M",
+    primaryAreaId: "ca-gma-mendocino",
+    data: NORCAL,
+  },
+  {
+    regionId: "ca_gma_san_francisco",
+    jurisdictionLabel: "California — San Francisco GMA — CDFW (US)",
+    shortCode: "CA·SF",
+    primaryAreaId: "ca-gma-san-francisco",
+    data: NORCAL,
+  },
+  {
+    regionId: "ca_gma_central",
+    jurisdictionLabel: "California — Central GMA — CDFW (US)",
+    shortCode: "CA·C",
+    primaryAreaId: "ca-gma-central",
+    data: NORCAL,
+  },
+  {
+    regionId: "ca_gma_southern",
+    jurisdictionLabel: "California — Southern GMA — CDFW (US)",
+    shortCode: "CA·S",
+    primaryAreaId: "ca-gma-southern",
+    data: SOCAL,
+  },
   {
     regionId: "northern_california",
     jurisdictionLabel: "Northern California — CDFW (US)",

--- a/src/features/fish-legal/reg-engine.ts
+++ b/src/features/fish-legal/reg-engine.ts
@@ -215,11 +215,27 @@ export function regulationCard(
   platform: PlatformScope,
 ): RegulationCard | null {
   const { rules, groups } = rulesForSpecies(pack, areaId, speciesId);
-  // Group exceptions live in the GMA; if the caller asked the ocean region for an
-  // RCG member, also fold the GMA group rows in (the two areas share a coastline).
+  // Companion-area fold (spec §3): an ocean region and its GMA share a coastline —
+  // species bag/size rows live on the ocean region, group season/depth rows on the
+  // GMA. Whichever side the caller asked, fold the other side in. The five CDFW GMA
+  // settings regions (2026-09-02, "break up California even further") need the
+  // reverse direction: ask a GMA, pick up the ocean-size/bag rows.
+  const COMPANION_AREA: Record<string, string> = {
+    "ca-ocean-southern": "ca-gma-southern",
+    "ca-gma-southern": "ca-ocean-southern",
+    // The plain Northern California region spans the Northern + Mendocino GMAs;
+    // their 2026 windows are identical (CDFW June 2026 table), so Northern GMA's
+    // season rows read true for both.
+    "ca-ocean-northern": "ca-gma-northern",
+    "ca-gma-northern": "ca-ocean-northern",
+    "ca-gma-mendocino": "ca-ocean-northern",
+    "ca-gma-san-francisco": "ca-ocean-northern",
+    "ca-gma-central": "ca-ocean-northern",
+  };
+  const companion = COMPANION_AREA[areaId];
   const { rules: gmaRules, groups: gmaGroups } =
-    areaId === "ca-ocean-southern"
-      ? rulesForSpecies(pack, "ca-gma-southern", speciesId)
+    companion !== undefined && companion !== areaId
+      ? rulesForSpecies(pack, companion, speciesId)
       : { rules: [] as readonly RegRule[], groups: [] as readonly RegGroup[] };
   const allRules = [...rules, ...gmaRules];
   const allGroups = [...groups, ...gmaGroups.filter((g) => !groups.some((x) => x.id === g.id))];

--- a/src/features/fish-legal/states-wave1.test.ts
+++ b/src/features/fish-legal/states-wave1.test.ts
@@ -65,4 +65,22 @@ describe("states expansion wave 1 (Gulf + Baja)", () => {
       expect(pops.every((s) => speciesById(s) !== null)).toBe(true);
     }
   });
+
+  it("California's five GMAs are selectable Settings regions with packs and a GMA focus area", () => {
+    const GMAS = [
+      { id: "ca_gma_northern", area: "ca-gma-northern" },
+      { id: "ca_gma_mendocino", area: "ca-gma-mendocino" },
+      { id: "ca_gma_san_francisco", area: "ca-gma-san-francisco" },
+      { id: "ca_gma_central", area: "ca-gma-central" },
+      { id: "ca_gma_southern", area: "ca-gma-southern" },
+    ] as const;
+    for (const { id, area } of GMAS) {
+      expect(regionById(id), id).not.toBeNull();
+      expect(popularSpeciesIds(id).every((s) => speciesById(s) !== null), id).toBe(true);
+      const bundle = packForRegion(id);
+      expect(bundle, id).not.toBeNull();
+      expect(bundle!.primaryAreaId, id).toBe(area);
+      expect(bundle!.jurisdictionLabel, id).toContain("CDFW");
+    }
+  });
 });


### PR DESCRIPTION
Founder request after merging #30: the Settings **Fishing region** picker only offered "Northern California" and "Southern California" — the five CDFW Groundfish Management Areas from the CA GMA layer weren't selectable.

## What this adds (additive — the plain NorCal/SoCal entries stay)

Five new entries in the Settings → Fishing region picker:

- **CA · Northern GMA** — OR border → Cape Mendocino (40°10′ N)
- **CA · Mendocino GMA** — Cape Mendocino → Point Arena
- **CA · San Francisco GMA** — Point Arena → Pigeon Point (Cordell Bank: all groundfish prohibited)
- **CA · Central GMA** — Pigeon Point → Point Conception
- **CA · Southern GMA** — Point Conception → Mexico (50-fm RCA inshore/offshore split)

Each hint line states its boundaries and the 2026 season headline.

## Plumbing

- `core/ontology/regions.ts` — five `RegionId`s + species leads for each.
- `fish-legal/packs.ts` — five `BundledPack` rows with GMA focus areas (NORCAL bundle ×4, SOCAL ×1), so the jurisdiction chip reads the real CDFW pack instead of "no pack".
- `reg-engine` — `regulationCard` now folds the companion area both directions: a GMA-scoped question sees the ocean region's species size/bag rows, and the plain Northern California entry gets the GMA season windows (Northern and Mendocino GMAs read identically in the June 2026 CDFW table).
- Boundary map centers on the chosen GMA; GPS watches now also fold NorCal's GMA polygons.

## Gates

tsc clean · eslint clean · 423/423 vitest (new pin: five GMAs selectable with packs + focus areas) · `next build` clean.