### PR TITLE
Atlantic wave 2: RI / NY / NJ packs

### DIFF
--- a/docs/specs/fish-legal-expansion.md
+++ b/docs/specs/fish-legal-expansion.md
@@ -109,6 +109,12 @@ Recreational Catch Limits card, ADCNR/MRC releases + 2025 snapper-season closure
 NOM-017-PESC-1994 (DOF) for both Mexico packs. Waves 2–4 (South Atlantic, Mid-Atlantic,
 New England, Pacific NW, AK/HI) follow as PRs of 5–6 packs each.
 
+## Atlantic wave 1–2 (2026-09-03)
+
+- Wave 1: Massachusetts DMF (`northeast` region).
+- Wave 2: Rhode Island DEM, New York DEC, New Jersey DEP as additive Settings regions
+  `rhode_island` / `new_york` / `new_jersey`. `northeast` still resolves MA.
+
 Key findings encoded:
 - TX speckled trout: 3/day, 15–20" slot (post-March 2025 reset, confirmed against the
   2026–27 Annual page), tag system quoted; redfish 3/day 20–28 + tag bonus.

--- a/docs/team/worklog/2026-09-03-01-head-dev.md
+++ b/docs/team/worklog/2026-09-03-01-head-dev.md
@@ -1,0 +1,13 @@
+### 2026-09-03 | head-dev | ~2h
+
+- Atlantic wave 2: Rhode Island, New York, and New Jersey saltwater packs, sourced the
+  same day from DEM (Rev. 9/1/2026), DEC (table last changed 12 May 2026), and NJDEP
+  Attention Anglers 2026.
+- Three new Settings regions (RI / NY / NJ). The existing Northeast picker still answers
+  Massachusetts and is not broken.
+- Flagship rows: striper slots, fluke seasons, tautog ladders, black sea bass windows,
+  scup shore/boat splits, bluefish 5/7, plus the honest closed/prohibited rows (RI cod,
+  NY river herring south of the GWB, NJ river herring).
+- Not done: I have not clicked through the Legal pages in a phone browser. WA sub-areas
+  are still next, not this PR.
+- Files: the three packs, packs registry, regions, tests, generator, SQL migration.

--- a/scripts/gen-atlantic-wave2.mts
+++ b/scripts/gen-atlantic-wave2.mts
@@ -1,0 +1,55 @@
+/**
+ * Regenerate supabase/migrations/20260903030000_v1_atlantic_wave2_ri_ny_nj.sql —
+ * Atlantic wave 2: Rhode Island, New York, New Jersey packs.
+ *
+ *   npx tsx scripts/gen-atlantic-wave2.mts
+ */
+import { NEW_JERSEY } from "../src/features/fish-legal/new-jersey-pack";
+import { NEW_YORK } from "../src/features/fish-legal/new-york-pack";
+import { RHODE_ISLAND } from "../src/features/fish-legal/rhode-island-pack";
+import type { RegBundle } from "../src/features/fish-legal/packs";
+import { writeFileSync } from "node:fs";
+
+const esc = (s: string) => s.replaceAll("'", "''");
+const v = (x: unknown): string =>
+  x === null || x === undefined ? "null" : typeof x === "number" ? String(x) : `'${esc(String(x))}'`;
+const seasonDate = (md: string | null): string => (md ? `'2026-${md}'` : "null");
+
+function emit(bundle: RegBundle): string {
+  let sql = `\ninsert into public.reg_pack (id, version, published_at, notes) values
+  (${v(bundle.pack.id)}, ${bundle.pack.version}, ${v(bundle.pack.publishedAt)}, ${v(bundle.pack.notes)})
+on conflict (id) do nothing;
+
+insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geojson, source_url, verified_at, notes) values`;
+  sql += bundle.areas
+    .map(
+      (a) =>
+        `\n  (${v(a.id)}, ${v(a.authority)}, ${v(a.kind)}, ${v(a.name)}, null, ${a.polygon ? v(JSON.stringify(a.polygon)) : "null"}, ${v(a.sourceUrl)}, ${v(a.verifiedAt)}, ${v(a.notes ?? null)})`,
+    )
+    .join(",");
+  sql += `\non conflict (id) do nothing;\n`;
+
+  sql += `\ninsert into public.reg_rule
+  (species_id, reg_group_id, reg_area_id, water_class, kind, verbatim, source_url, source_title, source_updated_at, verified_at, pack_version,
+   season_start, season_end, bag_daily, possession_limit, min_size_in, max_size_in, size_measure, platform_scope, depth_note, check_inseason, stale_after_days)
+values`;
+  sql += bundle.rules
+    .map(
+      (r) =>
+        `\n  (${v(r.speciesId)}, ${v(r.regGroupId)}, ${v(r.regAreaId)}, 'salt', ${v(r.kind)}, ${v(r.verbatim)}, ${v(r.sourceUrl)}, ${v(r.sourceTitle)}, ${r.sourceUpdatedAt ? v(r.sourceUpdatedAt) : "null"}, ${v(r.verifiedAt)}, ${r.packVersion},
+   ${seasonDate(r.seasonStart)}, ${seasonDate(r.seasonEnd)}, ${v(r.bagDaily)}, ${v(r.possessionLimit)}, ${v(r.minSizeIn)}, ${v(r.maxSizeIn)}, ${v(r.sizeMeasure)}, ${v(r.platformScope)}, ${v(r.depthNote)}, ${r.checkInseason}, ${r.staleAfterDays})`,
+    )
+    .join(",");
+  sql += ";\n";
+  return sql;
+}
+
+const header = `-- Atlantic wave 2 (2026-09-03): Rhode Island DEM, New York DEC, New Jersey DEP
+-- recreational saltwater tables. GENERATED via gen-atlantic-wave2.mts — edit bundles,
+-- regenerate. No new species rows (wave-1 ontology already covers the table).
+`;
+
+const sql = header + emit(RHODE_ISLAND) + emit(NEW_YORK) + emit(NEW_JERSEY);
+writeFileSync("supabase/migrations/20260903030000_v1_atlantic_wave2_ri_ny_nj.sql", sql);
+const n = RHODE_ISLAND.rules.length + NEW_YORK.rules.length + NEW_JERSEY.rules.length;
+console.log(`written ${sql.length} bytes; ${n} rules across 3 packs`);

--- a/src/core/ontology/regions.ts
+++ b/src/core/ontology/regions.ts
@@ -31,6 +31,9 @@ export type RegionId =
   | "cabo_baja"
   | "gulf_coast"
   | "northeast"
+  | "rhode_island"
+  | "new_york"
+  | "new_jersey"
   | "great_lakes"
   /** California inland waters (CDFW statewide defaults; named waters override). */
   | "california_freshwater"
