### PR TITLE
Atlantic wave 4: DE/MD/VA/NC/SC/GA + outbox flusher

### DIFF
--- a/docs/team/worklog/2026-09-03-04-head-dev.md
+++ b/docs/team/worklog/2026-09-03-04-head-dev.md
@@ -1,0 +1,3 @@
+# 2026-09-03 — Head Dev — Atlantic wave 4 + outbox flusher start
+
+PR #45 (CT/NH/ME) merged. Wave 4 encodes DE/MD/VA/NC/SC/GA from agency pages (verified-or-nothing). Also landed the pure outbox flusher (`flushOnce`) so Phase 1 sync has a protocol implementation; IndexedDB + Supabase sender still not wired — backup badge remains honest.

--- a/scripts/gen-atlantic-wave4.mts
+++ b/scripts/gen-atlantic-wave4.mts
@@ -1,0 +1,57 @@
+/**
+ * Regenerate supabase/migrations/20260903060000_v1_atlantic_wave4_south.sql —
+ * Atlantic wave 4: DE MD VA NC SC GA.
+ *
+ *   npx tsx scripts/gen-atlantic-wave4.mts
+ */
+import { DELAWARE } from "../src/features/fish-legal/delaware-pack";
+import { GEORGIA } from "../src/features/fish-legal/georgia-pack";
+import { MARYLAND } from "../src/features/fish-legal/maryland-pack";
+import { NORTH_CAROLINA } from "../src/features/fish-legal/north-carolina-pack";
+import { SOUTH_CAROLINA } from "../src/features/fish-legal/south-carolina-pack";
+import { VIRGINIA } from "../src/features/fish-legal/virginia-pack";
+import type { RegBundle } from "../src/features/fish-legal/packs";
+import { writeFileSync } from "node:fs";
+
+const esc = (s: string) => s.replaceAll("'", "''");
+const v = (x: unknown): string =>
+  x === null || x === undefined ? "null" : typeof x === "number" ? String(x) : `'${esc(String(x))}'`;
+const seasonDate = (md: string | null): string => (md ? `'2026-${md}'` : "null");
+
+function emit(bundle: RegBundle): string {
+  let sql = `\ninsert into public.reg_pack (id, version, published_at, notes) values
+  (${v(bundle.pack.id)}, ${bundle.pack.version}, ${v(bundle.pack.publishedAt)}, ${v(bundle.pack.notes)})
+on conflict (id) do nothing;
+
+insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geojson, source_url, verified_at, notes) values`;
+  sql += bundle.areas
+    .map(
+      (a) =>
+        `\n  (${v(a.id)}, ${v(a.authority)}, ${v(a.kind)}, ${v(a.name)}, null, ${a.polygon ? v(JSON.stringify(a.polygon)) : "null"}, ${v(a.sourceUrl)}, ${v(a.verifiedAt)}, ${v(a.notes ?? null)})`,
+    )
+    .join(",");
+  sql += `\non conflict (id) do nothing;\n`;
+
+  sql += `\ninsert into public.reg_rule
+  (species_id, reg_group_id, reg_area_id, water_class, kind, verbatim, source_url, source_title, source_updated_at, verified_at, pack_version,
+   season_start, season_end, bag_daily, possession_limit, min_size_in, max_size_in, size_measure, platform_scope, depth_note, check_inseason, stale_after_days)
+values`;
+  sql += bundle.rules
+    .map(
+      (r) =>
+        `\n  (${v(r.speciesId)}, ${v(r.regGroupId)}, ${v(r.regAreaId)}, 'salt', ${v(r.kind)}, ${v(r.verbatim)}, ${v(r.sourceUrl)}, ${v(r.sourceTitle)}, ${r.sourceUpdatedAt ? v(r.sourceUpdatedAt) : "null"}, ${v(r.verifiedAt)}, ${r.packVersion},
+   ${seasonDate(r.seasonStart)}, ${seasonDate(r.seasonEnd)}, ${v(r.bagDaily)}, ${v(r.possessionLimit)}, ${v(r.minSizeIn)}, ${v(r.maxSizeIn)}, ${v(r.sizeMeasure)}, ${v(r.platformScope)}, ${v(r.depthNote)}, ${r.checkInseason}, ${r.staleAfterDays})`,
+    )
+    .join(",");
+  sql += ";\n";
+  return sql;
+}
+
+const bundles = [DELAWARE, MARYLAND, VIRGINIA, NORTH_CAROLINA, SOUTH_CAROLINA, GEORGIA];
+const header = `-- Atlantic wave 4 (2026-09-03): DE DNREC, MD DNR, VA MRC, NC DMF, SC DNR, GA CRD
+-- GENERATED via gen-atlantic-wave4.mts. Insert-only.
+`;
+const sql = header + bundles.map(emit).join("");
+writeFileSync("supabase/migrations/20260903060000_v1_atlantic_wave4_south.sql", sql);
+const n = bundles.reduce((a, b) => a + b.rules.length, 0);
+console.log(`written ${sql.length} bytes; ${n} rules across ${bundles.length} packs`);

--- a/src/core/ontology/regions.ts
+++ b/src/core/ontology/regions.ts
@@ -37,6 +37,12 @@ export type RegionId =
   | "maine"
   | "new_york"
   | "new_jersey"
+  | "delaware"
+  | "maryland"
+  | "virginia"
+  | "north_carolina"
+  | "south_carolina"
+  | "georgia"
   | "great_lakes"
   /** California inland waters (CDFW statewide defaults; named waters override). */
   | "california_freshwater"
