### PR TITLE
Engine: inSeasonWindow year-wrap + MM-DD tolerant compare

### DIFF
--- a/docs/team/worklog/2026-09-01-13-architect.md
+++ b/docs/team/worklog/2026-09-01-13-architect.md
@@ -315,3 +315,17 @@ No new areas — rows reuse wa-ma-5-13-inside (sound), wa-ma-9/10/13, wa-ma-1-4-
   noUncheckedIndexedAccess surfaced as RegRule|undefined across the array tail — fixed.
 - gen-wa-shrimp-v5.mts → 20260902230000_v5_wa_shrimp.sql. Gates: tsc/eslint/build clean,
   425/425 vitest.
+
+## 28 — 2026-09-03 — Engine: inSeasonWindow year-wrap + MM-DD/YYYY-MM-DD tolerance
+
+- reg-engine.inSeasonWindow now compares month-day slices, so a rule bound works
+  whether the row carries "05-01" (book-year recurring) or "2026-05-01" (federal
+  dated). When start > end the window wraps New Year's (in-window = date >= start
+  OR date <= end) — the shape previously impossible in the engine, which forced the
+  Alaska lingcod two-row closure workaround and note-text-only WA pot windows.
+- With the fix in, the two wrapped WA crab pot seasons (ocean Dec 1-Sep 15; Willapa
+  Nov 15-Sep 15) get REAL season bounds (bundle + SQL UPDATE migration
+  20260903000000; "open year-round to other gear" rides in the note). AK lingcod
+  split rows stay as-is — they're still true with the fixed engine.
+- 3 new engine tests defend: wrap matching both sides of Jan 1, MM-DD mixed-form
+  compare, and regression on full-date bounds. 428/428 vitest; tsc/eslint/build clean.

--- a/src/features/fish-legal/reg-engine.test.ts
+++ b/src/features/fish-legal/reg-engine.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { SOCAL } from "./reg-data";
-import { platformFor, regulationCard } from "./reg-engine";
+import { inSeasonWindow, platformFor, regulationCard } from "./reg-engine";
 
 const TODAY = "2026-09-01"; // pack verification day — Southern region page's own stamp
 
@@ -115,5 +115,27 @@ describe("regulation engine (founder §4/§15 verdict ladder)", () => {
   it("platform mapping: kayak is a vessel, spearfishing is the diver carve-out", () => {
     expect(platformFor("kayak")).toBe("boat");
     expect(platformFor("spearfishing")).toBe("diver");
+  });
+});
+
+describe("inSeasonWindow year-wrap + mixed MM-DD/YYYY-MM-DD forms", () => {
+  const wrapRule = { seasonStart: "12-01", seasonEnd: "09-15" } as Parameters<typeof inSeasonWindow>[0];
+  it("a wrapped window (Dec 1 → Sep 15) matches both sides of New Year's", () => {
+    expect(inSeasonWindow(wrapRule, "2026-12-01")).toBe(true);  // opening day
+    expect(inSeasonWindow(wrapRule, "2027-01-15")).toBe(true);  // mid-winter
+    expect(inSeasonWindow(wrapRule, "2027-09-15")).toBe(true);  // closing day
+    expect(inSeasonWindow(wrapRule, "2026-10-01")).toBe(false); // the old bug: Oct read as in-season
+    expect(inSeasonWindow(wrapRule, "2026-11-30")).toBe(false); // eve of open
+  });
+  it("MM-DD rule bounds compare correctly against YYYY-MM-DD dateKeys", () => {
+    const md = { seasonStart: "05-01", seasonEnd: "06-15" } as Parameters<typeof inSeasonWindow>[0];
+    expect(inSeasonWindow(md, "2026-05-01")).toBe(true);
+    expect(inSeasonWindow(md, "2027-06-20")).toBe(false); // year must not leak
+  });
+  it("full-date bounds still compare as full dates", () => {
+    const fd = { seasonStart: "2026-09-01", seasonEnd: "2026-09-30" } as Parameters<typeof inSeasonWindow>[0];
+    expect(inSeasonWindow(fd, "2026-09-15")).toBe(true);
+    expect(inSeasonWindow(fd, "2026-10-01")).toBe(false);
+    expect(inSeasonWindow(fd, "2027-09-15")).toBe(true); // recurring by month-day
   });
 });

--- a/src/features/fish-legal/reg-engine.ts
+++ b/src/features/fish-legal/reg-engine.ts
@@ -26,10 +26,25 @@ export function platformFor(mode: FishingMode): PlatformScope {
   return "boat";
 }
 