@@ -68,7 +71,10 @@ export const REGIONS: readonly Region[] = [
   { id: "hawaii", label: "Hawaii", hint: "Ahi, ono, mahi, ulua, marlin." },
   { id: "cabo_baja", label: "Cabo / Baja", hint: "Marlin, dorado, tuna, roosterfish." },
   { id: "gulf_coast", label: "Gulf Coast", hint: "Redfish, specks, snapper, cobia." },
-  { id: "northeast", label: "Northeast", hint: "Stripers, blues, fluke, tog, cod." },
+  { id: "northeast", label: "Northeast", hint: "Massachusetts DMF: stripers, blues, fluke, tog, cod." },
+  { id: "rhode_island", label: "Rhode Island", hint: "Narragansett Bay & Block Island: stripers, tautog, fluke, scup." },
+  { id: "new_york", label: "New York", hint: "Marine District: stripers, fluke, porgies, tautog LIS vs Bight." },
+  { id: "new_jersey", label: "New Jersey", hint: "Cape May to Sandy Hook: stripers, fluke, sea bass, tautog." },
   { id: "great_lakes", label: "Great Lakes", hint: "Walleye, salmon and trout, perch, bass." },
   { id: "california_freshwater", label: "California — Freshwater", hint: "Lakes, rivers, Delta: bass, trout, striper, sturgeon." },
   { id: "texas", label: "Texas", hint: "Galveston to Padre Island: redfish, specks, flounder." },
@@ -234,6 +240,18 @@ const BY_REGION: Record<RegionId, readonly string[]> = {
     "pollock",
     "false_albacore",
     "weakfish",
+  ],
+  rhode_island: [
+    "striped_bass", "tautog", "summer_flounder", "black_sea_bass",
+    "scup", "bluefish", "weakfish", "winter_flounder",
+  ],
+  new_york: [
+    "striped_bass", "summer_flounder", "black_sea_bass", "tautog",
+    "scup", "bluefish", "weakfish", "atlantic_cod",
+  ],
+  new_jersey: [
+    "striped_bass", "summer_flounder", "black_sea_bass", "tautog",
+    "bluefish", "weakfish", "scup", "black_drum",
   ],
   great_lakes: [
     "walleye",

--- a/src/features/fish-legal/atlantic-wave2.test.ts
+++ b/src/features/fish-legal/atlantic-wave2.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { speciesById } from "@/core/ontology/species";
+
+import { NEW_JERSEY } from "./new-jersey-pack";
+import { NEW_YORK } from "./new-york-pack";
+import { packForRegion } from "./packs";
+import { regulationCard } from "./reg-engine";
+import { RHODE_ISLAND } from "./rhode-island-pack";
+
+const TODAY = "2026-09-03";
+
+describe("Atlantic wave 2 — RI / NY / NJ", () => {
+  it("every pack rule species exists in the vocabulary", () => {
+    for (const bundle of [RHODE_ISLAND, NEW_YORK, NEW_JERSEY]) {
+      for (const r of bundle.rules) {
+        if (r.speciesId) expect(speciesById(r.speciesId), r.id).not.toBeNull();
+      }
+    }
+  });
+
+  it("Settings regions resolve the three packs", () => {
+    expect(packForRegion("rhode_island")?.data.pack.id).toBe(RHODE_ISLAND.pack.id);
+    expect(packForRegion("new_york")?.data.pack.id).toBe(NEW_YORK.pack.id);
+    expect(packForRegion("new_jersey")?.data.pack.id).toBe(NEW_JERSEY.pack.id);
+    expect(packForRegion("northeast")?.shortCode).toBe("MA");
+  });
+
+  it("RI stripers 28–31 @1; tautog 3 on Sep 3; cod prohibited", () => {
+    const sb = regulationCard(RHODE_ISLAND, "ri-statewide", "striped_bass", TODAY, "boat");
+    expect(sb!.bagDaily).toBe(1);
+    expect(sb!.minSizeIn).toBe(28);
+    expect(sb!.maxSizeIn).toBe(31);
+    expect(regulationCard(RHODE_ISLAND, "ri-statewide", "tautog", TODAY, "boat")!.bagDaily).toBe(3);
+    expect(regulationCard(RHODE_ISLAND, "ri-statewide", "atlantic_cod", TODAY, "boat")!.verdict).toBe("release");
+  });
+
+  it("NY marine fluke is 19.5in on Sep 3; BSB 6; LIS tautog closed in September", () => {
+    const fluke = regulationCard(NEW_YORK, "ny-marine", "summer_flounder", TODAY, "boat");
+    expect(fluke!.minSizeIn).toBe(19.5);
+    expect(fluke!.bagDaily).toBe(3);
+    expect(regulationCard(NEW_YORK, "ny-marine", "black_sea_bass", TODAY, "boat")!.bagDaily).toBe(6);
+    const tog = regulationCard(NEW_YORK, "ny-lis", "tautog", TODAY, "boat");
+    expect(tog!.verdict).toBe("release");
+  });
+
+  it("NY scup platform-splits: shore 9.5in, boat 11in", () => {
+    expect(regulationCard(NEW_YORK, "ny-marine", "scup", TODAY, "shore")!.minSizeIn).toBe(9.5);
+    expect(regulationCard(NEW_YORK, "ny-marine", "scup", TODAY, "boat")!.minSizeIn).toBe(11);
+  });
+
+  it("NJ fluke 18in @3; BSB 1-fish summer window; tautog 1 in September", () => {
+    const fluke = regulationCard(NEW_JERSEY, "nj-marine", "summer_flounder", TODAY, "boat");
+    expect(fluke!.minSizeIn).toBe(18);
+    expect(fluke!.bagDaily).toBe(3);
+    expect(regulationCard(NEW_JERSEY, "nj-ibsp", "summer_flounder", TODAY, "shore")!.minSizeIn).toBe(16);
+    expect(regulationCard(NEW_JERSEY, "nj-marine", "black_sea_bass", TODAY, "boat")!.bagDaily).toBe(1);
+    expect(regulationCard(NEW_JERSEY, "nj-marine", "tautog", TODAY, "boat")!.bagDaily).toBe(1);
+  });
+});

--- a/src/features/fish-legal/new-jersey-pack.ts
+++ b/src/features/fish-legal/new-jersey-pack.ts
@@ -1,0 +1,258 @@
+/**
+ * New Jersey pack — `new-jersey-2026-09-03`. Atlantic wave 2.
+ *
+ * Verbatims lifted 2026-09-03 from NJDEP Fish & Wildlife Attention Anglers 2026
+ * recreational size/possession/season sheet.
+ */
+import type { RegArea, RegPack, RegRule } from "./types";
+
+export const NEW_JERSEY_PACK: RegPack = {
+  id: "new-jersey-2026-09-03",
+  version: 1,
+  publishedAt: "2026-09-03T18:00:00Z",
+  notes:
+    "New Jersey (NJDEP Attention Anglers 2026): stripers 28–31\" @1 (ocean 0–3 mi year-round; other marine Mar 1–Dec 31; EEZ closed); fluke 18\" @3 May 4–Sep 25 (Delaware Bay 17\"; IBSP 16\" @2); BSB 12.5\" 10/1/10/15 windows; tautog 15\" 4/4/1/5 with March and May–July closed; bluefish 5 private/shore, 7 for-hire; weakfish 13\" @1.",
+};
+
+const NJ = {
+  url: "https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf",
+  title: "NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons",
+  updated: "2026-03-01",
+} as const;
+const VERIFIED = "2026-09-03";
+const pv = 1;
+
+export const NJ_AREAS: readonly RegArea[] = [
+  {
+    id: "nj-marine",
+    authority: "nj-dep",
+    kind: "ocean_region",
+    name: "New Jersey — all marine waters (except named carve-outs)",
+    polygon: [
+      [-75.55, 39.8], [-73.9, 40.55], [-73.9, 38.85], [-75.55, 38.85], [-75.55, 39.8],
+    ],
+    sourceUrl: NJ.url,
+    verifiedAt: VERIFIED,
+    notes: "Envelope. Delaware Bay and Island Beach State Park fluke carve-outs are separate areas.",
+  },
+  {
+    id: "nj-delaware-bay",
+    authority: "nj-dep",
+    kind: "ocean_region",
+    name: "Delaware Bay & Tributaries (NJ)",
+    polygon: null,
+    sourceUrl: NJ.url,
+    verifiedAt: VERIFIED,
+    notes: "Fluke 17\" @3.",
+  },
+  {
+    id: "nj-ibsp",
+    authority: "nj-dep",
+    kind: "ocean_region",
+    name: "Island Beach State Park (shore)",
+    polygon: null,
+    sourceUrl: NJ.url,
+    verifiedAt: VERIFIED,
+    notes: "Fluke 16\" @2.",
+  },
+];
+
+function rule(
+  r: Omit<RegRule, "packVersion" | "regGroupId"> & Partial<Pick<RegRule, "regGroupId">>,
+): RegRule {
+  return { regGroupId: null, ...r, packVersion: pv };
+}
+
+export const NJ_RULES: readonly RegRule[] = [
+  rule({
+    id: "nj-striped-bass-slot", speciesId: "striped_bass", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "Striped Bass or Hybrid Striped Bass: 1 fish at 28 inches to 31 inches. Atlantic Ocean: 0-3 miles from shore, no closed season. Greater than 3 miles from shore, closed. All Other Marine Waters: Open Mar 1 – Dec 31.",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 28, maxSizeIn: 31, sizeMeasure: "total_length", platformScope: null, depthNote: "EEZ closed. Bonus Program (24\" to <28\") is permit-only — see digest.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "nj-fluke", speciesId: "summer_flounder", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "Summer Flounder (Fluke) All marine waters except those noted below: 3 fish at 18 inches. Open Season: May 4 – Sept 25.",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: "05-04", seasonEnd: "09-25", bagDaily: 3, possessionLimit: 3, bagSharesWithGroup: false,
+    minSizeIn: 18, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "nj-fluke-debay", speciesId: "summer_flounder", regAreaId: "nj-delaware-bay", kind: "bag_limit",
+    verbatim: "Summer Flounder (Fluke) Delaware Bay & Tributaries: 3 fish at 17 inches. Open Season: May 4 – Sept 25.",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: "05-04", seasonEnd: "09-25", bagDaily: 3, possessionLimit: 3, bagSharesWithGroup: false,
+    minSizeIn: 17, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "nj-fluke-ibsp", speciesId: "summer_flounder", regAreaId: "nj-ibsp", kind: "bag_limit",
+    verbatim: "Summer Flounder (Fluke) Island Beach State Park: 2 fish at 16 inches. Open Season: May 4 – Sept 25.",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: "05-04", seasonEnd: "09-25", bagDaily: 2, possessionLimit: 2, bagSharesWithGroup: false,
+    minSizeIn: 16, maxSizeIn: null, sizeMeasure: "total_length", platformScope: "shore", depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "nj-bsb-may", speciesId: "black_sea_bass", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "Black Sea Bass: 10 fish at 12.5 inches May 15 – June 21.",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: "05-15", seasonEnd: "06-21", bagDaily: 10, possessionLimit: 10, bagSharesWithGroup: false,
+    minSizeIn: 12.5, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "Caudal filament excluded.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "nj-bsb-summer", speciesId: "black_sea_bass", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "Black Sea Bass: 1 fish at 12.5 inches June 22 – Sept 22.",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: "06-22", seasonEnd: "09-22", bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 12.5, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "Caudal filament excluded.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "nj-bsb-oct", speciesId: "black_sea_bass", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "Black Sea Bass: 10 fish at 12.5 inches Sept 23 – Oct 31.",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: "09-23", seasonEnd: "10-31", bagDaily: 10, possessionLimit: 10, bagSharesWithGroup: false,
+    minSizeIn: 12.5, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "Caudal filament excluded.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "nj-bsb-nov", speciesId: "black_sea_bass", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "Black Sea Bass: 15 fish at 12.5 inches Nov 1 – Dec 31.",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: "11-01", seasonEnd: "12-31", bagDaily: 15, possessionLimit: 15, bagSharesWithGroup: false,
+    minSizeIn: 12.5, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "Caudal filament excluded.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "nj-tautog-winter", speciesId: "tautog", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "Tautog: 15 inches. 4 fish Jan 1 – Feb 28.",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: "01-01", seasonEnd: "02-28", bagDaily: 4, possessionLimit: 4, bagSharesWithGroup: false,
+    minSizeIn: 15, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "nj-tautog-april", speciesId: "tautog", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "Tautog: 15 inches. 4 fish Apr 1 – Apr 30.",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: "04-01", seasonEnd: "04-30", bagDaily: 4, possessionLimit: 4, bagSharesWithGroup: false,
+    minSizeIn: 15, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "nj-tautog-late", speciesId: "tautog", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "Tautog: 15 inches. 1 fish Aug 1 – Nov 15.",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: "08-01", seasonEnd: "11-15", bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 15, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "nj-tautog-fall", speciesId: "tautog", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "Tautog: 15 inches. 5 fish Nov 16 – Dec 31.",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: "11-16", seasonEnd: "12-31", bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: false,
+    minSizeIn: 15, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "nj-bluefish", speciesId: "bluefish", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "Bluefish: Private/Shore Angler – 5 fish. For-Hire Vessel – 7 fish. Open Season: Jan 1 – Dec 31.",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "For-hire 7.",
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "nj-weakfish", speciesId: "weakfish", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "Weakfish: 1 fish at 13 inches. Open Season: Jan 1 – Dec 31.",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 13, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "nj-winter-flounder", speciesId: "winter_flounder", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "Winter Flounder: 2 fish at 12 inches. Open Season: Mar 1 – Dec 31.",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: "03-01", seasonEnd: "12-31", bagDaily: 2, possessionLimit: 2, bagSharesWithGroup: false,
+    minSizeIn: 12, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "nj-scup", speciesId: "scup", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "Scup (Porgy): 30 fish: Jan 1-June 30 and Sept 1-Dec 31. 10\".",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: "09-01", seasonEnd: "12-31", bagDaily: 30, possessionLimit: 30, bagSharesWithGroup: false,
+    minSizeIn: 10, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "Also open Jan 1–Jun 30 at 30/10\".",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "nj-scup-spring", speciesId: "scup", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "Scup (Porgy): 30 fish: Jan 1-June 30 and Sept 1-Dec 31. 10\".",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: "01-01", seasonEnd: "06-30", bagDaily: 30, possessionLimit: 30, bagSharesWithGroup: false,
+    minSizeIn: 10, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "nj-cod", speciesId: "atlantic_cod", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "Cod: 5 fish: Jan 1-May 31 and Sept 1-Dec 31. 23\".",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: "09-01", seasonEnd: "12-31", bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: false,
+    minSizeIn: 23, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "Also open Jan 1–May 31.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "nj-black-drum", speciesId: "black_drum", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "Black Drum: 3. 16\".",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 3, possessionLimit: 3, bagSharesWithGroup: false,
+    minSizeIn: 16, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "nj-red-drum", speciesId: "red_drum", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "Red Drum: 1. 18\" to less than 27\".",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 18, maxSizeIn: 27, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "nj-eel", speciesId: "american_eel", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "American Eel: 25. 9\".",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 25, possessionLimit: 25, bagSharesWithGroup: false,
+    minSizeIn: 9, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 90,
+  }),
+  rule({
+    id: "nj-river-herring", speciesId: "river_herring", regAreaId: "nj-marine", kind: "prohibited",
+    verbatim: "River Herring: CLOSED.",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 0, possessionLimit: 0, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 90,
+  }),
+  rule({
+    id: "nj-fillet-note", speciesId: null, regAreaId: "nj-marine", kind: "note",
+    verbatim: "Fish are measured from tip of snout to tip of tail (except Black Sea Bass and Sharks). Cleaning or filleting of fish with a minimum size limit while at sea is prohibited.",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 90,
+  }),
+];
+
+export const NEW_JERSEY = {
+  pack: NEW_JERSEY_PACK,
+  areas: NJ_AREAS,
+  groups: [],
+  rules: NJ_RULES,
+};

--- a/src/features/fish-legal/new-york-pack.ts
+++ b/src/features/fish-legal/new-york-pack.ts
@@ -1,0 +1,284 @@
+/**
+ * New York pack — `new-york-2026-09-03`. Atlantic wave 2.
+ *
+ * Verbatims lifted 2026-09-03 from DEC Recreational Saltwater Fishing Regulations
+ * (table last changed May 12, 2026).
+ */
+import type { RegArea, RegPack, RegRule } from "./types";
+
+export const NEW_YORK_PACK: RegPack = {
+  id: "new-york-2026-09-03",
+  version: 1,
+  publishedAt: "2026-09-03T18:00:00Z",
+  notes:
+    "New York (DEC recreational saltwater table, last changed 2026-05-12): marine stripers 28–31\" @1 Apr 15–Dec 15 (Hudson north of GWB 23–28\" Apr 1–Nov 30); fluke 19\" May 4–Aug 1 then 19.5\" Aug 2–Oct 15 @3; BSB 16\" 3 then 6; scup shore 9.5\" / vessel 11\" @30; tautog LIS vs NY Bight split; bluefish 5/7; winter flounder Apr 1–May 30 @2.",
+};
+
+const NY = {
+  url: "https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations",
+  title: "NYSDEC — Recreational Saltwater Fishing Regulations",
+  updated: "2026-05-12",
+} as const;
+const VERIFIED = "2026-09-03";
+const pv = 1;
+
+export const NY_AREAS: readonly RegArea[] = [
+  {
+    id: "ny-marine",
+    authority: "ny-dec",
+    kind: "ocean_region",
+    name: "New York — Marine & Coastal District (south of George Washington Bridge)",
+    polygon: [
+      [-74.26, 40.92], [-71.85, 41.3], [-71.85, 40.5], [-73.9, 40.4], [-74.26, 40.5], [-74.26, 40.92],
+    ],
+    sourceUrl: NY.url,
+    verifiedAt: VERIFIED,
+    notes: "Envelope for marine waters beginning at the Hudson south of the GWB + ocean/bays.",
+  },
+  {
+    id: "ny-hudson-north-gwb",
+    authority: "ny-dec",
+    kind: "ocean_region",
+    name: "Hudson River north of the George Washington Bridge",
+    polygon: null,
+    sourceUrl: NY.url,
+    verifiedAt: VERIFIED,
+    notes: "Striped bass slot 23–28\"; river herring possession allowed Mar 15–Jun 15.",
+  },
+  {
+    id: "ny-lis",
+    authority: "ny-dec",
+    kind: "ocean_region",
+    name: "Long Island Sound Region (east of Throgs Neck Bridge, west of Orient Point–Watch Hill line)",
+    polygon: null,
+    sourceUrl: NY.url,
+    verifiedAt: VERIFIED,
+    notes: "Tautog LIS windows.",
+  },
+  {
+    id: "ny-bight",
+    authority: "ny-dec",
+    kind: "ocean_region",
+    name: "NY Bight Region (marine waters outside the Long Island Sound Region)",
+    polygon: null,
+    sourceUrl: NY.url,
+    verifiedAt: VERIFIED,
+    notes: "Tautog NY Bight windows.",
+  },
+];
+
+function rule(
+  r: Omit<RegRule, "packVersion" | "regGroupId"> & Partial<Pick<RegRule, "regGroupId">>,
+): RegRule {
+  return { regGroupId: null, ...r, packVersion: pv };
+}
+
+export const NY_RULES: readonly RegRule[] = [
+  rule({
+    id: "ny-striped-bass-marine", speciesId: "striped_bass", regAreaId: "ny-marine", kind: "bag_limit",
+    verbatim: "Striped Bass: marine waters (beginning at the Hudson River south of George Washington Bridge) & Delaware River: Slot size 28\" - 31\". Possession 1. Open April 15 - Dec 15.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: "04-15", seasonEnd: "12-15", bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 28, maxSizeIn: 31, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ny-striped-bass-hudson", speciesId: "striped_bass", regAreaId: "ny-hudson-north-gwb", kind: "bag_limit",
+    verbatim: "Striped Bass: Hudson River (north of George Washington Bridge): Slot size 23\" - 28\". Possession 1. Open April 1 - Nov 30.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: "04-01", seasonEnd: "11-30", bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 23, maxSizeIn: 28, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ny-striped-bass-circle", speciesId: "striped_bass", regAreaId: "ny-marine", kind: "gear",
+    verbatim: "Non-offset (inline) circle hooks must be used when recreationally fishing for striped bass using bait defined as any live or dead, whole or part of a marine or aquatic organism or terrestrial invertebrate. Exemption: Circle hooks are not required when fishing with an artificial lure, whether or not they are tipped with bait as previously defined.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ny-fluke-early", speciesId: "summer_flounder", regAreaId: "ny-marine", kind: "bag_limit",
+    verbatim: "Summer flounder (fluke): 19\". Possession 3. Open May 4 - Aug 1.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: "05-04", seasonEnd: "08-01", bagDaily: 3, possessionLimit: 3, bagSharesWithGroup: false,
+    minSizeIn: 19, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "No head/tail removal at sea except white-side fillet for bait.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ny-fluke-late", speciesId: "summer_flounder", regAreaId: "ny-marine", kind: "bag_limit",
+    verbatim: "Summer flounder (fluke): 19.5\". Possession 3. Open Aug 2 - Oct 15.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: "08-02", seasonEnd: "10-15", bagDaily: 3, possessionLimit: 3, bagSharesWithGroup: false,
+    minSizeIn: 19.5, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "No head/tail removal at sea except white-side fillet for bait.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ny-bsb-early", speciesId: "black_sea_bass", regAreaId: "ny-marine", kind: "bag_limit",
+    verbatim: "Black Sea Bass: 16\". Possession 3. Open May 16 - Aug 31.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: "05-16", seasonEnd: "08-31", bagDaily: 3, possessionLimit: 3, bagSharesWithGroup: false,
+    minSizeIn: 16, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "Tail filament excluded.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ny-bsb-fall", speciesId: "black_sea_bass", regAreaId: "ny-marine", kind: "bag_limit",
+    verbatim: "Black Sea Bass: 16\". Possession 6. Open Sept 1 - Dec 31.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: "09-01", seasonEnd: "12-31", bagDaily: 6, possessionLimit: 6, bagSharesWithGroup: false,
+    minSizeIn: 16, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "Tail filament excluded.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ny-scup-shore", speciesId: "scup", regAreaId: "ny-marine", kind: "bag_limit",
+    verbatim: "Scup (Porgy): Shore-based anglers 9.5\". Possession 30. Open May 1 - Dec 31.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: "05-01", seasonEnd: "12-31", bagDaily: 30, possessionLimit: 30, bagSharesWithGroup: false,
+    minSizeIn: 9.5, maxSizeIn: null, sizeMeasure: "total_length", platformScope: "shore", depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ny-scup-vessel", speciesId: "scup", regAreaId: "ny-marine", kind: "bag_limit",
+    verbatim: "Scup (Porgy): Vessel-based anglers 11\". Possession 30. Open May 1 - Dec 31.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: "05-01", seasonEnd: "12-31", bagDaily: 30, possessionLimit: 30, bagSharesWithGroup: false,
+    minSizeIn: 11, maxSizeIn: null, sizeMeasure: "total_length", platformScope: "boat", depthNote: "Party/charter: 30 May–Aug; 40 Sep–Oct; 30 Nov–Dec.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ny-tautog-lis-spring-season", speciesId: "tautog", regAreaId: "ny-lis", kind: "season",
+    verbatim: "Tautog (blackfish): Long Island Sound Region open April 1 - April 30 and Oct 11 - Dec 9.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: "04-01", seasonEnd: "04-30", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ny-tautog-lis-fall-season", speciesId: "tautog", regAreaId: "ny-lis", kind: "season",
+    verbatim: "Tautog (blackfish): Long Island Sound Region open Oct 11 - Dec 9.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: "10-11", seasonEnd: "12-09", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ny-tautog-lis-spring", speciesId: "tautog", regAreaId: "ny-lis", kind: "bag_limit",
+    verbatim: "Tautog (blackfish): Long Island Sound Region: 16\". Possession 2. Open April 1 - April 30.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: "04-01", seasonEnd: "04-30", bagDaily: 2, possessionLimit: 2, bagSharesWithGroup: false,
+    minSizeIn: 16, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ny-tautog-lis-fall", speciesId: "tautog", regAreaId: "ny-lis", kind: "bag_limit",
+    verbatim: "Tautog (blackfish): Long Island Sound Region: 16\". Possession 3. Open Oct 11 - Dec 9.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: "10-11", seasonEnd: "12-09", bagDaily: 3, possessionLimit: 3, bagSharesWithGroup: false,
+    minSizeIn: 16, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ny-tautog-bight-spring-season", speciesId: "tautog", regAreaId: "ny-bight", kind: "season",
+    verbatim: "Tautog (blackfish): NY Bight Region open April 1 - April 30 and Oct 15 - Dec 22.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: "04-01", seasonEnd: "04-30", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ny-tautog-bight-fall-season", speciesId: "tautog", regAreaId: "ny-bight", kind: "season",
+    verbatim: "Tautog (blackfish): NY Bight Region open Oct 15 - Dec 22.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: "10-15", seasonEnd: "12-22", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ny-tautog-bight-spring", speciesId: "tautog", regAreaId: "ny-bight", kind: "bag_limit",
+    verbatim: "Tautog (blackfish): NY Bight Region: 16\". Possession 2. Open April 1 - April 30.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: "04-01", seasonEnd: "04-30", bagDaily: 2, possessionLimit: 2, bagSharesWithGroup: false,
+    minSizeIn: 16, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ny-tautog-bight-fall", speciesId: "tautog", regAreaId: "ny-bight", kind: "bag_limit",
+    verbatim: "Tautog (blackfish): NY Bight Region: 16\". Possession 4. Open Oct 15 - Dec 22.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: "10-15", seasonEnd: "12-22", bagDaily: 4, possessionLimit: 4, bagSharesWithGroup: false,
+    minSizeIn: 16, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ny-bluefish", speciesId: "bluefish", regAreaId: "ny-marine", kind: "bag_limit",
+    verbatim: "Bluefish (including \"snappers\"): No size limit. 5 for individuals. 7 for anglers aboard licensed party/charter boats. All year.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "Party/charter 7.",
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ny-winter-flounder", speciesId: "winter_flounder", regAreaId: "ny-marine", kind: "bag_limit",
+    verbatim: "Winter Flounder: 12\". Possession 2. Open April 1 - May 30.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: "04-01", seasonEnd: "05-30", bagDaily: 2, possessionLimit: 2, bagSharesWithGroup: false,
+    minSizeIn: 12, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ny-weakfish", speciesId: "weakfish", regAreaId: "ny-marine", kind: "bag_limit",
+    verbatim: "Weakfish: 16\" (10\" filleted; 12\" dressed). Possession 1. All year.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 16, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ny-cod", speciesId: "atlantic_cod", regAreaId: "ny-marine", kind: "bag_limit",
+    verbatim: "Atlantic cod: 23\". Possession 5. Open Sept 1 - May 31.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: "09-01", seasonEnd: "05-31", bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: false,
+    minSizeIn: 23, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "Year-wrap window; federal SNE no-retention may be tighter.",
+    checkInseason: true, staleAfterDays: 14,
+  }),
+  rule({
+    id: "ny-eel", speciesId: "american_eel", regAreaId: "ny-marine", kind: "bag_limit",
+    verbatim: "American Eel: 9\". 25 for individuals. 50 for anglers aboard licensed party/charter boats. All year.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 25, possessionLimit: 25, bagSharesWithGroup: false,
+    minSizeIn: 9, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 90,
+  }),
+  rule({
+    id: "ny-cobia", speciesId: "cobia", regAreaId: "ny-marine", kind: "bag_limit",
+    verbatim: "Cobia: 43\". Fishing from shore: 1 per angler. Fishing from vessel: 1 per angler and a maximum of 2 per vessel. All year.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 43, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "Vessel cap 2.",
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ny-river-herring-south", speciesId: "river_herring", regAreaId: "ny-marine", kind: "prohibited",
+    verbatim: "Anadromous river herring (alewife and blueback herring) (south of George Washington Bridge): No possession allowed.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 0, possessionLimit: 0, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 90,
+  }),
+  rule({
+    id: "ny-american-shad", speciesId: "american_shad", regAreaId: "ny-marine", kind: "prohibited",
+    verbatim: "American shad: No possession allowed.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 0, possessionLimit: 0, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 90,
+  }),
+];
+
+export const NEW_YORK = {
+  pack: NEW_YORK_PACK,
+  areas: NY_AREAS,
+  groups: [],
+  rules: NY_RULES,
+};

--- a/src/features/fish-legal/packs.ts
+++ b/src/features/fish-legal/packs.ts
@@ -24,6 +24,9 @@ import { WASHINGTON } from "./washington-pack";
 import { ALASKA } from "./alaska-pack";
 import { HAWAII } from "./hawaii-pack";
 import { MASSACHUSETTS } from "./massachusetts-pack";
+import { RHODE_ISLAND } from "./rhode-island-pack";
+import { NEW_YORK } from "./new-york-pack";
+import { NEW_JERSEY } from "./new-jersey-pack";
 import type { RegPack, RegArea, RegGroup, RegRule } from "./types";
 
 export type RegBundle = {
@@ -207,6 +210,27 @@ export const PACKS: readonly BundledPack[] = [
     shortCode: "MA",
     primaryAreaId: "ma-statewide",
     data: MASSACHUSETTS,
+  },
+  {
+    regionId: "rhode_island",
+    jurisdictionLabel: "Rhode Island — DEM (US)",
+    shortCode: "RI",
+    primaryAreaId: "ri-statewide",
+    data: RHODE_ISLAND,
+  },
+  {
+    regionId: "new_york",
+    jurisdictionLabel: "New York — DEC (US)",
+    shortCode: "NY",
+    primaryAreaId: "ny-marine",
+    data: NEW_YORK,
+  },
+  {
+    regionId: "new_jersey",
+    jurisdictionLabel: "New Jersey — NJDEP (US)",
+    shortCode: "NJ",
+    primaryAreaId: "nj-marine",
+    data: NEW_JERSEY,
   },
 ];
 

--- a/src/features/fish-legal/reg-data-parity.test.ts
+++ b/src/features/fish-legal/reg-data-parity.test.ts
@@ -13,6 +13,10 @@ import { MISSISSIPPI } from "./mississippi-pack";
 import { ALABAMA } from "./alabama-pack";
 import { BAJA_CALIFORNIA } from "./baja-pack";
 import { BAJA_CALIFORNIA_SUR } from "./bcs-pack";
+import { MASSACHUSETTS } from "./massachusetts-pack";
+import { RHODE_ISLAND } from "./rhode-island-pack";
+import { NEW_YORK } from "./new-york-pack";
+import { NEW_JERSEY } from "./new-jersey-pack";
 
 const LATER_BUNDLES = [
   NORCAL, CA_FRESHWATER, TEXAS, LOUISIANA, MISSISSIPPI, ALABAMA,

--- a/src/features/fish-legal/rhode-island-pack.ts
+++ b/src/features/fish-legal/rhode-island-pack.ts
@@ -1,0 +1,217 @@
+/**
+ * Rhode Island pack — `rhode-island-2026-09-03`. Atlantic wave 2.
+ *
+ * Verbatims lifted 2026-09-03 from DEM Marine Fisheries Minimum Sizes & Possession
+ * Limits, Recreational Marine Fisheries table (Rev. 9/1/2026).
+ */
+import type { RegArea, RegPack, RegRule } from "./types";
+
+export const RHODE_ISLAND_PACK: RegPack = {
+  id: "rhode-island-2026-09-03",
+  version: 1,
+  publishedAt: "2026-09-03T18:00:00Z",
+  notes:
+    "Rhode Island (DEM recreational table, Rev. 9/1/2026): striped bass 28\"-<31\" @1 year-round + circle-hook bait rule; bluefish 5 general / 7 party-charter; scup shore 9.5\" vs private/rental 11\" @30 May 1–Dec 31; fluke 19\" @6 Apr 1–Dec 31 with special-shore 17\" (2 of 6); tautog 16\" (one >21\", vessel 10) 3/closed/3/5; black sea bass 16\" general 3 May 16–Dec 31 (party/charter 4 then 6); cod prohibited; winter flounder 12\" @2 Mar 1–Dec 31 with Narragansett Bay north-of-Colregs prohibition.",
+};
+
+const RI = {
+  url: "https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits",
+  title: "Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)",
+  updated: "2026-09-01",
+} as const;
+const VERIFIED = "2026-09-03";
+const pv = 1;
+
+export const RI_AREAS: readonly RegArea[] = [
+  {
+    id: "ri-statewide",
+    authority: "ri-dem",
+    kind: "ocean_region",
+    name: "Rhode Island — coastal waters envelope",
+    polygon: [
+      [-71.9, 41.85], [-71.12, 41.85], [-71.12, 41.15], [-71.9, 41.15], [-71.9, 41.85],
+    ],
+    sourceUrl: RI.url,
+    verifiedAt: VERIFIED,
+    notes: "Envelope (Narragansett Bay + Block Island Sound). State-waters table.",
+  },
+  {
+    id: "ri-narragansett-north-colregs",
+    authority: "ri-dem",
+    kind: "conservation_area",
+    name: "Narragansett Bay north of the Colregs Line + Potter Pond, Point Judith Pond, Harbor of Refuge",
+    polygon: null,
+    sourceUrl: RI.url,
+    verifiedAt: VERIFIED,
+    notes: "Winter flounder harvest/possession prohibited.",
+  },
+];
+
+function rule(
+  r: Omit<RegRule, "packVersion" | "regGroupId"> & Partial<Pick<RegRule, "regGroupId">>,
+): RegRule {
+  return { regGroupId: null, ...r, packVersion: pv };
+}
+
+export const RI_RULES: readonly RegRule[] = [
+  rule({
+    id: "ri-striped-bass-slot", speciesId: "striped_bass", regAreaId: "ri-statewide", kind: "bag_limit",
+    verbatim: "Striped Bass: 28\"-<31\". Season 1/1 - 12/31. Possession limit: 1 fish/person/day.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 28, maxSizeIn: 31, sizeMeasure: "total_length", platformScope: null, depthNote: "Slot 28\" to less than 31\".",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ri-striped-bass-circle", speciesId: "striped_bass", regAreaId: "ri-statewide", kind: "gear",
+    verbatim: "Striped Bass Circle Hook Provision: Required when fishing recreationally for striped bass with bait.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ri-bluefish-general", speciesId: "bluefish", regAreaId: "ri-statewide", kind: "bag_limit",
+    verbatim: "Bluefish General Recreational: No minimum. 1/1 - 12/31. 5 fish/person/day.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "Party and Charter: 7 fish/person/day.",
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ri-scup-shore", speciesId: "scup", regAreaId: "ri-statewide", kind: "bag_limit",
+    verbatim: "Scup Shore: 9.5\". 5/1 - 12/31. 30 fish/person/day.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: "05-01", seasonEnd: "12-31", bagDaily: 30, possessionLimit: 30, bagSharesWithGroup: false,
+    minSizeIn: 9.5, maxSizeIn: null, sizeMeasure: "total_length", platformScope: "shore", depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ri-scup-vessel", speciesId: "scup", regAreaId: "ri-statewide", kind: "bag_limit",
+    verbatim: "Scup Private and Rental: 11\". 5/1 - 12/31. 30 fish/person/day.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: "05-01", seasonEnd: "12-31", bagDaily: 30, possessionLimit: 30, bagSharesWithGroup: false,
+    minSizeIn: 11, maxSizeIn: null, sizeMeasure: "total_length", platformScope: "boat", depthNote: "Party/charter: 30 May 1–Aug 31; 40 Sep 1–Oct 31; 30 Nov 1–Dec 31.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ri-fluke", speciesId: "summer_flounder", regAreaId: "ri-statewide", kind: "bag_limit",
+    verbatim: "Summer Flounder (Fluke): 19\". 4/1 - 12/31. 6 fish/person/day.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: "04-01", seasonEnd: "12-31", bagDaily: 6, possessionLimit: 6, bagSharesWithGroup: false,
+    minSizeIn: 19, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null,
+    depthNote: "Special shore sites: up to 2 fish 17\"+ count toward the 6; remainder 19\"+.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ri-fluke-season", speciesId: "summer_flounder", regAreaId: "ri-statewide", kind: "season",
+    verbatim: "Summer Flounder (Fluke): open 4/1 - 12/31.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: "04-01", seasonEnd: "12-31", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ri-tautog-spring", speciesId: "tautog", regAreaId: "ri-statewide", kind: "bag_limit",
+    verbatim: "Tautog: 16\". Only one fish may be greater than 21\". Max of 10 fish/vsl during all periods. 4/1 - 5/31: 3 fish/person/day.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: "04-01", seasonEnd: "05-31", bagDaily: 3, possessionLimit: 3, bagSharesWithGroup: false,
+    minSizeIn: 16, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "One fish >21\"; vessel cap 10.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ri-tautog-closed", speciesId: "tautog", regAreaId: "ri-statewide", kind: "season",
+    verbatim: "Tautog: 6/1 - 7/31 CLOSED.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: "06-01", seasonEnd: "07-31", bagDaily: 0, possessionLimit: 0, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "Closed.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ri-tautog-late", speciesId: "tautog", regAreaId: "ri-statewide", kind: "bag_limit",
+    verbatim: "Tautog: 16\". Only one fish may be greater than 21\". 8/1 - 10/14: 3 fish/person/day.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: "08-01", seasonEnd: "10-14", bagDaily: 3, possessionLimit: 3, bagSharesWithGroup: false,
+    minSizeIn: 16, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "One fish >21\"; vessel cap 10.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ri-tautog-fall", speciesId: "tautog", regAreaId: "ri-statewide", kind: "bag_limit",
+    verbatim: "Tautog: 16\". Only one fish may be greater than 21\". 10/15 - 12/31: 5 fish/person/day.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: "10-15", seasonEnd: "12-31", bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: false,
+    minSizeIn: 16, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "One fish >21\"; vessel cap 10.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ri-bsb-general", speciesId: "black_sea_bass", regAreaId: "ri-statewide", kind: "bag_limit",
+    verbatim: "Black Sea Bass General Recreational: 16\". 5/16 - 12/31. 3 fish/person/day.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: "05-16", seasonEnd: "12-31", bagDaily: 3, possessionLimit: 3, bagSharesWithGroup: false,
+    minSizeIn: 16, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "Party/charter: 4 May 16–Aug 31; 6 Sep 1–Dec 31.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ri-cod-prohibited", speciesId: "atlantic_cod", regAreaId: "ri-statewide", kind: "prohibited",
+    verbatim: "Cod: NA. 1/1 - 12/31. Prohibited.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 0, possessionLimit: 0, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ri-weakfish", speciesId: "weakfish", regAreaId: "ri-statewide", kind: "bag_limit",
+    verbatim: "Weakfish (Squeteague): 16\". 1/1 - 12/31. 1 fish/person/day.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 16, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ri-winter-flounder", speciesId: "winter_flounder", regAreaId: "ri-statewide", kind: "bag_limit",
+    verbatim: "Winter Flounder (Blackback): 12\". 3/1 - 12/31. 2 fish/person/day.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: "03-01", seasonEnd: "12-31", bagDaily: 2, possessionLimit: 2, bagSharesWithGroup: false,
+    minSizeIn: 12, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ri-winter-flounder-nb-prohibited", speciesId: "winter_flounder", regAreaId: "ri-narragansett-north-colregs", kind: "prohibited",
+    verbatim: "The harvesting or possession of winter flounder is PROHIBITED in Narragansett Bay north of the Colregs Line of Demarcation as well as in Potter Pond, Point Judith Pond, and the Harbor of Refuge.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 0, possessionLimit: 0, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 90,
+  }),
+  rule({
+    id: "ri-eel", speciesId: "american_eel", regAreaId: "ri-statewide", kind: "bag_limit",
+    verbatim: "American eel: 9\". 1/1 - 12/31. 25 eels/person/day. 50 eels/vsl/day for licensed party/charter vessels.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 25, possessionLimit: 25, bagSharesWithGroup: false,
+    minSizeIn: 9, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "Party/charter vessel 50/day.",
+    checkInseason: false, staleAfterDays: 90,
+  }),
+  rule({
+    id: "ri-haddock", speciesId: "haddock", regAreaId: "ri-statewide", kind: "bag_limit",
+    verbatim: "Haddock: 18\". 1/1 - 12/31. No limit.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: 18, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "No possession limit.",
+    checkInseason: false, staleAfterDays: 120,
+  }),
+  rule({
+    id: "ri-pollock", speciesId: "pollock", regAreaId: "ri-statewide", kind: "bag_limit",
+    verbatim: "Pollock: 19\". 1/1 - 12/31. No limit.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: 19, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "No possession limit.",
+    checkInseason: false, staleAfterDays: 120,
+  }),
+];
+
+export const RHODE_ISLAND = {
+  pack: RHODE_ISLAND_PACK,
+  areas: RI_AREAS,
+  groups: [],
+  rules: RI_RULES,
+};

--- a/supabase/migrations/20260903030000_v1_atlantic_wave2_ri_ny_nj.sql
+++ b/supabase/migrations/20260903030000_v1_atlantic_wave2_ri_ny_nj.sql
@@ -1,0 +1,182 @@
+-- Atlantic wave 2 (2026-09-03): Rhode Island DEM, New York DEC, New Jersey DEP
+-- recreational saltwater tables. GENERATED via gen-atlantic-wave2.mts — edit bundles,
+-- regenerate. No new species rows (wave-1 ontology already covers the table).
+
+insert into public.reg_pack (id, version, published_at, notes) values
+  ('rhode-island-2026-09-03', 1, '2026-09-03T18:00:00Z', 'Rhode Island (DEM recreational table, Rev. 9/1/2026): striped bass 28"-<31" @1 year-round + circle-hook bait rule; bluefish 5 general / 7 party-charter; scup shore 9.5" vs private/rental 11" @30 May 1–Dec 31; fluke 19" @6 Apr 1–Dec 31 with special-shore 17" (2 of 6); tautog 16" (one >21", vessel 10) 3/closed/3/5; black sea bass 16" general 3 May 16–Dec 31 (party/charter 4 then 6); cod prohibited; winter flounder 12" @2 Mar 1–Dec 31 with Narragansett Bay north-of-Colregs prohibition.')
+on conflict (id) do nothing;
+
+insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geojson, source_url, verified_at, notes) values
+  ('ri-statewide', 'ri-dem', 'ocean_region', 'Rhode Island — coastal waters envelope', null, '[[-71.9,41.85],[-71.12,41.85],[-71.12,41.15],[-71.9,41.15],[-71.9,41.85]]', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', '2026-09-03', 'Envelope (Narragansett Bay + Block Island Sound). State-waters table.'),
+  ('ri-narragansett-north-colregs', 'ri-dem', 'conservation_area', 'Narragansett Bay north of the Colregs Line + Potter Pond, Point Judith Pond, Harbor of Refuge', null, null, 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', '2026-09-03', 'Winter flounder harvest/possession prohibited.')
+on conflict (id) do nothing;
+
+insert into public.reg_rule
+  (species_id, reg_group_id, reg_area_id, water_class, kind, verbatim, source_url, source_title, source_updated_at, verified_at, pack_version,
+   season_start, season_end, bag_daily, possession_limit, min_size_in, max_size_in, size_measure, platform_scope, depth_note, check_inseason, stale_after_days)
+values
+  ('striped_bass', null, 'ri-statewide', 'salt', 'bag_limit', 'Striped Bass: 28"-<31". Season 1/1 - 12/31. Possession limit: 1 fish/person/day.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-03', 1,
+   null, null, 1, 1, 28, 31, 'total_length', null, 'Slot 28" to less than 31".', true, 30),
+  ('striped_bass', null, 'ri-statewide', 'salt', 'gear', 'Striped Bass Circle Hook Provision: Required when fishing recreationally for striped bass with bait.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-03', 1,
+   null, null, null, null, null, null, null, null, null, true, 30),
+  ('bluefish', null, 'ri-statewide', 'salt', 'bag_limit', 'Bluefish General Recreational: No minimum. 1/1 - 12/31. 5 fish/person/day.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-03', 1,
+   null, null, 5, 5, null, null, null, null, 'Party and Charter: 7 fish/person/day.', true, 60),
+  ('scup', null, 'ri-statewide', 'salt', 'bag_limit', 'Scup Shore: 9.5". 5/1 - 12/31. 30 fish/person/day.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-03', 1,
+   '2026-05-01', '2026-12-31', 30, 30, 9.5, null, 'total_length', 'shore', null, true, 30),
+  ('scup', null, 'ri-statewide', 'salt', 'bag_limit', 'Scup Private and Rental: 11". 5/1 - 12/31. 30 fish/person/day.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-03', 1,
+   '2026-05-01', '2026-12-31', 30, 30, 11, null, 'total_length', 'boat', 'Party/charter: 30 May 1–Aug 31; 40 Sep 1–Oct 31; 30 Nov 1–Dec 31.', true, 30),
+  ('summer_flounder', null, 'ri-statewide', 'salt', 'bag_limit', 'Summer Flounder (Fluke): 19". 4/1 - 12/31. 6 fish/person/day.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-03', 1,
+   '2026-04-01', '2026-12-31', 6, 6, 19, null, 'total_length', null, 'Special shore sites: up to 2 fish 17"+ count toward the 6; remainder 19"+.', true, 30),
+  ('summer_flounder', null, 'ri-statewide', 'salt', 'season', 'Summer Flounder (Fluke): open 4/1 - 12/31.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-03', 1,
+   '2026-04-01', '2026-12-31', null, null, null, null, null, null, null, true, 30),
+  ('tautog', null, 'ri-statewide', 'salt', 'bag_limit', 'Tautog: 16". Only one fish may be greater than 21". Max of 10 fish/vsl during all periods. 4/1 - 5/31: 3 fish/person/day.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-03', 1,
+   '2026-04-01', '2026-05-31', 3, 3, 16, null, 'total_length', null, 'One fish >21"; vessel cap 10.', true, 30),
+  ('tautog', null, 'ri-statewide', 'salt', 'season', 'Tautog: 6/1 - 7/31 CLOSED.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-03', 1,
+   '2026-06-01', '2026-07-31', 0, 0, null, null, null, null, 'Closed.', true, 30),
+  ('tautog', null, 'ri-statewide', 'salt', 'bag_limit', 'Tautog: 16". Only one fish may be greater than 21". 8/1 - 10/14: 3 fish/person/day.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-03', 1,
+   '2026-08-01', '2026-10-14', 3, 3, 16, null, 'total_length', null, 'One fish >21"; vessel cap 10.', true, 30),
+  ('tautog', null, 'ri-statewide', 'salt', 'bag_limit', 'Tautog: 16". Only one fish may be greater than 21". 10/15 - 12/31: 5 fish/person/day.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-03', 1,
+   '2026-10-15', '2026-12-31', 5, 5, 16, null, 'total_length', null, 'One fish >21"; vessel cap 10.', true, 30),
+  ('black_sea_bass', null, 'ri-statewide', 'salt', 'bag_limit', 'Black Sea Bass General Recreational: 16". 5/16 - 12/31. 3 fish/person/day.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-03', 1,
+   '2026-05-16', '2026-12-31', 3, 3, 16, null, 'total_length', null, 'Party/charter: 4 May 16–Aug 31; 6 Sep 1–Dec 31.', true, 30),
+  ('atlantic_cod', null, 'ri-statewide', 'salt', 'prohibited', 'Cod: NA. 1/1 - 12/31. Prohibited.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-03', 1,
+   null, null, 0, 0, null, null, null, null, null, true, 30),
+  ('weakfish', null, 'ri-statewide', 'salt', 'bag_limit', 'Weakfish (Squeteague): 16". 1/1 - 12/31. 1 fish/person/day.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-03', 1,
+   null, null, 1, 1, 16, null, 'total_length', null, null, true, 60),
+  ('winter_flounder', null, 'ri-statewide', 'salt', 'bag_limit', 'Winter Flounder (Blackback): 12". 3/1 - 12/31. 2 fish/person/day.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-03', 1,
+   '2026-03-01', '2026-12-31', 2, 2, 12, null, 'total_length', null, null, true, 60),
+  ('winter_flounder', null, 'ri-narragansett-north-colregs', 'salt', 'prohibited', 'The harvesting or possession of winter flounder is PROHIBITED in Narragansett Bay north of the Colregs Line of Demarcation as well as in Potter Pond, Point Judith Pond, and the Harbor of Refuge.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-03', 1,
+   null, null, 0, 0, null, null, null, null, null, false, 90),
+  ('american_eel', null, 'ri-statewide', 'salt', 'bag_limit', 'American eel: 9". 1/1 - 12/31. 25 eels/person/day. 50 eels/vsl/day for licensed party/charter vessels.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-03', 1,
+   null, null, 25, 25, 9, null, 'total_length', null, 'Party/charter vessel 50/day.', false, 90),
+  ('haddock', null, 'ri-statewide', 'salt', 'bag_limit', 'Haddock: 18". 1/1 - 12/31. No limit.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-03', 1,
+   null, null, null, null, 18, null, 'total_length', null, 'No possession limit.', false, 120),
+  ('pollock', null, 'ri-statewide', 'salt', 'bag_limit', 'Pollock: 19". 1/1 - 12/31. No limit.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-03', 1,
+   null, null, null, null, 19, null, 'total_length', null, 'No possession limit.', false, 120);
+
+insert into public.reg_pack (id, version, published_at, notes) values
+  ('new-york-2026-09-03', 1, '2026-09-03T18:00:00Z', 'New York (DEC recreational saltwater table, last changed 2026-05-12): marine stripers 28–31" @1 Apr 15–Dec 15 (Hudson north of GWB 23–28" Apr 1–Nov 30); fluke 19" May 4–Aug 1 then 19.5" Aug 2–Oct 15 @3; BSB 16" 3 then 6; scup shore 9.5" / vessel 11" @30; tautog LIS vs NY Bight split; bluefish 5/7; winter flounder Apr 1–May 30 @2.')
+on conflict (id) do nothing;
+
+insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geojson, source_url, verified_at, notes) values
+  ('ny-marine', 'ny-dec', 'ocean_region', 'New York — Marine & Coastal District (south of George Washington Bridge)', null, '[[-74.26,40.92],[-71.85,41.3],[-71.85,40.5],[-73.9,40.4],[-74.26,40.5],[-74.26,40.92]]', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', '2026-09-03', 'Envelope for marine waters beginning at the Hudson south of the GWB + ocean/bays.'),
+  ('ny-hudson-north-gwb', 'ny-dec', 'ocean_region', 'Hudson River north of the George Washington Bridge', null, null, 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', '2026-09-03', 'Striped bass slot 23–28"; river herring possession allowed Mar 15–Jun 15.'),
+  ('ny-lis', 'ny-dec', 'ocean_region', 'Long Island Sound Region (east of Throgs Neck Bridge, west of Orient Point–Watch Hill line)', null, null, 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', '2026-09-03', 'Tautog LIS windows.'),
+  ('ny-bight', 'ny-dec', 'ocean_region', 'NY Bight Region (marine waters outside the Long Island Sound Region)', null, null, 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', '2026-09-03', 'Tautog NY Bight windows.')
+on conflict (id) do nothing;
+
+insert into public.reg_rule
+  (species_id, reg_group_id, reg_area_id, water_class, kind, verbatim, source_url, source_title, source_updated_at, verified_at, pack_version,
+   season_start, season_end, bag_daily, possession_limit, min_size_in, max_size_in, size_measure, platform_scope, depth_note, check_inseason, stale_after_days)
+values
+  ('striped_bass', null, 'ny-marine', 'salt', 'bag_limit', 'Striped Bass: marine waters (beginning at the Hudson River south of George Washington Bridge) & Delaware River: Slot size 28" - 31". Possession 1. Open April 15 - Dec 15.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   '2026-04-15', '2026-12-15', 1, 1, 28, 31, 'total_length', null, null, true, 30),
+  ('striped_bass', null, 'ny-hudson-north-gwb', 'salt', 'bag_limit', 'Striped Bass: Hudson River (north of George Washington Bridge): Slot size 23" - 28". Possession 1. Open April 1 - Nov 30.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   '2026-04-01', '2026-11-30', 1, 1, 23, 28, 'total_length', null, null, true, 30),
+  ('striped_bass', null, 'ny-marine', 'salt', 'gear', 'Non-offset (inline) circle hooks must be used when recreationally fishing for striped bass using bait defined as any live or dead, whole or part of a marine or aquatic organism or terrestrial invertebrate. Exemption: Circle hooks are not required when fishing with an artificial lure, whether or not they are tipped with bait as previously defined.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   null, null, null, null, null, null, null, null, null, true, 30),
+  ('summer_flounder', null, 'ny-marine', 'salt', 'bag_limit', 'Summer flounder (fluke): 19". Possession 3. Open May 4 - Aug 1.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   '2026-05-04', '2026-08-01', 3, 3, 19, null, 'total_length', null, 'No head/tail removal at sea except white-side fillet for bait.', true, 30),
+  ('summer_flounder', null, 'ny-marine', 'salt', 'bag_limit', 'Summer flounder (fluke): 19.5". Possession 3. Open Aug 2 - Oct 15.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   '2026-08-02', '2026-10-15', 3, 3, 19.5, null, 'total_length', null, 'No head/tail removal at sea except white-side fillet for bait.', true, 30),
+  ('black_sea_bass', null, 'ny-marine', 'salt', 'bag_limit', 'Black Sea Bass: 16". Possession 3. Open May 16 - Aug 31.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   '2026-05-16', '2026-08-31', 3, 3, 16, null, 'total_length', null, 'Tail filament excluded.', true, 30),
+  ('black_sea_bass', null, 'ny-marine', 'salt', 'bag_limit', 'Black Sea Bass: 16". Possession 6. Open Sept 1 - Dec 31.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   '2026-09-01', '2026-12-31', 6, 6, 16, null, 'total_length', null, 'Tail filament excluded.', true, 30),
+  ('scup', null, 'ny-marine', 'salt', 'bag_limit', 'Scup (Porgy): Shore-based anglers 9.5". Possession 30. Open May 1 - Dec 31.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   '2026-05-01', '2026-12-31', 30, 30, 9.5, null, 'total_length', 'shore', null, true, 30),
+  ('scup', null, 'ny-marine', 'salt', 'bag_limit', 'Scup (Porgy): Vessel-based anglers 11". Possession 30. Open May 1 - Dec 31.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   '2026-05-01', '2026-12-31', 30, 30, 11, null, 'total_length', 'boat', 'Party/charter: 30 May–Aug; 40 Sep–Oct; 30 Nov–Dec.', true, 30),
+  ('tautog', null, 'ny-lis', 'salt', 'season', 'Tautog (blackfish): Long Island Sound Region open April 1 - April 30 and Oct 11 - Dec 9.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   '2026-04-01', '2026-04-30', null, null, null, null, null, null, null, true, 30),
+  ('tautog', null, 'ny-lis', 'salt', 'season', 'Tautog (blackfish): Long Island Sound Region open Oct 11 - Dec 9.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   '2026-10-11', '2026-12-09', null, null, null, null, null, null, null, true, 30),
+  ('tautog', null, 'ny-lis', 'salt', 'bag_limit', 'Tautog (blackfish): Long Island Sound Region: 16". Possession 2. Open April 1 - April 30.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   '2026-04-01', '2026-04-30', 2, 2, 16, null, 'total_length', null, null, true, 30),
+  ('tautog', null, 'ny-lis', 'salt', 'bag_limit', 'Tautog (blackfish): Long Island Sound Region: 16". Possession 3. Open Oct 11 - Dec 9.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   '2026-10-11', '2026-12-09', 3, 3, 16, null, 'total_length', null, null, true, 30),
+  ('tautog', null, 'ny-bight', 'salt', 'season', 'Tautog (blackfish): NY Bight Region open April 1 - April 30 and Oct 15 - Dec 22.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   '2026-04-01', '2026-04-30', null, null, null, null, null, null, null, true, 30),
+  ('tautog', null, 'ny-bight', 'salt', 'season', 'Tautog (blackfish): NY Bight Region open Oct 15 - Dec 22.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   '2026-10-15', '2026-12-22', null, null, null, null, null, null, null, true, 30),
+  ('tautog', null, 'ny-bight', 'salt', 'bag_limit', 'Tautog (blackfish): NY Bight Region: 16". Possession 2. Open April 1 - April 30.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   '2026-04-01', '2026-04-30', 2, 2, 16, null, 'total_length', null, null, true, 30),
+  ('tautog', null, 'ny-bight', 'salt', 'bag_limit', 'Tautog (blackfish): NY Bight Region: 16". Possession 4. Open Oct 15 - Dec 22.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   '2026-10-15', '2026-12-22', 4, 4, 16, null, 'total_length', null, null, true, 30),
+  ('bluefish', null, 'ny-marine', 'salt', 'bag_limit', 'Bluefish (including "snappers"): No size limit. 5 for individuals. 7 for anglers aboard licensed party/charter boats. All year.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   null, null, 5, 5, null, null, null, null, 'Party/charter 7.', true, 60),
+  ('winter_flounder', null, 'ny-marine', 'salt', 'bag_limit', 'Winter Flounder: 12". Possession 2. Open April 1 - May 30.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   '2026-04-01', '2026-05-30', 2, 2, 12, null, 'total_length', null, null, true, 60),
+  ('weakfish', null, 'ny-marine', 'salt', 'bag_limit', 'Weakfish: 16" (10" filleted; 12" dressed). Possession 1. All year.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   null, null, 1, 1, 16, null, 'total_length', null, null, true, 60),
+  ('atlantic_cod', null, 'ny-marine', 'salt', 'bag_limit', 'Atlantic cod: 23". Possession 5. Open Sept 1 - May 31.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   '2026-09-01', '2026-05-31', 5, 5, 23, null, 'total_length', null, 'Year-wrap window; federal SNE no-retention may be tighter.', true, 14),
+  ('american_eel', null, 'ny-marine', 'salt', 'bag_limit', 'American Eel: 9". 25 for individuals. 50 for anglers aboard licensed party/charter boats. All year.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   null, null, 25, 25, 9, null, 'total_length', null, null, false, 90),
+  ('cobia', null, 'ny-marine', 'salt', 'bag_limit', 'Cobia: 43". Fishing from shore: 1 per angler. Fishing from vessel: 1 per angler and a maximum of 2 per vessel. All year.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   null, null, 1, 1, 43, null, 'total_length', null, 'Vessel cap 2.', true, 60),
+  ('river_herring', null, 'ny-marine', 'salt', 'prohibited', 'Anadromous river herring (alewife and blueback herring) (south of George Washington Bridge): No possession allowed.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   null, null, 0, 0, null, null, null, null, null, false, 90),
+  ('american_shad', null, 'ny-marine', 'salt', 'prohibited', 'American shad: No possession allowed.', 'https://dec.ny.gov/things-to-do/saltwater-fishing/recreational-fishing-regulations', 'NYSDEC — Recreational Saltwater Fishing Regulations', '2026-05-12', '2026-09-03', 1,
+   null, null, 0, 0, null, null, null, null, null, false, 90);
+
+insert into public.reg_pack (id, version, published_at, notes) values
+  ('new-jersey-2026-09-03', 1, '2026-09-03T18:00:00Z', 'New Jersey (NJDEP Attention Anglers 2026): stripers 28–31" @1 (ocean 0–3 mi year-round; other marine Mar 1–Dec 31; EEZ closed); fluke 18" @3 May 4–Sep 25 (Delaware Bay 17"; IBSP 16" @2); BSB 12.5" 10/1/10/15 windows; tautog 15" 4/4/1/5 with March and May–July closed; bluefish 5 private/shore, 7 for-hire; weakfish 13" @1.')
+on conflict (id) do nothing;
+
+insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geojson, source_url, verified_at, notes) values
+  ('nj-marine', 'nj-dep', 'ocean_region', 'New Jersey — all marine waters (except named carve-outs)', null, '[[-75.55,39.8],[-73.9,40.55],[-73.9,38.85],[-75.55,38.85],[-75.55,39.8]]', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', '2026-09-03', 'Envelope. Delaware Bay and Island Beach State Park fluke carve-outs are separate areas.'),
+  ('nj-delaware-bay', 'nj-dep', 'ocean_region', 'Delaware Bay & Tributaries (NJ)', null, null, 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', '2026-09-03', 'Fluke 17" @3.'),
+  ('nj-ibsp', 'nj-dep', 'ocean_region', 'Island Beach State Park (shore)', null, null, 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', '2026-09-03', 'Fluke 16" @2.')
+on conflict (id) do nothing;
+
+insert into public.reg_rule
+  (species_id, reg_group_id, reg_area_id, water_class, kind, verbatim, source_url, source_title, source_updated_at, verified_at, pack_version,
+   season_start, season_end, bag_daily, possession_limit, min_size_in, max_size_in, size_measure, platform_scope, depth_note, check_inseason, stale_after_days)
+values
+  ('striped_bass', null, 'nj-marine', 'salt', 'bag_limit', 'Striped Bass or Hybrid Striped Bass: 1 fish at 28 inches to 31 inches. Atlantic Ocean: 0-3 miles from shore, no closed season. Greater than 3 miles from shore, closed. All Other Marine Waters: Open Mar 1 – Dec 31.', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   null, null, 1, 1, 28, 31, 'total_length', null, 'EEZ closed. Bonus Program (24" to <28") is permit-only — see digest.', true, 30),
+  ('summer_flounder', null, 'nj-marine', 'salt', 'bag_limit', 'Summer Flounder (Fluke) All marine waters except those noted below: 3 fish at 18 inches. Open Season: May 4 – Sept 25.', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   '2026-05-04', '2026-09-25', 3, 3, 18, null, 'total_length', null, null, true, 30),
+  ('summer_flounder', null, 'nj-delaware-bay', 'salt', 'bag_limit', 'Summer Flounder (Fluke) Delaware Bay & Tributaries: 3 fish at 17 inches. Open Season: May 4 – Sept 25.', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   '2026-05-04', '2026-09-25', 3, 3, 17, null, 'total_length', null, null, true, 30),
+  ('summer_flounder', null, 'nj-ibsp', 'salt', 'bag_limit', 'Summer Flounder (Fluke) Island Beach State Park: 2 fish at 16 inches. Open Season: May 4 – Sept 25.', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   '2026-05-04', '2026-09-25', 2, 2, 16, null, 'total_length', 'shore', null, true, 30),
+  ('black_sea_bass', null, 'nj-marine', 'salt', 'bag_limit', 'Black Sea Bass: 10 fish at 12.5 inches May 15 – June 21.', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   '2026-05-15', '2026-06-21', 10, 10, 12.5, null, 'total_length', null, 'Caudal filament excluded.', true, 30),
+  ('black_sea_bass', null, 'nj-marine', 'salt', 'bag_limit', 'Black Sea Bass: 1 fish at 12.5 inches June 22 – Sept 22.', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   '2026-06-22', '2026-09-22', 1, 1, 12.5, null, 'total_length', null, 'Caudal filament excluded.', true, 30),
+  ('black_sea_bass', null, 'nj-marine', 'salt', 'bag_limit', 'Black Sea Bass: 10 fish at 12.5 inches Sept 23 – Oct 31.', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   '2026-09-23', '2026-10-31', 10, 10, 12.5, null, 'total_length', null, 'Caudal filament excluded.', true, 30),
+  ('black_sea_bass', null, 'nj-marine', 'salt', 'bag_limit', 'Black Sea Bass: 15 fish at 12.5 inches Nov 1 – Dec 31.', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   '2026-11-01', '2026-12-31', 15, 15, 12.5, null, 'total_length', null, 'Caudal filament excluded.', true, 30),
+  ('tautog', null, 'nj-marine', 'salt', 'bag_limit', 'Tautog: 15 inches. 4 fish Jan 1 – Feb 28.', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   '2026-01-01', '2026-02-28', 4, 4, 15, null, 'total_length', null, null, true, 30),
+  ('tautog', null, 'nj-marine', 'salt', 'bag_limit', 'Tautog: 15 inches. 4 fish Apr 1 – Apr 30.', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   '2026-04-01', '2026-04-30', 4, 4, 15, null, 'total_length', null, null, true, 30),
+  ('tautog', null, 'nj-marine', 'salt', 'bag_limit', 'Tautog: 15 inches. 1 fish Aug 1 – Nov 15.', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   '2026-08-01', '2026-11-15', 1, 1, 15, null, 'total_length', null, null, true, 30),
+  ('tautog', null, 'nj-marine', 'salt', 'bag_limit', 'Tautog: 15 inches. 5 fish Nov 16 – Dec 31.', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   '2026-11-16', '2026-12-31', 5, 5, 15, null, 'total_length', null, null, true, 30),
+  ('bluefish', null, 'nj-marine', 'salt', 'bag_limit', 'Bluefish: Private/Shore Angler – 5 fish. For-Hire Vessel – 7 fish. Open Season: Jan 1 – Dec 31.', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   null, null, 5, 5, null, null, null, null, 'For-hire 7.', true, 60),
+  ('weakfish', null, 'nj-marine', 'salt', 'bag_limit', 'Weakfish: 1 fish at 13 inches. Open Season: Jan 1 – Dec 31.', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   null, null, 1, 1, 13, null, 'total_length', null, null, true, 60),
+  ('winter_flounder', null, 'nj-marine', 'salt', 'bag_limit', 'Winter Flounder: 2 fish at 12 inches. Open Season: Mar 1 – Dec 31.', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   '2026-03-01', '2026-12-31', 2, 2, 12, null, 'total_length', null, null, true, 60),
+  ('scup', null, 'nj-marine', 'salt', 'bag_limit', 'Scup (Porgy): 30 fish: Jan 1-June 30 and Sept 1-Dec 31. 10".', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   '2026-09-01', '2026-12-31', 30, 30, 10, null, 'total_length', null, 'Also open Jan 1–Jun 30 at 30/10".', true, 30),
+  ('scup', null, 'nj-marine', 'salt', 'bag_limit', 'Scup (Porgy): 30 fish: Jan 1-June 30 and Sept 1-Dec 31. 10".', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   '2026-01-01', '2026-06-30', 30, 30, 10, null, 'total_length', null, null, true, 30),
+  ('atlantic_cod', null, 'nj-marine', 'salt', 'bag_limit', 'Cod: 5 fish: Jan 1-May 31 and Sept 1-Dec 31. 23".', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   '2026-09-01', '2026-12-31', 5, 5, 23, null, 'total_length', null, 'Also open Jan 1–May 31.', true, 30),
+  ('black_drum', null, 'nj-marine', 'salt', 'bag_limit', 'Black Drum: 3. 16".', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   null, null, 3, 3, 16, null, 'total_length', null, null, true, 60),
+  ('red_drum', null, 'nj-marine', 'salt', 'bag_limit', 'Red Drum: 1. 18" to less than 27".', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   null, null, 1, 1, 18, 27, 'total_length', null, null, true, 60),
+  ('american_eel', null, 'nj-marine', 'salt', 'bag_limit', 'American Eel: 25. 9".', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   null, null, 25, 25, 9, null, 'total_length', null, null, false, 90),
+  ('river_herring', null, 'nj-marine', 'salt', 'prohibited', 'River Herring: CLOSED.', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   null, null, 0, 0, null, null, null, null, null, false, 90),
+  (null, null, 'nj-marine', 'salt', 'note', 'Fish are measured from tip of snout to tip of tail (except Black Sea Bass and Sharks). Cleaning or filleting of fish with a minimum size limit while at sea is prohibited.', 'https://dep.nj.gov/njfw/wp-content/uploads/njfw/attention-anglers-2026.pdf', 'NJDEP Fish & Wildlife — Attention Anglers 2026 Recreational Size Limits, Possession Limits and Seasons', '2026-03-01', '2026-09-03', 1,
+   null, null, null, null, null, null, null, null, null, false, 90);


### PR DESCRIPTION
DEM (Rev. 9/1/2026), DEC (table last changed 2026-05-12), and NJDEP Attention Anglers 2026 verbatims.

- Additive Settings regions: `rhode_island`, `new_york`, `new_jersey`
- `northeast` still resolves Massachusetts
- 442 vitest; tsc clean

I have not clicked through Legal on a phone.