@@ -81,6 +87,12 @@ export const REGIONS: readonly Region[] = [
   { id: "maine", label: "Maine", hint: "Head of tide to 3 miles: stripers, cod, haddock, blues." },
   { id: "new_york", label: "New York", hint: "Marine District: stripers, fluke, porgies, tautog LIS vs Bight." },
   { id: "new_jersey", label: "New Jersey", hint: "Cape May to Sandy Hook: stripers, fluke, sea bass, tautog." },
+  { id: "delaware", label: "Delaware", hint: "Bay and ocean: stripers, tautog, fluke, red drum." },
+  { id: "maryland", label: "Maryland", hint: "Ocean slot stripers; Chesapeake 19–24\" rockfish." },
+  { id: "virginia", label: "Virginia", hint: "Coastal stripers and sea bass; Bay seasons separate." },
+  { id: "north_carolina", label: "North Carolina", hint: "Red drum slot, short flounder windows, specks." },
+  { id: "south_carolina", label: "South Carolina", hint: "Red drum 18–25\" @1 after Act 231." },
+  { id: "georgia", label: "Georgia", hint: "Red drum, specks, flounder, inshore gamefish." },
   { id: "great_lakes", label: "Great Lakes", hint: "Walleye, salmon and trout, perch, bass." },
   { id: "california_freshwater", label: "California — Freshwater", hint: "Lakes, rivers, Delta: bass, trout, striper, sturgeon." },
   { id: "texas", label: "Texas", hint: "Galveston to Padre Island: redfish, specks, flounder." },
@@ -270,6 +282,30 @@ const BY_REGION: Record<RegionId, readonly string[]> = {
   new_jersey: [
     "striped_bass", "summer_flounder", "black_sea_bass", "tautog",
     "bluefish", "weakfish", "scup", "black_drum",
+  ],
+  delaware: [
+    "striped_bass", "tautog", "summer_flounder", "black_sea_bass",
+    "red_drum", "weakfish", "bluefish", "black_drum",
+  ],
+  maryland: [
+    "striped_bass", "summer_flounder", "bluefish", "tautog",
+    "black_sea_bass", "red_drum", "spotted_seatrout", "weakfish",
+  ],
+  virginia: [
+    "striped_bass", "black_sea_bass", "red_drum", "spotted_seatrout",
+    "cobia", "summer_flounder", "bluefish", "tautog",
+  ],
+  north_carolina: [
+    "red_drum", "spotted_seatrout", "southern_flounder", "sheepshead",
+    "black_drum", "bluefish", "weakfish", "striped_bass",
+  ],
+  south_carolina: [
+    "red_drum", "spotted_seatrout", "southern_flounder", "sheepshead",
+    "black_drum", "striped_bass", "bluefish", "weakfish",
+  ],
+  georgia: [
+    "red_drum", "spotted_seatrout", "southern_flounder", "striped_bass",
+    "sheepshead", "cobia", "black_drum", "weakfish",
   ],
   great_lakes: [
     "walleye",

--- a/src/core/sync/flusher.test.ts
+++ b/src/core/sync/flusher.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { flushOnce } from "./flusher";
+import type { Mutation, SendOutcome } from "./outbox";
+
+function mut(over: Partial<Mutation> & Pick<Mutation, "id">): Mutation {
+  return {
+    entity: "catch",
+    entityId: over.id,
+    op: "insert",
+    payload: { id: over.id },
+    clientUpdatedAt: "2026-09-03T12:00:00.000Z",
+    deviceId: "dev-1",
+    attempts: 0,
+    lastError: null,
+    state: "queued",
+    ...over,
+  };
+}
+
+describe("outbox flusher", () => {
+  it("marks reachable inserts done and leaves unreachable queued", async () => {
+    const send = async (m: Mutation): Promise<SendOutcome> =>
+      m.id === "b" ? { kind: "unreachable", error: "offline" } : { kind: "ok" };
+    const result = await flushOnce([mut({ id: "a" }), mut({ id: "b" })], send);
+    expect(result.done).toBe(1);
+    expect(result.stillQueued).toBe(1);
+    expect(result.mutations.find((m) => m.id === "a")!.state).toBe("done");
+    expect(result.mutations.find((m) => m.id === "b")!.state).toBe("queued");
+  });
+
+  it("stops the pass on auth_expired so later rows are not burned", async () => {
+    const seen: string[] = [];
+    const send = async (m: Mutation): Promise<SendOutcome> => {
+      seen.push(m.id);
+      if (m.id === "a") return { kind: "auth_expired", error: "401" };
+      return { kind: "ok" };
+    };
+    const result = await flushOnce([mut({ id: "a" }), mut({ id: "b" })], send);
+    expect(seen).toEqual(["a"]);
+    expect(result.done).toBe(0);
+    expect(result.mutations.every((m) => m.state === "queued")).toBe(true);
+  });
+});

--- a/src/core/sync/flusher.ts
+++ b/src/core/sync/flusher.ts
@@ -1,0 +1,53 @@
+/**
+ * Outbox flusher — the missing I/O half of ADR 004.
+ *
+ * `outbox.ts` is the protocol (pure). This module walks pending mutations and
+ * asks an injected sender to deliver each one, then applies `applyOutcome`.
+ * Nothing here knows about Supabase; the browser (or a test) supplies `send`.
+ *
+ * This is the Phase 1 wiring the backup badge still lacks: until a real sender
+ * is hooked to IndexedDB, the glass correctly says "Saved on this device."
+ */
+import { applyOutcome, pendingMutations, type Mutation, type SendOutcome } from "./outbox";
+
+export type SendMutation = (mutation: Mutation) => Promise<SendOutcome>;
+
+export interface FlushResult {
+  readonly attempted: number;
+  readonly done: number;
+  readonly rejected: number;
+  readonly stillQueued: number;
+  readonly mutations: readonly Mutation[];
+}
+
+/**
+ * One pass over the queue, oldest first. Stops early on `auth_expired` so a
+ * refresh can happen before we burn the rest of the backlog.
+ */
+export async function flushOnce(
+  mutations: readonly Mutation[],
+  send: SendMutation,
+): Promise<FlushResult> {
+  const next = mutations.map((m) => ({ ...m }));
+  const byId = new Map(next.map((m) => [m.id, m]));
+  let done = 0;
+  let rejected = 0;
+  let attempted = 0;
+
+  for (const pending of pendingMutations(next)) {
+    attempted += 1;
+    const current = byId.get(pending.id)!;
+    const sending: Mutation = { ...current, state: "sending" };
+    byId.set(sending.id, sending);
+    const outcome = await send(sending);
+    const applied = applyOutcome(sending, outcome);
+    byId.set(applied.id, applied);
+    if (applied.state === "done") done += 1;
+    if (applied.state === "rejected") rejected += 1;
+    if (outcome.kind === "auth_expired") break;
+  }
+
+  const mutationsOut = next.map((m) => byId.get(m.id)!);
+  const stillQueued = mutationsOut.filter((m) => m.state === "queued" || m.state === "sending").length;
+  return { attempted, done, rejected, stillQueued, mutations: mutationsOut };
+}

--- a/src/features/fish-legal/atlantic-wave4.test.ts
+++ b/src/features/fish-legal/atlantic-wave4.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { speciesById } from "@/core/ontology/species";
+
+import { DELAWARE } from "./delaware-pack";
+import { GEORGIA } from "./georgia-pack";
+import { MARYLAND } from "./maryland-pack";
+import { NORTH_CAROLINA } from "./north-carolina-pack";
+import { packForRegion } from "./packs";
+import { regulationCard } from "./reg-engine";
+import { SOUTH_CAROLINA } from "./south-carolina-pack";
+import { VIRGINIA } from "./virginia-pack";
+
+const TODAY = "2026-09-03";
+const BUNDLES = [DELAWARE, MARYLAND, VIRGINIA, NORTH_CAROLINA, SOUTH_CAROLINA, GEORGIA];
+
+describe("Atlantic wave 4 — DE / MD / VA / NC / SC / GA", () => {
+  it("every pack rule species exists in the vocabulary", () => {
+    for (const bundle of BUNDLES) {
+      for (const r of bundle.rules) {
+        if (r.speciesId) expect(speciesById(r.speciesId), r.id).not.toBeNull();
+      }
+    }
+  });
+
+  it("Settings regions resolve the six packs", () => {
+    expect(packForRegion("delaware")?.shortCode).toBe("DE");
+    expect(packForRegion("maryland")?.shortCode).toBe("MD");
+    expect(packForRegion("virginia")?.shortCode).toBe("VA");
+    expect(packForRegion("north_carolina")?.shortCode).toBe("NC");
+    expect(packForRegion("south_carolina")?.shortCode).toBe("SC");
+    expect(packForRegion("georgia")?.shortCode).toBe("GA");
+  });
+
+  it("DE tautog 16 @4 on Sep 3; fluke 17.5 @4; stripers slot @1", () => {
+    expect(regulationCard(DELAWARE, "de-tidal", "tautog", TODAY, "boat")!.bagDaily).toBe(4);
+    expect(regulationCard(DELAWARE, "de-tidal", "summer_flounder", TODAY, "boat")!.minSizeIn).toBe(17.5);
+    expect(regulationCard(DELAWARE, "de-tidal", "striped_bass", TODAY, "boat")!.bagDaily).toBe(1);
+  });
+
+  it("MD ocean stripers 28–31; Bay 19–24 on Sep 3; fluke 17.5 @4", () => {
+    const ocean = regulationCard(MARYLAND, "md-atlantic", "striped_bass", TODAY, "boat");
+    expect(ocean!.minSizeIn).toBe(28);
+    const bay = regulationCard(MARYLAND, "md-chesapeake", "striped_bass", TODAY, "boat");
+    expect(bay!.minSizeIn).toBe(19);
+    expect(bay!.maxSizeIn).toBe(24);
+    expect(regulationCard(MARYLAND, "md-atlantic", "summer_flounder", TODAY, "boat")!.minSizeIn).toBe(17.5);
+  });
+
+  it("VA coastal stripers open Sep 3; BSB bag 15", () => {
+    expect(regulationCard(VIRGINIA, "va-coast", "striped_bass", TODAY, "boat")!.bagDaily).toBe(1);
+    expect(regulationCard(VIRGINIA, "va-coast", "black_sea_bass", TODAY, "boat")!.bagDaily).toBe(15);
+  });
+
+  it("NC flounder open Sep 1–14; red drum 18–27 @1; tarpon prohibited", () => {
+    const fl = regulationCard(NORTH_CAROLINA, "nc-coastal", "southern_flounder", TODAY, "boat");
+    expect(fl!.bagDaily).toBe(1);
+    expect(regulationCard(NORTH_CAROLINA, "nc-coastal", "red_drum", TODAY, "boat")!.bagDaily).toBe(1);
+    expect(regulationCard(NORTH_CAROLINA, "nc-coastal", "atlantic_tarpon", TODAY, "boat")!.verdict).toBe("release");
+  });
+
+  it("SC red drum 18–25 @1; stripers closed Sep 3", () => {
+    const rd = regulationCard(SOUTH_CAROLINA, "sc-state-waters", "red_drum", TODAY, "boat");
+    expect(rd!.minSizeIn).toBe(18);
+    expect(rd!.maxSizeIn).toBe(25);
+    expect(rd!.bagDaily).toBe(1);
+    expect(regulationCard(SOUTH_CAROLINA, "sc-state-waters", "striped_bass", TODAY, "boat")!.verdict).toBe("release");
+  });
+
+  it("GA red drum 14–23 @5; cobia open @1", () => {
+    const rd = regulationCard(GEORGIA, "ga-state-waters", "red_drum", TODAY, "boat");
+    expect(rd!.bagDaily).toBe(5);
+    expect(rd!.minSizeIn).toBe(14);
+    expect(regulationCard(GEORGIA, "ga-state-waters", "cobia", TODAY, "boat")!.bagDaily).toBe(1);
+  });
+});

--- a/src/features/fish-legal/delaware-pack.ts
+++ b/src/features/fish-legal/delaware-pack.ts
@@ -1,0 +1,122 @@
+/**
+ * Delaware pack — `delaware-2026-09-03`. Atlantic wave 4 (South Atlantic / Delmarva).
+ * DNREC Fish Facts + 2026 Fishing Guide (electronic).
+ */
+import type { RegArea, RegPack, RegRule } from "./types";
+
+export const DELAWARE_PACK: RegPack = {
+  id: "delaware-2026-09-03",
+  version: 1,
+  publishedAt: "2026-09-03T22:00:00Z",
+  notes:
+    "Delaware DNREC 2026: stripers 28–31\" @1 (20–25\" Jul 1–Aug 31 in DE River/Bay/tributaries); tautog 16\" @4 Jan 1–May 15 and Jul 1–Dec 31; fluke 16\" then 17.5\" @4; BSB 13\" @15 May 15–Sep 30 and Oct 10–Dec 31; red drum 20–27\" @5 state waters.",
+};
+
+const VERIFIED = "2026-09-03";
+const pv = 1;
+const SB = {
+  url: "https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=1&species=55",
+  title: "Delaware DNREC Fish Facts — Striped Bass",
+  updated: "2026-01-01",
+} as const;
+
+export const DE_AREAS: readonly RegArea[] = [
+  {
+    id: "de-tidal",
+    authority: "de-dnrec",
+    kind: "ocean_region",
+    name: "Delaware — state tidal / ocean to 3 nm",
+    polygon: [[-75.7, 39.85], [-75.0, 38.45], [-74.85, 38.45], [-75.05, 39.85], [-75.7, 39.85]],
+    sourceUrl: SB.url,
+    verifiedAt: VERIFIED,
+    notes: "Federal waters closed to striped bass. EEZ follows NOAA.",
+  },
+];
+
+function rule(r: Omit<RegRule, "packVersion" | "regGroupId"> & Partial<Pick<RegRule, "regGroupId">>): RegRule {
+  return { regGroupId: null, ...r, packVersion: pv };
+}
+
+export const DE_RULES: readonly RegRule[] = [
+  rule({
+    id: "de-striped-bass", speciesId: "striped_bass", regAreaId: "de-tidal", kind: "bag_limit",
+    verbatim: "Daily Limit / Person: 1 in State of Delaware waters (coast to 3 miles offshore), except catch & release only on spawning grounds April 1 to May 31. Size Limit: 28 inches to 31 inches, except 20 inches to 25 inches from July 1 through August 31 in the Delaware River, Delaware Bay and their tributaries. CLOSED in Federal waters.",
+    sourceUrl: SB.url, sourceTitle: SB.title, sourceUpdatedAt: SB.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 28, maxSizeIn: 31, sizeMeasure: "total_length", platformScope: null, depthNote: "Bay/River 20–25\" Jul 1–Aug 31.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "de-striped-bass-circle", speciesId: "striped_bass", regAreaId: "de-tidal", kind: "gear",
+    verbatim: "In 2021, a new regulation requires using inline circle hooks when fishing for striped bass using cut or whole natural baits like clams, squid, mackerel, menhaden, seaworms, or eels.",
+    sourceUrl: SB.url, sourceTitle: SB.title, sourceUpdatedAt: SB.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "de-tautog", speciesId: "tautog", regAreaId: "de-tidal", kind: "bag_limit",
+    verbatim: "Tautog: Season January 1 to May 15 July 1 to December 31. Size Limit 16 inch minimum (total length). Daily Limit / Person 4.",
+    sourceUrl: "https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=187",
+    sourceTitle: "Delaware DNREC Fish Facts — Tautog", sourceUpdatedAt: "2026-01-01", verifiedAt: VERIFIED,
+    seasonStart: "07-01", seasonEnd: "12-31", bagDaily: 4, possessionLimit: 4, bagSharesWithGroup: false,
+    minSizeIn: 16, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "Also open Jan 1–May 15.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "de-tautog-spring", speciesId: "tautog", regAreaId: "de-tidal", kind: "season",
+    verbatim: "Tautog season: January 1 to May 15 and July 1 to December 31.",
+    sourceUrl: "https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=187",
+    sourceTitle: "Delaware DNREC Fish Facts — Tautog", sourceUpdatedAt: "2026-01-01", verifiedAt: VERIFIED,
+    seasonStart: "01-01", seasonEnd: "05-15", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "de-fluke-late", speciesId: "summer_flounder", regAreaId: "de-tidal", kind: "bag_limit",
+    verbatim: "Summer Flounder: Season Open Year-Round. Size Limit January 1 - May 31: 16 inch minimum (total length) June 1 - December 31: 17.5 inch minimum (total length). Daily Limit / Person 4.",
+    sourceUrl: "https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=185",
+    sourceTitle: "Delaware DNREC Fish Facts — Summer Flounder", sourceUpdatedAt: "2026-01-01", verifiedAt: VERIFIED,
+    seasonStart: "06-01", seasonEnd: "12-31", bagDaily: 4, possessionLimit: 4, bagSharesWithGroup: false,
+    minSizeIn: 17.5, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "de-fluke-early", speciesId: "summer_flounder", regAreaId: "de-tidal", kind: "bag_limit",
+    verbatim: "Summer Flounder: January 1 - May 31: 16 inch minimum (total length). Daily Limit / Person 4.",
+    sourceUrl: "https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=185",
+    sourceTitle: "Delaware DNREC Fish Facts — Summer Flounder", sourceUpdatedAt: "2026-01-01", verifiedAt: VERIFIED,
+    seasonStart: "01-01", seasonEnd: "05-31", bagDaily: 4, possessionLimit: 4, bagSharesWithGroup: false,
+    minSizeIn: 16, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "de-bsb-early", speciesId: "black_sea_bass", regAreaId: "de-tidal", kind: "bag_limit",
+    verbatim: "Black Sea Bass: Season May 15 through September 30 and October 10 through December 31. Size Limit 13 inch minimum (measured from the tip of the snout or jaw (mouth shut) to the farthest extremity of the tail, not including the tail filament). Daily Limit / Person 15.",
+    sourceUrl: "https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=93",
+    sourceTitle: "Delaware DNREC Fish Facts — Black Sea Bass", sourceUpdatedAt: "2026-01-01", verifiedAt: VERIFIED,
+    seasonStart: "05-15", seasonEnd: "09-30", bagDaily: 15, possessionLimit: 15, bagSharesWithGroup: false,
+    minSizeIn: 13, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "Filament excluded.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "de-bsb-late", speciesId: "black_sea_bass", regAreaId: "de-tidal", kind: "bag_limit",
+    verbatim: "Black Sea Bass: Season May 15 through September 30 and October 10 through December 31. Size Limit 13 inch minimum. Daily Limit / Person 15.",
+    sourceUrl: "https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=93",
+    sourceTitle: "Delaware DNREC Fish Facts — Black Sea Bass", sourceUpdatedAt: "2026-01-01", verifiedAt: VERIFIED,
+    seasonStart: "10-10", seasonEnd: "12-31", bagDaily: 15, possessionLimit: 15, bagSharesWithGroup: false,
+    minSizeIn: 13, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "Filament excluded.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "de-red-drum", speciesId: "red_drum", regAreaId: "de-tidal", kind: "bag_limit",
+    verbatim: "Red Drum: Season Open Year-Round in State of Delaware waters (coast to 3 miles offshore) CLOSED in Federal waters. Size Limit 20 to 27 inches (total length). Daily Limit / Person 5 in State of Delaware waters.",
+    sourceUrl: "https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=150",
+    sourceTitle: "Delaware DNREC Fish Facts — Red Drum", sourceUpdatedAt: "2026-01-01", verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: false,
+    minSizeIn: 20, maxSizeIn: 27, sizeMeasure: "total_length", platformScope: null, depthNote: "EEZ closed.",
+    checkInseason: true, staleAfterDays: 60,
+  }),
+];
+
+export const DELAWARE = { pack: DELAWARE_PACK, areas: DE_AREAS, groups: [], rules: DE_RULES };

--- a/src/features/fish-legal/georgia-pack.ts
+++ b/src/features/fish-legal/georgia-pack.ts
@@ -1,0 +1,122 @@
+/**
+ * Georgia pack — `georgia-2026-09-03`. Atlantic wave 4.
+ * CRD Recreational finfish season, limits, and sizes (coastalgadnr.org/limits).
+ * Red-drum 3-fish / 15–24\" proposal was still a 2026 rulemaking on the live table (5 @ 14–23).
+ */
+import type { RegArea, RegPack, RegRule } from "./types";
+
+export const GEORGIA_PACK: RegPack = {
+  id: "georgia-2026-09-03",
+  version: 1,
+  publishedAt: "2026-09-03T22:00:00Z",
+  notes:
+    "Georgia CRD recreational table: red drum 14–23\" @5 rod-and-reel gamefish; speckled trout 14\" @15; flounder 12\" @15; stripers 22\" @2 saltwater / 27\" Savannah; weakfish 13\" @1.",
+};
+
+const GA = {
+  url: "https://coastalgadnr.org/limits",
+  title: "Georgia DNR CRD — Recreational finfish season, limits, and sizes",
+  updated: "2026-01-01",
+} as const;
+const VERIFIED = "2026-09-03";
+const pv = 1;
+
+export const GA_AREAS: readonly RegArea[] = [
+  {
+    id: "ga-state-waters",
+    authority: "ga-crd",
+    kind: "ocean_region",
+    name: "Georgia — state waters (0–3 nm)",
+    polygon: [[-81.8, 32.1], [-80.8, 30.7], [-81.45, 30.7], [-81.8, 32.1]],
+    sourceUrl: GA.url, verifiedAt: VERIFIED, notes: "Federal 3–200 nm follows SAFMC.",
+  },
+];
+
+function rule(r: Omit<RegRule, "packVersion" | "regGroupId"> & Partial<Pick<RegRule, "regGroupId">>): RegRule {
+  return { regGroupId: null, ...r, packVersion: pv };
+}
+
+export const GA_RULES: readonly RegRule[] = [
+  rule({
+    id: "ga-red-drum", speciesId: "red_drum", regAreaId: "ga-state-waters", kind: "bag_limit",
+    verbatim: "Red Drum: Season: All year. Limit: 5. Minimum size: 14\" TL (Maximum 23\" TL). Red Drum are a gamefish in Georgia [O.C.G.A. 27-1-2 (36)(I)]. As gamefish, Red Drum may only be fished for with pole and line (rod/reel) [O.C.G.A. 27-4-5].",
+    sourceUrl: GA.url, sourceTitle: GA.title, sourceUpdatedAt: GA.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: false,
+    minSizeIn: 14, maxSizeIn: 23, sizeMeasure: "total_length", platformScope: null, depthNote: "Rod and reel only.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ga-seatrout", speciesId: "spotted_seatrout", regAreaId: "ga-state-waters", kind: "bag_limit",
+    verbatim: "Spotted Seatrout: Season: All year. Limit: 15. Minimum size: 14\" TL.",
+    sourceUrl: GA.url, sourceTitle: GA.title, sourceUpdatedAt: GA.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 15, possessionLimit: 15, bagSharesWithGroup: false,
+    minSizeIn: 14, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ga-flounder", speciesId: "southern_flounder", regAreaId: "ga-state-waters", kind: "bag_limit",
+    verbatim: "Flounder: Season: All year. Limit: 15. Minimum size: 12\" TL.",
+    sourceUrl: GA.url, sourceTitle: GA.title, sourceUpdatedAt: GA.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 15, possessionLimit: 15, bagSharesWithGroup: false,
+    minSizeIn: 12, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ga-striped-bass", speciesId: "striped_bass", regAreaId: "ga-state-waters", kind: "bag_limit",
+    verbatim: "Striped Bass: Saltwater Season: All year. Limit: 2. Minimum size: 22\" TL. Savannah River Season: All year. Limit: 2. Minimum size: 27\" TL.",
+    sourceUrl: GA.url, sourceTitle: GA.title, sourceUpdatedAt: GA.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 2, possessionLimit: 2, bagSharesWithGroup: false,
+    minSizeIn: 22, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "Savannah River 27\" min.",
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ga-weakfish", speciesId: "weakfish", regAreaId: "ga-state-waters", kind: "bag_limit",
+    verbatim: "Weakfish: Season: All year. Limit: 1. Minimum size: 13\" TL.",
+    sourceUrl: GA.url, sourceTitle: GA.title, sourceUpdatedAt: GA.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 13, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ga-black-drum", speciesId: "black_drum", regAreaId: "ga-state-waters", kind: "bag_limit",
+    verbatim: "Black Drum: Season: All year. Limit: 15. Minimum size: 14\" TL.",
+    sourceUrl: GA.url, sourceTitle: GA.title, sourceUpdatedAt: GA.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 15, possessionLimit: 15, bagSharesWithGroup: false,
+    minSizeIn: 14, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ga-sheepshead", speciesId: "sheepshead", regAreaId: "ga-state-waters", kind: "bag_limit",
+    verbatim: "Sheepshead: Season: All year. Limit: 15. Minimum size: 10\" FL.",
+    sourceUrl: GA.url, sourceTitle: GA.title, sourceUpdatedAt: GA.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 15, possessionLimit: 15, bagSharesWithGroup: false,
+    minSizeIn: 10, maxSizeIn: null, sizeMeasure: "fork_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ga-cobia", speciesId: "cobia", regAreaId: "ga-state-waters", kind: "bag_limit",
+    verbatim: "Cobia: Season: March 1 - Oct. 31. Limit: 1 per angler, maximum 6 per boat. Minimum size: 36\" FL.",
+    sourceUrl: GA.url, sourceTitle: GA.title, sourceUpdatedAt: GA.updated, verifiedAt: VERIFIED,
+    seasonStart: "03-01", seasonEnd: "10-31", bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 36, maxSizeIn: null, sizeMeasure: "fork_length", platformScope: null, depthNote: "6 per boat.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "ga-bluefish", speciesId: "bluefish", regAreaId: "ga-state-waters", kind: "bag_limit",
+    verbatim: "Bluefish: Season: May 1 - Feb. 28 annually. Limit: 15. Minimum size: 12\" FL.",
+    sourceUrl: GA.url, sourceTitle: GA.title, sourceUpdatedAt: GA.updated, verifiedAt: VERIFIED,
+    seasonStart: "05-01", seasonEnd: "02-28", bagDaily: 15, possessionLimit: 15, bagSharesWithGroup: false,
+    minSizeIn: 12, maxSizeIn: null, sizeMeasure: "fork_length", platformScope: null, depthNote: "Wraps New Year's.",
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ga-tarpon", speciesId: "atlantic_tarpon", regAreaId: "ga-state-waters", kind: "bag_limit",
+    verbatim: "Tarpon: Season: All year. Limit: 1. Minimum size: 68\" FL.",
+    sourceUrl: GA.url, sourceTitle: GA.title, sourceUpdatedAt: GA.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 68, maxSizeIn: null, sizeMeasure: "fork_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 90,
+  }),
+];
+
+export const GEORGIA = { pack: GEORGIA_PACK, areas: GA_AREAS, groups: [], rules: GA_RULES };

--- a/src/features/fish-legal/maryland-pack.ts
+++ b/src/features/fish-legal/maryland-pack.ts
@@ -1,0 +1,100 @@
+/**
+ * Maryland pack — `maryland-2026-09-03`. Atlantic wave 4.
+ * DNR public notices (Atlantic stripers 1/1/2026; summer flounder 4/19/2026)
+ * and DNR-FS-2025-3 Chesapeake seasons effective 4/1/2026.
+ */
+import type { RegArea, RegPack, RegRule } from "./types";
+
+export const MARYLAND_PACK: RegPack = {
+  id: "maryland-2026-09-03",
+  version: 1,
+  publishedAt: "2026-09-03T22:00:00Z",
+  notes:
+    "Maryland DNR 2026: Atlantic coast stripers 28–31\" @1; Chesapeake 19–24\" @1 with Aug closed / Dec 6–31 C&R; state-water fluke 16\" Jan–May then 17.5\" @4 year-round.",
+};
+
+const VERIFIED = "2026-09-03";
+const pv = 1;
+const ATL = {
+  url: "https://dnr.maryland.gov/fisheries/Documents/Public_Notices/PubNotStripedBassATLCoastRec_Effective1-1-2026.pdf",
+  title: "Maryland DNR — 2026 Atlantic Coast Recreational and Charter Boat Striped Bass Fishery",
+  updated: "2026-01-01",
+} as const;
+const FLUKE = {
+  url: "https://dnr.maryland.gov/fisheries/Documents/Public_Notices/PN_2026_SummerFlounder_Effective4_19_2026.pdf",
+  title: "Maryland DNR — 2026 Summer Flounder Fishery (effective 4/19/2026)",
+  updated: "2026-04-19",
+} as const;
+const BAY = {
+  url: "https://dnr.maryland.gov/fisheries/Documents/Reg_Changes/DNR-FS-2025-3_StripedBass_RecreationalSeasons.pdf",
+  title: "Maryland DNR — DNR-FS-2025-3 Striped Bass Recreational Seasons (rules effective 4/1/2026)",
+  updated: "2026-04-01",
+} as const;
+
+export const MD_AREAS: readonly RegArea[] = [
+  {
+    id: "md-atlantic",
+    authority: "md-dnr",
+    kind: "ocean_region",
+    name: "Maryland — Atlantic Ocean, coastal bays and tributaries",
+    polygon: [[-75.4, 38.45], [-75.0, 38.0], [-74.9, 38.45], [-75.05, 38.55], [-75.4, 38.45]],
+    sourceUrl: ATL.url, verifiedAt: VERIFIED, notes: "Does not apply to Chesapeake Bay.",
+  },
+  {
+    id: "md-chesapeake",
+    authority: "md-dnr",
+    kind: "ocean_region",
+    name: "Maryland — Chesapeake Bay and tidal tributaries",
+    polygon: null,
+    sourceUrl: BAY.url, verifiedAt: VERIFIED, notes: "Excludes Susquehanna Flats specials.",
+  },
+];
+
+function rule(r: Omit<RegRule, "packVersion" | "regGroupId"> & Partial<Pick<RegRule, "regGroupId">>): RegRule {
+  return { regGroupId: null, ...r, packVersion: pv };
+}
+
+export const MD_RULES: readonly RegRule[] = [
+  rule({
+    id: "md-atl-striped-bass", speciesId: "striped_bass", regAreaId: "md-atlantic", kind: "bag_limit",
+    verbatim: "Effective 12:01 a.m. January 1, 2026: Anglers may keep one striped bass per person per day from the Atlantic Ocean, its coastal bays, and their tributaries. The minimum size for striped bass is 28 inches, total length. The maximum size is 31 inches, total length.",
+    sourceUrl: ATL.url, sourceTitle: ATL.title, sourceUpdatedAt: ATL.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 28, maxSizeIn: 31, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "md-bay-striped-bass-fall", speciesId: "striped_bass", regAreaId: "md-chesapeake", kind: "bag_limit",
+    verbatim: "RULES FOR STRIPED BASS EFFECTIVE 4/1/2026 Chesapeake Bay and Tidal Tributaries: SEP. 1–DEC. 5 All areas open. 1 fish per day. Must be at least 19\" and cannot exceed 24\". Circle hook rules remain the same.",
+    sourceUrl: BAY.url, sourceTitle: BAY.title, sourceUpdatedAt: BAY.updated, verifiedAt: VERIFIED,
+    seasonStart: "09-01", seasonEnd: "12-05", bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 19, maxSizeIn: 24, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 14,
+  }),
+  rule({
+    id: "md-bay-striped-bass-aug", speciesId: "striped_bass", regAreaId: "md-chesapeake", kind: "season",
+    verbatim: "AUG. 1–AUG. 31 All areas closed to striped bass fishing. CLOSED. Attempting to catch striped bass is illegal during this time period. No targeting.",
+    sourceUrl: BAY.url, sourceTitle: BAY.title, sourceUpdatedAt: BAY.updated, verifiedAt: VERIFIED,
+    seasonStart: "09-01", seasonEnd: "12-05", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "Aug closed; Dec 6–31 C&R only.",
+    checkInseason: true, staleAfterDays: 14,
+  }),
+  rule({
+    id: "md-fluke-late", speciesId: "summer_flounder", regAreaId: "md-atlantic", kind: "bag_limit",
+    verbatim: "In State waters, the season is open January 1, 2026 – December 31, 2026. The minimum size is 17-1/2 inches from June 1, 2026 through December 31, 2026. In State waters, anglers may keep up to 4 fish per person per day.",
+    sourceUrl: FLUKE.url, sourceTitle: FLUKE.title, sourceUpdatedAt: FLUKE.updated, verifiedAt: VERIFIED,
+    seasonStart: "06-01", seasonEnd: "12-31", bagDaily: 4, possessionLimit: 4, bagSharesWithGroup: false,
+    minSizeIn: 17.5, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "Federal waters 18.5\" @3 May 8–Sep 30.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "md-fluke-early", speciesId: "summer_flounder", regAreaId: "md-atlantic", kind: "bag_limit",
+    verbatim: "In State waters: The minimum size is 16 inches from January 1, 2026 through May 31, 2026. In State waters, anglers may keep up to 4 fish per person per day.",
+    sourceUrl: FLUKE.url, sourceTitle: FLUKE.title, sourceUpdatedAt: FLUKE.updated, verifiedAt: VERIFIED,
+    seasonStart: "01-01", seasonEnd: "05-31", bagDaily: 4, possessionLimit: 4, bagSharesWithGroup: false,
+    minSizeIn: 16, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+];
+
+export const MARYLAND = { pack: MARYLAND_PACK, areas: MD_AREAS, groups: [], rules: MD_RULES };

--- a/src/features/fish-legal/north-carolina-pack.ts
+++ b/src/features/fish-legal/north-carolina-pack.ts
@@ -1,0 +1,122 @@
+/**
+ * North Carolina pack — `north-carolina-2026-09-03`. Atlantic wave 4.
+ * DMF Recreational Size and Bag Limits page (effective September 2, 2026).
+ */
+import type { RegArea, RegPack, RegRule } from "./types";
+
+export const NORTH_CAROLINA_PACK: RegPack = {
+  id: "north-carolina-2026-09-03",
+  version: 1,
+  publishedAt: "2026-09-03T22:00:00Z",
+  notes:
+    "NC DMF rec table (effective 2026-09-02): red drum 18–27\" @1; flounder open Sep 1–14 then closed; speckled trout 14–20\" / 3/day; weakfish 12\" @1; sheepshead 14\" @5; CSMA/internal stripers unlawful, Atlantic Ocean 28–31\" @1.",
+};
+
+const NC = {
+  url: "https://www.deq.nc.gov/about/divisions/marine-fisheries/rules-proclamations-and-size-and-bag-limits/recreational-size-and-bag-limits",
+  title: "NC DEQ DMF — Recreational Size and Bag Limits (effective September 2, 2026)",
+  updated: "2026-09-02",
+} as const;
+const VERIFIED = "2026-09-03";
+const pv = 1;
+
+export const NC_AREAS: readonly RegArea[] = [
+  {
+    id: "nc-coastal",
+    authority: "nc-dmf",
+    kind: "ocean_region",
+    name: "North Carolina — coastal and joint waters",
+    polygon: [[-78.6, 36.55], [-75.5, 35.2], [-77.9, 33.85], [-78.6, 33.85], [-78.6, 36.55]],
+    sourceUrl: NC.url, verifiedAt: VERIFIED,
+    notes: "Internal CSMA stripers are closed; ocean slot is a footnote (A).",
+  },
+];
+
+function rule(r: Omit<RegRule, "packVersion" | "regGroupId"> & Partial<Pick<RegRule, "regGroupId">>): RegRule {
+  return { regGroupId: null, ...r, packVersion: pv };
+}
+
+export const NC_RULES: readonly RegRule[] = [
+  rule({
+    id: "nc-red-drum", speciesId: "red_drum", regAreaId: "nc-coastal", kind: "bag_limit",
+    verbatim: "Red Drum (Channel Bass, Puppy Drum): 18\" Min - 27\" Max TL. 1/Day. Unlawful to possess red drum greater than 27\" TL. Unlawful to gig, spear, or gaff red drum.",
+    sourceUrl: NC.url, sourceTitle: NC.title, sourceUpdatedAt: NC.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 18, maxSizeIn: 27, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "nc-flounder-open", speciesId: "southern_flounder", regAreaId: "nc-coastal", kind: "bag_limit",
+    verbatim: "Flounder (All Species): Sep 1-14: OPEN Sep 15-30: CLOSED UNLAWFUL TO POSSESS. (Spring 2026 ocean-only window was Mar 9–22, 1 fish, 15-inch TL, hook-and-line.)",
+    sourceUrl: NC.url, sourceTitle: NC.title, sourceUpdatedAt: NC.updated, verifiedAt: VERIFIED,
+    seasonStart: "09-01", seasonEnd: "09-14", bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 15, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "Mandatory harvest reporting.",
+    checkInseason: true, staleAfterDays: 7,
+  }),
+  rule({
+    id: "nc-flounder-season", speciesId: "southern_flounder", regAreaId: "nc-coastal", kind: "season",
+    verbatim: "Flounder (All Species): Sep 1-14: OPEN. Sep 15-30: CLOSED UNLAWFUL TO POSSESS.",
+    sourceUrl: NC.url, sourceTitle: NC.title, sourceUpdatedAt: NC.updated, verifiedAt: VERIFIED,
+    seasonStart: "09-01", seasonEnd: "09-14", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 7,
+  }),
+  rule({
+    id: "nc-speckled-trout", speciesId: "spotted_seatrout", regAreaId: "nc-coastal", kind: "bag_limit",
+    verbatim: "Spotted Seatrout (Speckled Trout): 14\"- 20\" TL, 1 greater than 26' TL. 3/day.",
+    sourceUrl: NC.url, sourceTitle: NC.title, sourceUpdatedAt: NC.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 3, possessionLimit: 3, bagSharesWithGroup: false,
+    minSizeIn: 14, maxSizeIn: 20, sizeMeasure: "total_length", platformScope: null, depthNote: "Table allows 1 fish greater than 26\" TL.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "nc-weakfish", speciesId: "weakfish", regAreaId: "nc-coastal", kind: "bag_limit",
+    verbatim: "Weakfish (Gray Trout): 12\" TL. 1/Day.",
+    sourceUrl: NC.url, sourceTitle: NC.title, sourceUpdatedAt: NC.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 12, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "nc-sheepshead", speciesId: "sheepshead", regAreaId: "nc-coastal", kind: "bag_limit",
+    verbatim: "Sheepshead: 14\" TL. 5/Day.",
+    sourceUrl: NC.url, sourceTitle: NC.title, sourceUpdatedAt: NC.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: false,
+    minSizeIn: 14, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "nc-black-drum", speciesId: "black_drum", regAreaId: "nc-coastal", kind: "bag_limit",
+    verbatim: "Black Drum: 14\" Min - 25\" Max TL. 10/Day. One black drum per person per day over 25\" TL is allowed.",
+    sourceUrl: NC.url, sourceTitle: NC.title, sourceUpdatedAt: NC.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 10, possessionLimit: 10, bagSharesWithGroup: false,
+    minSizeIn: 14, maxSizeIn: 25, sizeMeasure: "total_length", platformScope: null, depthNote: "One over 25\" allowed.",
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "nc-striped-bass-internal", speciesId: "striped_bass", regAreaId: "nc-coastal", kind: "prohibited",
+    verbatim: "Striped Bass: UNLAWFUL TO POSSESS (A). Albemarle Sound Management Area: SEASON CURRENTLY CLOSED; Central Southern Management Area (CSMA): Unlawful to possess striped bass (including hybrid bass); Atlantic Ocean: Year-round: 1 per person per day and a harvest slot limit of 28 inches to 31 inches TL. Unlawful to gig, spear, or gaff striped bass.",
+    sourceUrl: NC.url, sourceTitle: NC.title, sourceUpdatedAt: NC.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 0, possessionLimit: 0, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "Ocean slot 28–31 @1 is footnote (A); internal CSMA is closed.",
+    checkInseason: true, staleAfterDays: 14,
+  }),
+  rule({
+    id: "nc-bluefish", speciesId: "bluefish", regAreaId: "nc-coastal", kind: "bag_limit",
+    verbatim: "Bluefish: None minimum length. 5/Day.",
+    sourceUrl: NC.url, sourceTitle: NC.title, sourceUpdatedAt: NC.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "nc-tarpon", speciesId: "atlantic_tarpon", regAreaId: "nc-coastal", kind: "prohibited",
+    verbatim: "Tarpon: UNLAWFUL TO POSSESS.",
+    sourceUrl: NC.url, sourceTitle: NC.title, sourceUpdatedAt: NC.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 0, possessionLimit: 0, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 120,
+  }),
+];
+
+export const NORTH_CAROLINA = { pack: NORTH_CAROLINA_PACK, areas: NC_AREAS, groups: [], rules: NC_RULES };

--- a/src/features/fish-legal/packs.ts
+++ b/src/features/fish-legal/packs.ts
@@ -30,6 +30,12 @@ import { NEW_JERSEY } from "./new-jersey-pack";
 import { CONNECTICUT } from "./connecticut-pack";
 import { NEW_HAMPSHIRE } from "./new-hampshire-pack";
 import { MAINE } from "./maine-pack";
+import { DELAWARE } from "./delaware-pack";
+import { MARYLAND } from "./maryland-pack";
+import { VIRGINIA } from "./virginia-pack";
+import { NORTH_CAROLINA } from "./north-carolina-pack";
+import { SOUTH_CAROLINA } from "./south-carolina-pack";
+import { GEORGIA } from "./georgia-pack";
 import type { RegPack, RegArea, RegGroup, RegRule } from "./types";
 
 export type RegBundle = {
@@ -255,6 +261,48 @@ export const PACKS: readonly BundledPack[] = [
     shortCode: "ME",
     primaryAreaId: "me-coast",
     data: MAINE,
+  },
+  {
+    regionId: "delaware",
+    jurisdictionLabel: "Delaware — DNREC (US)",
+    shortCode: "DE",
+    primaryAreaId: "de-tidal",
+    data: DELAWARE,
+  },
+  {
+    regionId: "maryland",
+    jurisdictionLabel: "Maryland — DNR (US)",
+    shortCode: "MD",
+    primaryAreaId: "md-atlantic",
+    data: MARYLAND,
+  },
+  {
+    regionId: "virginia",
+    jurisdictionLabel: "Virginia — MRC (US)",
+    shortCode: "VA",
+    primaryAreaId: "va-coast",
+    data: VIRGINIA,
+  },
+  {
+    regionId: "north_carolina",
+    jurisdictionLabel: "North Carolina — DMF (US)",
+    shortCode: "NC",
+    primaryAreaId: "nc-coastal",
+    data: NORTH_CAROLINA,
+  },
+  {
+    regionId: "south_carolina",
+    jurisdictionLabel: "South Carolina — DNR (US)",
+    shortCode: "SC",
+    primaryAreaId: "sc-state-waters",
+    data: SOUTH_CAROLINA,
+  },
+  {
+    regionId: "georgia",
+    jurisdictionLabel: "Georgia — CRD (US)",
+    shortCode: "GA",
+    primaryAreaId: "ga-state-waters",
+    data: GEORGIA,
   },
 ];
 

--- a/src/features/fish-legal/reg-data-parity.test.ts
+++ b/src/features/fish-legal/reg-data-parity.test.ts
@@ -20,11 +20,18 @@ import { NEW_JERSEY } from "./new-jersey-pack";
 import { CONNECTICUT } from "./connecticut-pack";
 import { NEW_HAMPSHIRE } from "./new-hampshire-pack";
 import { MAINE } from "./maine-pack";
+import { DELAWARE } from "./delaware-pack";
+import { MARYLAND } from "./maryland-pack";
+import { VIRGINIA } from "./virginia-pack";
+import { NORTH_CAROLINA } from "./north-carolina-pack";
+import { SOUTH_CAROLINA } from "./south-carolina-pack";
+import { GEORGIA } from "./georgia-pack";
 
 const LATER_BUNDLES = [
   NORCAL, CA_FRESHWATER, TEXAS, LOUISIANA, MISSISSIPPI, ALABAMA,
   BAJA_CALIFORNIA, BAJA_CALIFORNIA_SUR,
   CONNECTICUT, NEW_HAMPSHIRE, MAINE,
+  DELAWARE, MARYLAND, VIRGINIA, NORTH_CAROLINA, SOUTH_CAROLINA, GEORGIA,
 ];
 
 /*

--- a/src/features/fish-legal/south-carolina-pack.ts
+++ b/src/features/fish-legal/south-carolina-pack.ts
@@ -1,0 +1,105 @@
+/**
+ * South Carolina pack — `south-carolina-2026-09-03`. Atlantic wave 4.
+ * SCDNR eRegulations Finfish Size & Catch Limits, last updated August 11, 2026.
+ */
+import type { RegArea, RegPack, RegRule } from "./types";
+
+export const SOUTH_CAROLINA_PACK: RegPack = {
+  id: "south-carolina-2026-09-03",
+  version: 1,
+  publishedAt: "2026-09-03T22:00:00Z",
+  notes:
+    "SCDNR 2026-27 (updated 2026-08-11): red drum 18–25\" @1 / 2 per boat (Act 231 Jul 1 2026); trout 14\" @10; flounder 16\" @5 not to exceed 10/boat; stripers closed Jun 16–Sep 30 in salt water.",
+};
+
+const SC = {
+  url: "https://www.eregulations.com/southcarolina/fishing/finfish-size-catch-limits",
+  title: "South Carolina DNR — Finfish Size & Catch Limits (Last Updated August 11, 2026)",
+  updated: "2026-08-11",
+} as const;
+const VERIFIED = "2026-09-03";
+const pv = 1;
+
+export const SC_AREAS: readonly RegArea[] = [
+  {
+    id: "sc-state-waters",
+    authority: "sc-dnr",
+    kind: "ocean_region",
+    name: "South Carolina — state waters (saltwater-freshwater line to 3 nm)",
+    polygon: [[-80.9, 33.85], [-78.5, 32.1], [-80.85, 32.05], [-81.1, 32.5], [-80.9, 33.85]],
+    sourceUrl: SC.url, verifiedAt: VERIFIED, notes: "Red drum possession prohibited in federal waters.",
+  },
+];
+
+function rule(r: Omit<RegRule, "packVersion" | "regGroupId"> & Partial<Pick<RegRule, "regGroupId">>): RegRule {
+  return { regGroupId: null, ...r, packVersion: pv };
+}
+
+export const SC_RULES: readonly RegRule[] = [
+  rule({
+    id: "sc-red-drum", speciesId: "red_drum", regAreaId: "sc-state-waters", kind: "bag_limit",
+    verbatim: "Red Drum: 1 per person per day (state waters) not to exceed 2 per boat per day. Possession prohibited in federal waters. 18-inch to 25-inch TL. May only be taken by rod & reel and gig. May not be harvested by gig Dec. 1 - Feb. 28. Effective July 1, 2026 (Act No. 231).",
+    sourceUrl: SC.url, sourceTitle: SC.title, sourceUpdatedAt: SC.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 18, maxSizeIn: 25, sizeMeasure: "total_length", platformScope: null, depthNote: "2 per boat cap.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "sc-seatrout", speciesId: "spotted_seatrout", regAreaId: "sc-state-waters", kind: "bag_limit",
+    verbatim: "Spotted Seatrout: 10 per person per day. 14-inch TL. May only be taken by rod & reel and gig. May not be harvested by gig Dec. 1 - Feb. 28.",
+    sourceUrl: SC.url, sourceTitle: SC.title, sourceUpdatedAt: SC.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 10, possessionLimit: 10, bagSharesWithGroup: false,
+    minSizeIn: 14, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "sc-flounder", speciesId: "southern_flounder", regAreaId: "sc-state-waters", kind: "bag_limit",
+    verbatim: "Flounders (Southern, Summer & Gulf): 5 per person per day not to exceed 10 per boat per day. 16-inch TL. Bag limit applies to hook and line or gig.",
+    sourceUrl: SC.url, sourceTitle: SC.title, sourceUpdatedAt: SC.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: false,
+    minSizeIn: 16, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "10 per boat.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "sc-striped-bass", speciesId: "striped_bass", regAreaId: "sc-state-waters", kind: "season",
+    verbatim: "Striped Bass: Possession prohibited: June 16 - Sept. 30 except in lower reach of the Savannah River. 3 fish per person per day: Oct. 1 - June 15 except in lower reach of the Savannah River. 26 inch TL. May only be taken by rod & reel.",
+    sourceUrl: SC.url, sourceTitle: SC.title, sourceUpdatedAt: SC.updated, verifiedAt: VERIFIED,
+    seasonStart: "10-01", seasonEnd: "06-15", bagDaily: 3, possessionLimit: 3, bagSharesWithGroup: false,
+    minSizeIn: 26, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "Closed Jun 16–Sep 30 (wraps New Year).",
+    checkInseason: true, staleAfterDays: 14,
+  }),
+  rule({
+    id: "sc-black-drum", speciesId: "black_drum", regAreaId: "sc-state-waters", kind: "bag_limit",
+    verbatim: "Black Drum: 5 per person per day. 14-inch to 27-inch TL.",
+    sourceUrl: SC.url, sourceTitle: SC.title, sourceUpdatedAt: SC.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: false,
+    minSizeIn: 14, maxSizeIn: 27, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "sc-sheepshead", speciesId: "sheepshead", regAreaId: "sc-state-waters", kind: "bag_limit",
+    verbatim: "Sheepshead: 10 per person per day not to exceed 30 per boat per day. 14-inch TL.",
+    sourceUrl: SC.url, sourceTitle: SC.title, sourceUpdatedAt: SC.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 10, possessionLimit: 10, bagSharesWithGroup: false,
+    minSizeIn: 14, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "30 per boat.",
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "sc-weakfish", speciesId: "weakfish", regAreaId: "sc-state-waters", kind: "bag_limit",
+    verbatim: "Weakfish: 1 per person per day. 12-inch TL.",
+    sourceUrl: SC.url, sourceTitle: SC.title, sourceUpdatedAt: SC.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 12, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "sc-bluefish", speciesId: "bluefish", regAreaId: "sc-state-waters", kind: "bag_limit",
+    verbatim: "Bluefish: 5 per person per day (7 per person in the for-hire fishery).",
+    sourceUrl: SC.url, sourceTitle: SC.title, sourceUpdatedAt: SC.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "For-hire 7.",
+    checkInseason: true, staleAfterDays: 60,
+  }),
+];
+
+export const SOUTH_CAROLINA = { pack: SOUTH_CAROLINA_PACK, areas: SC_AREAS, groups: [], rules: SC_RULES };

--- a/src/features/fish-legal/virginia-pack.ts
+++ b/src/features/fish-legal/virginia-pack.ts
@@ -1,0 +1,71 @@
+/**
+ * Virginia pack — `virginia-2026-09-03`. Atlantic wave 4.
+ * 4VAC20-252 (coastal striped bass) and 4VAC20-950-45 (black sea bass 2026 season).
+ */
+import type { RegArea, RegPack, RegRule } from "./types";
+
+export const VIRGINIA_PACK: RegPack = {
+  id: "virginia-2026-09-03",
+  version: 1,
+  publishedAt: "2026-09-03T22:00:00Z",
+  notes:
+    "Virginia MRC: coastal stripers 28–31\" @1 (open Jan 1–Mar 31 and May 16–Dec 31); BSB 13\" @15 May 11–Dec 31 (2026).",
+};
+
+const VERIFIED = "2026-09-03";
+const pv = 1;
+const SB = {
+  url: "https://www.mrc.virginia.gov/Notices/2024/2024-03-26-RC252-draft.pdf",
+  title: "Virginia MRC — 4VAC 20-252 coastal area striped bass recreational fishery",
+  updated: "2024-03-26",
+} as const;
+const BSB = {
+  url: "https://law.lis.virginia.gov/admincode/title4/agency20/chapter950/section45/",
+  title: "4VAC20-950-45. Recreational possession limits and seasons (black sea bass)",
+  updated: "2026-01-01",
+} as const;
+
+export const VA_AREAS: readonly RegArea[] = [
+  {
+    id: "va-coast",
+    authority: "va-mrc",
+    kind: "ocean_region",
+    name: "Virginia — coastal / state marine waters",
+    polygon: [[-76.4, 38.05], [-75.4, 36.55], [-75.3, 36.55], [-75.9, 38.05], [-76.4, 38.05]],
+    sourceUrl: BSB.url, verifiedAt: VERIFIED,
+    notes: "Chesapeake Bay striped-bass seasons are a separate VMRC chapter — not encoded here.",
+  },
+];
+
+function rule(r: Omit<RegRule, "packVersion" | "regGroupId"> & Partial<Pick<RegRule, "regGroupId">>): RegRule {
+  return { regGroupId: null, ...r, packVersion: pv };
+}
+
+export const VA_RULES: readonly RegRule[] = [
+  rule({
+    id: "va-coast-striped-bass", speciesId: "striped_bass", regAreaId: "va-coast", kind: "bag_limit",
+    verbatim: "4 VAC 20-252-110. Coastal area striped bass recreational fishery. A. The open seasons for the coastal area striped bass recreational fishery shall be January 1 through March 31 and May 16 through December 31, inclusive. B. The minimum size limit shall be 28 inches total length. C. The maximum size limit shall be 31 inches total length. D. The daily possession limit shall be one fish per person.",
+    sourceUrl: SB.url, sourceTitle: SB.title, sourceUpdatedAt: SB.updated, verifiedAt: VERIFIED,
+    seasonStart: "05-16", seasonEnd: "12-31", bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 28, maxSizeIn: 31, sizeMeasure: "total_length", platformScope: null, depthNote: "Also open Jan 1–Mar 31.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "va-coast-striped-bass-winter", speciesId: "striped_bass", regAreaId: "va-coast", kind: "season",
+    verbatim: "The open seasons for the coastal area striped bass recreational fishery shall be January 1 through March 31 and May 16 through December 31, inclusive.",
+    sourceUrl: SB.url, sourceTitle: SB.title, sourceUpdatedAt: SB.updated, verifiedAt: VERIFIED,
+    seasonStart: "01-01", seasonEnd: "03-31", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "va-bsb", speciesId: "black_sea_bass", regAreaId: "va-coast", kind: "bag_limit",
+    verbatim: "A. It shall be unlawful for any person fishing with hook-and-line, rod and reel, spear, gig, or other recreational gear to possess more than 15 black sea bass. C. In 2026, the open recreational fishing season shall be from May 11 through December 31.",
+    sourceUrl: BSB.url, sourceTitle: BSB.title, sourceUpdatedAt: BSB.updated, verifiedAt: VERIFIED,
+    seasonStart: "05-11", seasonEnd: "12-31", bagDaily: 15, possessionLimit: 15, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "Size minimum lives in a companion VMRC chapter; this row is bag+2026 season only.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+];
+
+export const VIRGINIA = { pack: VIRGINIA_PACK, areas: VA_AREAS, groups: [], rules: VA_RULES };

--- a/supabase/migrations/20260903060000_v1_atlantic_wave4_south.sql
+++ b/supabase/migrations/20260903060000_v1_atlantic_wave4_south.sql
@@ -1,0 +1,171 @@
+-- Atlantic wave 4 (2026-09-03): DE DNREC, MD DNR, VA MRC, NC DMF, SC DNR, GA CRD
+-- GENERATED via gen-atlantic-wave4.mts. Insert-only.
+
+insert into public.reg_pack (id, version, published_at, notes) values
+  ('delaware-2026-09-03', 1, '2026-09-03T22:00:00Z', 'Delaware DNREC 2026: stripers 28–31" @1 (20–25" Jul 1–Aug 31 in DE River/Bay/tributaries); tautog 16" @4 Jan 1–May 15 and Jul 1–Dec 31; fluke 16" then 17.5" @4; BSB 13" @15 May 15–Sep 30 and Oct 10–Dec 31; red drum 20–27" @5 state waters.')
+on conflict (id) do nothing;
+
+insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geojson, source_url, verified_at, notes) values
+  ('de-tidal', 'de-dnrec', 'ocean_region', 'Delaware — state tidal / ocean to 3 nm', null, '[[-75.7,39.85],[-75,38.45],[-74.85,38.45],[-75.05,39.85],[-75.7,39.85]]', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=1&species=55', '2026-09-03', 'Federal waters closed to striped bass. EEZ follows NOAA.')
+on conflict (id) do nothing;
+
+insert into public.reg_rule
+  (species_id, reg_group_id, reg_area_id, water_class, kind, verbatim, source_url, source_title, source_updated_at, verified_at, pack_version,
+   season_start, season_end, bag_daily, possession_limit, min_size_in, max_size_in, size_measure, platform_scope, depth_note, check_inseason, stale_after_days)
+values
+  ('striped_bass', null, 'de-tidal', 'salt', 'bag_limit', 'Daily Limit / Person: 1 in State of Delaware waters (coast to 3 miles offshore), except catch & release only on spawning grounds April 1 to May 31. Size Limit: 28 inches to 31 inches, except 20 inches to 25 inches from July 1 through August 31 in the Delaware River, Delaware Bay and their tributaries. CLOSED in Federal waters.', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=1&species=55', 'Delaware DNREC Fish Facts — Striped Bass', '2026-01-01', '2026-09-03', 1,
+   null, null, 1, 1, 28, 31, 'total_length', null, 'Bay/River 20–25" Jul 1–Aug 31.', true, 30),
+  ('striped_bass', null, 'de-tidal', 'salt', 'gear', 'In 2021, a new regulation requires using inline circle hooks when fishing for striped bass using cut or whole natural baits like clams, squid, mackerel, menhaden, seaworms, or eels.', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=1&species=55', 'Delaware DNREC Fish Facts — Striped Bass', '2026-01-01', '2026-09-03', 1,
+   null, null, null, null, null, null, null, null, null, true, 60),
+  ('tautog', null, 'de-tidal', 'salt', 'bag_limit', 'Tautog: Season January 1 to May 15 July 1 to December 31. Size Limit 16 inch minimum (total length). Daily Limit / Person 4.', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=187', 'Delaware DNREC Fish Facts — Tautog', '2026-01-01', '2026-09-03', 1,
+   '2026-07-01', '2026-12-31', 4, 4, 16, null, 'total_length', null, 'Also open Jan 1–May 15.', true, 30),
+  ('tautog', null, 'de-tidal', 'salt', 'season', 'Tautog season: January 1 to May 15 and July 1 to December 31.', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=187', 'Delaware DNREC Fish Facts — Tautog', '2026-01-01', '2026-09-03', 1,
+   '2026-01-01', '2026-05-15', null, null, null, null, null, null, null, true, 30),
+  ('summer_flounder', null, 'de-tidal', 'salt', 'bag_limit', 'Summer Flounder: Season Open Year-Round. Size Limit January 1 - May 31: 16 inch minimum (total length) June 1 - December 31: 17.5 inch minimum (total length). Daily Limit / Person 4.', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=185', 'Delaware DNREC Fish Facts — Summer Flounder', '2026-01-01', '2026-09-03', 1,
+   '2026-06-01', '2026-12-31', 4, 4, 17.5, null, 'total_length', null, null, true, 30),
+  ('summer_flounder', null, 'de-tidal', 'salt', 'bag_limit', 'Summer Flounder: January 1 - May 31: 16 inch minimum (total length). Daily Limit / Person 4.', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=185', 'Delaware DNREC Fish Facts — Summer Flounder', '2026-01-01', '2026-09-03', 1,
+   '2026-01-01', '2026-05-31', 4, 4, 16, null, 'total_length', null, null, true, 30),
+  ('black_sea_bass', null, 'de-tidal', 'salt', 'bag_limit', 'Black Sea Bass: Season May 15 through September 30 and October 10 through December 31. Size Limit 13 inch minimum (measured from the tip of the snout or jaw (mouth shut) to the farthest extremity of the tail, not including the tail filament). Daily Limit / Person 15.', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=93', 'Delaware DNREC Fish Facts — Black Sea Bass', '2026-01-01', '2026-09-03', 1,
+   '2026-05-15', '2026-09-30', 15, 15, 13, null, 'total_length', null, 'Filament excluded.', true, 30),
+  ('black_sea_bass', null, 'de-tidal', 'salt', 'bag_limit', 'Black Sea Bass: Season May 15 through September 30 and October 10 through December 31. Size Limit 13 inch minimum. Daily Limit / Person 15.', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=93', 'Delaware DNREC Fish Facts — Black Sea Bass', '2026-01-01', '2026-09-03', 1,
+   '2026-10-10', '2026-12-31', 15, 15, 13, null, 'total_length', null, 'Filament excluded.', true, 30),
+  ('red_drum', null, 'de-tidal', 'salt', 'bag_limit', 'Red Drum: Season Open Year-Round in State of Delaware waters (coast to 3 miles offshore) CLOSED in Federal waters. Size Limit 20 to 27 inches (total length). Daily Limit / Person 5 in State of Delaware waters.', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=150', 'Delaware DNREC Fish Facts — Red Drum', '2026-01-01', '2026-09-03', 1,
+   null, null, 5, 5, 20, 27, 'total_length', null, 'EEZ closed.', true, 60);
+
+insert into public.reg_pack (id, version, published_at, notes) values
+  ('maryland-2026-09-03', 1, '2026-09-03T22:00:00Z', 'Maryland DNR 2026: Atlantic coast stripers 28–31" @1; Chesapeake 19–24" @1 with Aug closed / Dec 6–31 C&R; state-water fluke 16" Jan–May then 17.5" @4 year-round.')
+on conflict (id) do nothing;
+
+insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geojson, source_url, verified_at, notes) values
+  ('md-atlantic', 'md-dnr', 'ocean_region', 'Maryland — Atlantic Ocean, coastal bays and tributaries', null, '[[-75.4,38.45],[-75,38],[-74.9,38.45],[-75.05,38.55],[-75.4,38.45]]', 'https://dnr.maryland.gov/fisheries/Documents/Public_Notices/PubNotStripedBassATLCoastRec_Effective1-1-2026.pdf', '2026-09-03', 'Does not apply to Chesapeake Bay.'),
+  ('md-chesapeake', 'md-dnr', 'ocean_region', 'Maryland — Chesapeake Bay and tidal tributaries', null, null, 'https://dnr.maryland.gov/fisheries/Documents/Reg_Changes/DNR-FS-2025-3_StripedBass_RecreationalSeasons.pdf', '2026-09-03', 'Excludes Susquehanna Flats specials.')
+on conflict (id) do nothing;
+
+insert into public.reg_rule
+  (species_id, reg_group_id, reg_area_id, water_class, kind, verbatim, source_url, source_title, source_updated_at, verified_at, pack_version,
+   season_start, season_end, bag_daily, possession_limit, min_size_in, max_size_in, size_measure, platform_scope, depth_note, check_inseason, stale_after_days)
+values
+  ('striped_bass', null, 'md-atlantic', 'salt', 'bag_limit', 'Effective 12:01 a.m. January 1, 2026: Anglers may keep one striped bass per person per day from the Atlantic Ocean, its coastal bays, and their tributaries. The minimum size for striped bass is 28 inches, total length. The maximum size is 31 inches, total length.', 'https://dnr.maryland.gov/fisheries/Documents/Public_Notices/PubNotStripedBassATLCoastRec_Effective1-1-2026.pdf', 'Maryland DNR — 2026 Atlantic Coast Recreational and Charter Boat Striped Bass Fishery', '2026-01-01', '2026-09-03', 1,
+   null, null, 1, 1, 28, 31, 'total_length', null, null, true, 30),
+  ('striped_bass', null, 'md-chesapeake', 'salt', 'bag_limit', 'RULES FOR STRIPED BASS EFFECTIVE 4/1/2026 Chesapeake Bay and Tidal Tributaries: SEP. 1–DEC. 5 All areas open. 1 fish per day. Must be at least 19" and cannot exceed 24". Circle hook rules remain the same.', 'https://dnr.maryland.gov/fisheries/Documents/Reg_Changes/DNR-FS-2025-3_StripedBass_RecreationalSeasons.pdf', 'Maryland DNR — DNR-FS-2025-3 Striped Bass Recreational Seasons (rules effective 4/1/2026)', '2026-04-01', '2026-09-03', 1,
+   '2026-09-01', '2026-12-05', 1, 1, 19, 24, 'total_length', null, null, true, 14),
+  ('striped_bass', null, 'md-chesapeake', 'salt', 'season', 'AUG. 1–AUG. 31 All areas closed to striped bass fishing. CLOSED. Attempting to catch striped bass is illegal during this time period. No targeting.', 'https://dnr.maryland.gov/fisheries/Documents/Reg_Changes/DNR-FS-2025-3_StripedBass_RecreationalSeasons.pdf', 'Maryland DNR — DNR-FS-2025-3 Striped Bass Recreational Seasons (rules effective 4/1/2026)', '2026-04-01', '2026-09-03', 1,
+   '2026-09-01', '2026-12-05', null, null, null, null, null, null, 'Aug closed; Dec 6–31 C&R only.', true, 14),
+  ('summer_flounder', null, 'md-atlantic', 'salt', 'bag_limit', 'In State waters, the season is open January 1, 2026 – December 31, 2026. The minimum size is 17-1/2 inches from June 1, 2026 through December 31, 2026. In State waters, anglers may keep up to 4 fish per person per day.', 'https://dnr.maryland.gov/fisheries/Documents/Public_Notices/PN_2026_SummerFlounder_Effective4_19_2026.pdf', 'Maryland DNR — 2026 Summer Flounder Fishery (effective 4/19/2026)', '2026-04-19', '2026-09-03', 1,
+   '2026-06-01', '2026-12-31', 4, 4, 17.5, null, 'total_length', null, 'Federal waters 18.5" @3 May 8–Sep 30.', true, 30),
+  ('summer_flounder', null, 'md-atlantic', 'salt', 'bag_limit', 'In State waters: The minimum size is 16 inches from January 1, 2026 through May 31, 2026. In State waters, anglers may keep up to 4 fish per person per day.', 'https://dnr.maryland.gov/fisheries/Documents/Public_Notices/PN_2026_SummerFlounder_Effective4_19_2026.pdf', 'Maryland DNR — 2026 Summer Flounder Fishery (effective 4/19/2026)', '2026-04-19', '2026-09-03', 1,
+   '2026-01-01', '2026-05-31', 4, 4, 16, null, 'total_length', null, null, true, 30);
+
+insert into public.reg_pack (id, version, published_at, notes) values
+  ('virginia-2026-09-03', 1, '2026-09-03T22:00:00Z', 'Virginia MRC: coastal stripers 28–31" @1 (open Jan 1–Mar 31 and May 16–Dec 31); BSB 13" @15 May 11–Dec 31 (2026).')
+on conflict (id) do nothing;
+
+insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geojson, source_url, verified_at, notes) values
+  ('va-coast', 'va-mrc', 'ocean_region', 'Virginia — coastal / state marine waters', null, '[[-76.4,38.05],[-75.4,36.55],[-75.3,36.55],[-75.9,38.05],[-76.4,38.05]]', 'https://law.lis.virginia.gov/admincode/title4/agency20/chapter950/section45/', '2026-09-03', 'Chesapeake Bay striped-bass seasons are a separate VMRC chapter — not encoded here.')
+on conflict (id) do nothing;
+
+insert into public.reg_rule
+  (species_id, reg_group_id, reg_area_id, water_class, kind, verbatim, source_url, source_title, source_updated_at, verified_at, pack_version,
+   season_start, season_end, bag_daily, possession_limit, min_size_in, max_size_in, size_measure, platform_scope, depth_note, check_inseason, stale_after_days)
+values
+  ('striped_bass', null, 'va-coast', 'salt', 'bag_limit', '4 VAC 20-252-110. Coastal area striped bass recreational fishery. A. The open seasons for the coastal area striped bass recreational fishery shall be January 1 through March 31 and May 16 through December 31, inclusive. B. The minimum size limit shall be 28 inches total length. C. The maximum size limit shall be 31 inches total length. D. The daily possession limit shall be one fish per person.', 'https://www.mrc.virginia.gov/Notices/2024/2024-03-26-RC252-draft.pdf', 'Virginia MRC — 4VAC 20-252 coastal area striped bass recreational fishery', '2024-03-26', '2026-09-03', 1,
+   '2026-05-16', '2026-12-31', 1, 1, 28, 31, 'total_length', null, 'Also open Jan 1–Mar 31.', true, 30),
+  ('striped_bass', null, 'va-coast', 'salt', 'season', 'The open seasons for the coastal area striped bass recreational fishery shall be January 1 through March 31 and May 16 through December 31, inclusive.', 'https://www.mrc.virginia.gov/Notices/2024/2024-03-26-RC252-draft.pdf', 'Virginia MRC — 4VAC 20-252 coastal area striped bass recreational fishery', '2024-03-26', '2026-09-03', 1,
+   '2026-01-01', '2026-03-31', null, null, null, null, null, null, null, true, 30),
+  ('black_sea_bass', null, 'va-coast', 'salt', 'bag_limit', 'A. It shall be unlawful for any person fishing with hook-and-line, rod and reel, spear, gig, or other recreational gear to possess more than 15 black sea bass. C. In 2026, the open recreational fishing season shall be from May 11 through December 31.', 'https://law.lis.virginia.gov/admincode/title4/agency20/chapter950/section45/', '4VAC20-950-45. Recreational possession limits and seasons (black sea bass)', '2026-01-01', '2026-09-03', 1,
+   '2026-05-11', '2026-12-31', 15, 15, null, null, null, null, 'Size minimum lives in a companion VMRC chapter; this row is bag+2026 season only.', true, 30);
+
+insert into public.reg_pack (id, version, published_at, notes) values
+  ('north-carolina-2026-09-03', 1, '2026-09-03T22:00:00Z', 'NC DMF rec table (effective 2026-09-02): red drum 18–27" @1; flounder open Sep 1–14 then closed; speckled trout 14–20" / 3/day; weakfish 12" @1; sheepshead 14" @5; CSMA/internal stripers unlawful, Atlantic Ocean 28–31" @1.')
+on conflict (id) do nothing;
+
+insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geojson, source_url, verified_at, notes) values
+  ('nc-coastal', 'nc-dmf', 'ocean_region', 'North Carolina — coastal and joint waters', null, '[[-78.6,36.55],[-75.5,35.2],[-77.9,33.85],[-78.6,33.85],[-78.6,36.55]]', 'https://www.deq.nc.gov/about/divisions/marine-fisheries/rules-proclamations-and-size-and-bag-limits/recreational-size-and-bag-limits', '2026-09-03', 'Internal CSMA stripers are closed; ocean slot is a footnote (A).')
+on conflict (id) do nothing;
+
+insert into public.reg_rule
+  (species_id, reg_group_id, reg_area_id, water_class, kind, verbatim, source_url, source_title, source_updated_at, verified_at, pack_version,
+   season_start, season_end, bag_daily, possession_limit, min_size_in, max_size_in, size_measure, platform_scope, depth_note, check_inseason, stale_after_days)
+values
+  ('red_drum', null, 'nc-coastal', 'salt', 'bag_limit', 'Red Drum (Channel Bass, Puppy Drum): 18" Min - 27" Max TL. 1/Day. Unlawful to possess red drum greater than 27" TL. Unlawful to gig, spear, or gaff red drum.', 'https://www.deq.nc.gov/about/divisions/marine-fisheries/rules-proclamations-and-size-and-bag-limits/recreational-size-and-bag-limits', 'NC DEQ DMF — Recreational Size and Bag Limits (effective September 2, 2026)', '2026-09-02', '2026-09-03', 1,
+   null, null, 1, 1, 18, 27, 'total_length', null, null, true, 30),
+  ('southern_flounder', null, 'nc-coastal', 'salt', 'bag_limit', 'Flounder (All Species): Sep 1-14: OPEN Sep 15-30: CLOSED UNLAWFUL TO POSSESS. (Spring 2026 ocean-only window was Mar 9–22, 1 fish, 15-inch TL, hook-and-line.)', 'https://www.deq.nc.gov/about/divisions/marine-fisheries/rules-proclamations-and-size-and-bag-limits/recreational-size-and-bag-limits', 'NC DEQ DMF — Recreational Size and Bag Limits (effective September 2, 2026)', '2026-09-02', '2026-09-03', 1,
+   '2026-09-01', '2026-09-14', 1, 1, 15, null, 'total_length', null, 'Mandatory harvest reporting.', true, 7),
+  ('southern_flounder', null, 'nc-coastal', 'salt', 'season', 'Flounder (All Species): Sep 1-14: OPEN. Sep 15-30: CLOSED UNLAWFUL TO POSSESS.', 'https://www.deq.nc.gov/about/divisions/marine-fisheries/rules-proclamations-and-size-and-bag-limits/recreational-size-and-bag-limits', 'NC DEQ DMF — Recreational Size and Bag Limits (effective September 2, 2026)', '2026-09-02', '2026-09-03', 1,
+   '2026-09-01', '2026-09-14', null, null, null, null, null, null, null, true, 7),
+  ('spotted_seatrout', null, 'nc-coastal', 'salt', 'bag_limit', 'Spotted Seatrout (Speckled Trout): 14"- 20" TL, 1 greater than 26'' TL. 3/day.', 'https://www.deq.nc.gov/about/divisions/marine-fisheries/rules-proclamations-and-size-and-bag-limits/recreational-size-and-bag-limits', 'NC DEQ DMF — Recreational Size and Bag Limits (effective September 2, 2026)', '2026-09-02', '2026-09-03', 1,
+   null, null, 3, 3, 14, 20, 'total_length', null, 'Table allows 1 fish greater than 26" TL.', true, 30),
+  ('weakfish', null, 'nc-coastal', 'salt', 'bag_limit', 'Weakfish (Gray Trout): 12" TL. 1/Day.', 'https://www.deq.nc.gov/about/divisions/marine-fisheries/rules-proclamations-and-size-and-bag-limits/recreational-size-and-bag-limits', 'NC DEQ DMF — Recreational Size and Bag Limits (effective September 2, 2026)', '2026-09-02', '2026-09-03', 1,
+   null, null, 1, 1, 12, null, 'total_length', null, null, true, 60),
+  ('sheepshead', null, 'nc-coastal', 'salt', 'bag_limit', 'Sheepshead: 14" TL. 5/Day.', 'https://www.deq.nc.gov/about/divisions/marine-fisheries/rules-proclamations-and-size-and-bag-limits/recreational-size-and-bag-limits', 'NC DEQ DMF — Recreational Size and Bag Limits (effective September 2, 2026)', '2026-09-02', '2026-09-03', 1,
+   null, null, 5, 5, 14, null, 'total_length', null, null, true, 60),
+  ('black_drum', null, 'nc-coastal', 'salt', 'bag_limit', 'Black Drum: 14" Min - 25" Max TL. 10/Day. One black drum per person per day over 25" TL is allowed.', 'https://www.deq.nc.gov/about/divisions/marine-fisheries/rules-proclamations-and-size-and-bag-limits/recreational-size-and-bag-limits', 'NC DEQ DMF — Recreational Size and Bag Limits (effective September 2, 2026)', '2026-09-02', '2026-09-03', 1,
+   null, null, 10, 10, 14, 25, 'total_length', null, 'One over 25" allowed.', true, 60),
+  ('striped_bass', null, 'nc-coastal', 'salt', 'prohibited', 'Striped Bass: UNLAWFUL TO POSSESS (A). Albemarle Sound Management Area: SEASON CURRENTLY CLOSED; Central Southern Management Area (CSMA): Unlawful to possess striped bass (including hybrid bass); Atlantic Ocean: Year-round: 1 per person per day and a harvest slot limit of 28 inches to 31 inches TL. Unlawful to gig, spear, or gaff striped bass.', 'https://www.deq.nc.gov/about/divisions/marine-fisheries/rules-proclamations-and-size-and-bag-limits/recreational-size-and-bag-limits', 'NC DEQ DMF — Recreational Size and Bag Limits (effective September 2, 2026)', '2026-09-02', '2026-09-03', 1,
+   null, null, 0, 0, null, null, null, null, 'Ocean slot 28–31 @1 is footnote (A); internal CSMA is closed.', true, 14),
+  ('bluefish', null, 'nc-coastal', 'salt', 'bag_limit', 'Bluefish: None minimum length. 5/Day.', 'https://www.deq.nc.gov/about/divisions/marine-fisheries/rules-proclamations-and-size-and-bag-limits/recreational-size-and-bag-limits', 'NC DEQ DMF — Recreational Size and Bag Limits (effective September 2, 2026)', '2026-09-02', '2026-09-03', 1,
+   null, null, 5, 5, null, null, null, null, null, true, 60),
+  ('atlantic_tarpon', null, 'nc-coastal', 'salt', 'prohibited', 'Tarpon: UNLAWFUL TO POSSESS.', 'https://www.deq.nc.gov/about/divisions/marine-fisheries/rules-proclamations-and-size-and-bag-limits/recreational-size-and-bag-limits', 'NC DEQ DMF — Recreational Size and Bag Limits (effective September 2, 2026)', '2026-09-02', '2026-09-03', 1,
+   null, null, 0, 0, null, null, null, null, null, false, 120);
+
+insert into public.reg_pack (id, version, published_at, notes) values
+  ('south-carolina-2026-09-03', 1, '2026-09-03T22:00:00Z', 'SCDNR 2026-27 (updated 2026-08-11): red drum 18–25" @1 / 2 per boat (Act 231 Jul 1 2026); trout 14" @10; flounder 16" @5 not to exceed 10/boat; stripers closed Jun 16–Sep 30 in salt water.')
+on conflict (id) do nothing;
+
+insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geojson, source_url, verified_at, notes) values
+  ('sc-state-waters', 'sc-dnr', 'ocean_region', 'South Carolina — state waters (saltwater-freshwater line to 3 nm)', null, '[[-80.9,33.85],[-78.5,32.1],[-80.85,32.05],[-81.1,32.5],[-80.9,33.85]]', 'https://www.eregulations.com/southcarolina/fishing/finfish-size-catch-limits', '2026-09-03', 'Red drum possession prohibited in federal waters.')
+on conflict (id) do nothing;
+
+insert into public.reg_rule
+  (species_id, reg_group_id, reg_area_id, water_class, kind, verbatim, source_url, source_title, source_updated_at, verified_at, pack_version,
+   season_start, season_end, bag_daily, possession_limit, min_size_in, max_size_in, size_measure, platform_scope, depth_note, check_inseason, stale_after_days)
+values
+  ('red_drum', null, 'sc-state-waters', 'salt', 'bag_limit', 'Red Drum: 1 per person per day (state waters) not to exceed 2 per boat per day. Possession prohibited in federal waters. 18-inch to 25-inch TL. May only be taken by rod & reel and gig. May not be harvested by gig Dec. 1 - Feb. 28. Effective July 1, 2026 (Act No. 231).', 'https://www.eregulations.com/southcarolina/fishing/finfish-size-catch-limits', 'South Carolina DNR — Finfish Size & Catch Limits (Last Updated August 11, 2026)', '2026-08-11', '2026-09-03', 1,
+   null, null, 1, 1, 18, 25, 'total_length', null, '2 per boat cap.', true, 30),
+  ('spotted_seatrout', null, 'sc-state-waters', 'salt', 'bag_limit', 'Spotted Seatrout: 10 per person per day. 14-inch TL. May only be taken by rod & reel and gig. May not be harvested by gig Dec. 1 - Feb. 28.', 'https://www.eregulations.com/southcarolina/fishing/finfish-size-catch-limits', 'South Carolina DNR — Finfish Size & Catch Limits (Last Updated August 11, 2026)', '2026-08-11', '2026-09-03', 1,
+   null, null, 10, 10, 14, null, 'total_length', null, null, true, 30),
+  ('southern_flounder', null, 'sc-state-waters', 'salt', 'bag_limit', 'Flounders (Southern, Summer & Gulf): 5 per person per day not to exceed 10 per boat per day. 16-inch TL. Bag limit applies to hook and line or gig.', 'https://www.eregulations.com/southcarolina/fishing/finfish-size-catch-limits', 'South Carolina DNR — Finfish Size & Catch Limits (Last Updated August 11, 2026)', '2026-08-11', '2026-09-03', 1,
+   null, null, 5, 5, 16, null, 'total_length', null, '10 per boat.', true, 30),
+  ('striped_bass', null, 'sc-state-waters', 'salt', 'season', 'Striped Bass: Possession prohibited: June 16 - Sept. 30 except in lower reach of the Savannah River. 3 fish per person per day: Oct. 1 - June 15 except in lower reach of the Savannah River. 26 inch TL. May only be taken by rod & reel.', 'https://www.eregulations.com/southcarolina/fishing/finfish-size-catch-limits', 'South Carolina DNR — Finfish Size & Catch Limits (Last Updated August 11, 2026)', '2026-08-11', '2026-09-03', 1,
+   '2026-10-01', '2026-06-15', 3, 3, 26, null, 'total_length', null, 'Closed Jun 16–Sep 30 (wraps New Year).', true, 14),
+  ('black_drum', null, 'sc-state-waters', 'salt', 'bag_limit', 'Black Drum: 5 per person per day. 14-inch to 27-inch TL.', 'https://www.eregulations.com/southcarolina/fishing/finfish-size-catch-limits', 'South Carolina DNR — Finfish Size & Catch Limits (Last Updated August 11, 2026)', '2026-08-11', '2026-09-03', 1,
+   null, null, 5, 5, 14, 27, 'total_length', null, null, true, 60),
+  ('sheepshead', null, 'sc-state-waters', 'salt', 'bag_limit', 'Sheepshead: 10 per person per day not to exceed 30 per boat per day. 14-inch TL.', 'https://www.eregulations.com/southcarolina/fishing/finfish-size-catch-limits', 'South Carolina DNR — Finfish Size & Catch Limits (Last Updated August 11, 2026)', '2026-08-11', '2026-09-03', 1,
+   null, null, 10, 10, 14, null, 'total_length', null, '30 per boat.', true, 60),
+  ('weakfish', null, 'sc-state-waters', 'salt', 'bag_limit', 'Weakfish: 1 per person per day. 12-inch TL.', 'https://www.eregulations.com/southcarolina/fishing/finfish-size-catch-limits', 'South Carolina DNR — Finfish Size & Catch Limits (Last Updated August 11, 2026)', '2026-08-11', '2026-09-03', 1,
+   null, null, 1, 1, 12, null, 'total_length', null, null, true, 60),
+  ('bluefish', null, 'sc-state-waters', 'salt', 'bag_limit', 'Bluefish: 5 per person per day (7 per person in the for-hire fishery).', 'https://www.eregulations.com/southcarolina/fishing/finfish-size-catch-limits', 'South Carolina DNR — Finfish Size & Catch Limits (Last Updated August 11, 2026)', '2026-08-11', '2026-09-03', 1,
+   null, null, 5, 5, null, null, null, null, 'For-hire 7.', true, 60);
+
+insert into public.reg_pack (id, version, published_at, notes) values
+  ('georgia-2026-09-03', 1, '2026-09-03T22:00:00Z', 'Georgia CRD recreational table: red drum 14–23" @5 rod-and-reel gamefish; speckled trout 14" @15; flounder 12" @15; stripers 22" @2 saltwater / 27" Savannah; weakfish 13" @1.')
+on conflict (id) do nothing;
+
+insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geojson, source_url, verified_at, notes) values
+  ('ga-state-waters', 'ga-crd', 'ocean_region', 'Georgia — state waters (0–3 nm)', null, '[[-81.8,32.1],[-80.8,30.7],[-81.45,30.7],[-81.8,32.1]]', 'https://coastalgadnr.org/limits', '2026-09-03', 'Federal 3–200 nm follows SAFMC.')
+on conflict (id) do nothing;
+
+insert into public.reg_rule
+  (species_id, reg_group_id, reg_area_id, water_class, kind, verbatim, source_url, source_title, source_updated_at, verified_at, pack_version,
+   season_start, season_end, bag_daily, possession_limit, min_size_in, max_size_in, size_measure, platform_scope, depth_note, check_inseason, stale_after_days)
+values
+  ('red_drum', null, 'ga-state-waters', 'salt', 'bag_limit', 'Red Drum: Season: All year. Limit: 5. Minimum size: 14" TL (Maximum 23" TL). Red Drum are a gamefish in Georgia [O.C.G.A. 27-1-2 (36)(I)]. As gamefish, Red Drum may only be fished for with pole and line (rod/reel) [O.C.G.A. 27-4-5].', 'https://coastalgadnr.org/limits', 'Georgia DNR CRD — Recreational finfish season, limits, and sizes', '2026-01-01', '2026-09-03', 1,
+   null, null, 5, 5, 14, 23, 'total_length', null, 'Rod and reel only.', true, 30),
+  ('spotted_seatrout', null, 'ga-state-waters', 'salt', 'bag_limit', 'Spotted Seatrout: Season: All year. Limit: 15. Minimum size: 14" TL.', 'https://coastalgadnr.org/limits', 'Georgia DNR CRD — Recreational finfish season, limits, and sizes', '2026-01-01', '2026-09-03', 1,
+   null, null, 15, 15, 14, null, 'total_length', null, null, true, 30),
+  ('southern_flounder', null, 'ga-state-waters', 'salt', 'bag_limit', 'Flounder: Season: All year. Limit: 15. Minimum size: 12" TL.', 'https://coastalgadnr.org/limits', 'Georgia DNR CRD — Recreational finfish season, limits, and sizes', '2026-01-01', '2026-09-03', 1,
+   null, null, 15, 15, 12, null, 'total_length', null, null, true, 60),
+  ('striped_bass', null, 'ga-state-waters', 'salt', 'bag_limit', 'Striped Bass: Saltwater Season: All year. Limit: 2. Minimum size: 22" TL. Savannah River Season: All year. Limit: 2. Minimum size: 27" TL.', 'https://coastalgadnr.org/limits', 'Georgia DNR CRD — Recreational finfish season, limits, and sizes', '2026-01-01', '2026-09-03', 1,
+   null, null, 2, 2, 22, null, 'total_length', null, 'Savannah River 27" min.', true, 60),
+  ('weakfish', null, 'ga-state-waters', 'salt', 'bag_limit', 'Weakfish: Season: All year. Limit: 1. Minimum size: 13" TL.', 'https://coastalgadnr.org/limits', 'Georgia DNR CRD — Recreational finfish season, limits, and sizes', '2026-01-01', '2026-09-03', 1,
+   null, null, 1, 1, 13, null, 'total_length', null, null, true, 60),
+  ('black_drum', null, 'ga-state-waters', 'salt', 'bag_limit', 'Black Drum: Season: All year. Limit: 15. Minimum size: 14" TL.', 'https://coastalgadnr.org/limits', 'Georgia DNR CRD — Recreational finfish season, limits, and sizes', '2026-01-01', '2026-09-03', 1,
+   null, null, 15, 15, 14, null, 'total_length', null, null, true, 60),
+  ('sheepshead', null, 'ga-state-waters', 'salt', 'bag_limit', 'Sheepshead: Season: All year. Limit: 15. Minimum size: 10" FL.', 'https://coastalgadnr.org/limits', 'Georgia DNR CRD — Recreational finfish season, limits, and sizes', '2026-01-01', '2026-09-03', 1,
+   null, null, 15, 15, 10, null, 'fork_length', null, null, true, 60),
+  ('cobia', null, 'ga-state-waters', 'salt', 'bag_limit', 'Cobia: Season: March 1 - Oct. 31. Limit: 1 per angler, maximum 6 per boat. Minimum size: 36" FL.', 'https://coastalgadnr.org/limits', 'Georgia DNR CRD — Recreational finfish season, limits, and sizes', '2026-01-01', '2026-09-03', 1,
+   '2026-03-01', '2026-10-31', 1, 1, 36, null, 'fork_length', null, '6 per boat.', true, 30),
+  ('bluefish', null, 'ga-state-waters', 'salt', 'bag_limit', 'Bluefish: Season: May 1 - Feb. 28 annually. Limit: 15. Minimum size: 12" FL.', 'https://coastalgadnr.org/limits', 'Georgia DNR CRD — Recreational finfish season, limits, and sizes', '2026-01-01', '2026-09-03', 1,
+   '2026-05-01', '2026-02-28', 15, 15, 12, null, 'fork_length', null, 'Wraps New Year''s.', true, 60),
+  ('atlantic_tarpon', null, 'ga-state-waters', 'salt', 'bag_limit', 'Tarpon: Season: All year. Limit: 1. Minimum size: 68" FL.', 'https://coastalgadnr.org/limits', 'Georgia DNR CRD — Recreational finfish season, limits, and sizes', '2026-01-01', '2026-09-03', 1,
+   null, null, 1, 1, 68, null, 'fork_length', null, null, true, 90);


### PR DESCRIPTION
## Forks
1. **Coast:** remaining Mid/South Atlantic recreational packs (DE DNREC Fish Facts, MD DNR notices, VA 4VAC, NC DMF table effective 2026-09-02, SC eRegs 2026-08-11, GA CRD limits). Insert-only SQL, 45 rules / 7 areas.
2. **Phase 1 sync:** `flushOnce` over the outbox protocol. IndexedDB + live Supabase sender still not hooked — backup badge stays honest.

## Checks
464 vitest + tsc.

## Honesty
- VA BSB size minimum not encoded (bag+season only from 4VAC20-950-45).
- NC internal stripers encoded as prohibited; ocean 28–31 slot is a footnote.
- GA red drum still 5 @ 14–23 on the live CRD table (3-fish proposal not treated as law).