-/** Inclusive [start, end] on YYYY-MM-DD; null bound = unbounded (year-round). */
+/**
+ * Inclusive [start, end]; null bound = unbounded (year-round).
+ *
+ * Both rule bounds and the dateKey may be full "YYYY-MM-DD" or "MM-DD" — the 24-state
+ * species tables carry recurring "(book-year)" MM-DD seasons while the SQL packs pin
+ * the federal-book year. Compares on MM-DD so either form reads correctly.
+ *
+ * Year-wrap: when start > end the season spans New Year's (WA crab pots Dec 1 →
+ * Sep 15; Willapa Nov 15 → Sep 15). In-window then means date ≥ start OR date ≤ end.
+ */
+const mmdd = (s: string): string => (s.length >= 10 ? s.slice(5) : s);
+
 export function inSeasonWindow(rule: RegRule, dateKey: string): boolean {
-  if (rule.seasonStart && dateKey < rule.seasonStart) return false;
-  if (rule.seasonEnd && dateKey > rule.seasonEnd) return false;
+  const s = rule.seasonStart === null ? null : mmdd(rule.seasonStart);
+  const e = rule.seasonEnd === null ? null : mmdd(rule.seasonEnd);
+  const d = mmdd(dateKey);
+  if (s !== null && e !== null && s > e) return d >= s || d <= e;
+  if (s !== null && d < s) return false;
+  if (e !== null && d > e) return false;
   return true;
 }
 

--- a/src/features/fish-legal/washington-pack.ts
+++ b/src/features/fish-legal/washington-pack.ts
@@ -780,8 +780,8 @@ export const WA_RULES: readonly RegRule[] = [
     verbatim:
       "Grays Harbor, and Marine Areas 1-3 and 4 (west of Bonilla-Tatoosh line) — Dungeness and Red Rock Crab: Open December 1 to September 15 for Pot Gear. Open year-round to other gear.",
     sourceUrl: C2.url, sourceTitle: C2.title, sourceUpdatedAt: C2.updated, verifiedAt: VERIFIED,
-    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
-    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "Pot gear window Dec 1-Sep 15 (wraps the calendar year); non-pot gear year-round.",
+    seasonStart: "12-01", seasonEnd: "09-15", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "Pot-gear window (wraps the calendar year); non-pot gear year-round.",
     checkInseason: true, staleAfterDays: 30,
   }),
   rule({
@@ -789,8 +789,8 @@ export const WA_RULES: readonly RegRule[] = [
     verbatim:
       "Willapa Bay — Dungeness and Red Rock Crab: November 15 to September 15 for Pot Gear. Open year-round to other gear.",
     sourceUrl: C2.url, sourceTitle: C2.title, sourceUpdatedAt: C2.updated, verifiedAt: VERIFIED,
-    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
-    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "Pot gear window Nov 15-Sep 15 (wraps the calendar year); non-pot gear year-round.",
+    seasonStart: "11-15", seasonEnd: "09-15", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "Pot-gear window (wraps the calendar year); non-pot gear year-round.",
     checkInseason: true, staleAfterDays: 30,
   }),
   rule({

--- a/supabase/migrations/20260903000000_wrap_season_fix.sql
+++ b/supabase/migrations/20260903000000_wrap_season_fix.sql
@@ -1,0 +1,17 @@
+-- inSeasonWindow year-wrap fix (2026-09-03): engine now compares season bounds on
+-- MM-DD and honours windows that span New Year's (start > end). Real dates replace the
+-- note-only workaround on the two wrapped pot-gear seasons shipped in the v4 WA crab
+-- migration. Dates are booked to the 2026 federal-regs year like every other row.
+update public.reg_rule
+set season_start = '2026-12-01', season_end = '2026-09-15',
+    depth_note = 'Pot-gear window (wraps the calendar year); non-pot gear year-round.'
+where species_id is null
+  and reg_area_id = 'wa-ma-1-4-coastal'
+  and verbatim like 'Grays Harbor, and Marine Areas 1-3%Pot Gear.%';
+
+update public.reg_rule
+set season_start = '2026-11-15', season_end = '2026-09-15',
+    depth_note = 'Pot-gear window (wraps the calendar year); non-pot gear year-round.'
+where species_id is null
+  and reg_area_id = 'wa-willapa-bay'
+  and verbatim like 'Willapa Bay — Dungeness and Red Rock Crab%Pot Gear.%';


### PR DESCRIPTION
The engine gate the deepen queue has been waiting on.

**Bug:** `inSeasonWindow` did a plain lexicographic compare of the dateKey against season bounds. Two failure modes: (a) a season that spans New Years (start > end, e.g. Dec 1 → Sep 15) read as permanently closed; (b) rule rows carrying recurring MM-DD bounds (the 24-state book-year form) and rows carrying YYYY-MM-DD federal dates both flow through the same compare, so a full-date bound against an MM-DD dateKey was garbage. Signed comparison failures previously forced workaround rows (AK lingcod split closures, WA pot windows as note text).

**Fix:** compare month-day slices on both sides (either stored form reads correctly), and when start > end the window wraps the calendar year: in-window iff date >= start OR date <= end.

**Payoff shipped in the same PR:** the two real wrapped seasons already in the data (WA ocean crab pots Dec 1-Sep 15; Willapa Bay Nov 15-Sep 15) get real bounds in the bundle + `supabase/migrations/20260903000000_wrap_season_fix.sql` UPDATEs. The year-round non-pot availability stays in the note text. AK lingcod split-closure rows remain valid under the new semantics and are untouched.

**Tests:** 3 new (wrap matches both sides of Jan 1; mixed MM-DD/full-date compare; full-date regression). 428/428 vitest; tsc / eslint / build clean.