### PR TITLE
Wire outbox flush to PostgREST

### DIFF
--- a/docs/team/worklog/2026-09-03-05-head-dev.md
+++ b/docs/team/worklog/2026-09-03-05-head-dev.md
@@ -1,0 +1,3 @@
+# 2026-09-03 — Head Dev — wire outbox flush to PostgREST
+
+PR #46 merged. Hooked `flushOnce` to IndexedDB + PostgREST sender, triggered after every persist and on `online` / visibility. Badge maps the real outbox: still says "Saved on this device" until Supabase is configured; then "N waiting to back up" / "Backed up". Auth-less prototype will leave rows queued (auth_expired) rather than lie.

--- a/src/core/sync/http-outcome.test.ts
+++ b/src/core/sync/http-outcome.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyHttp } from "./http-outcome";
+
+describe("classifyHttp", () => {
+  it("2xx is ok", () => {
+    expect(classifyHttp(201, "insert").kind).toBe("ok");
+    expect(classifyHttp(204, "delete").kind).toBe("ok");
+  });
+
+  it("insert 409 / 23505 is duplicate success", () => {
+    expect(classifyHttp(409, "insert").kind).toBe("duplicate");
+    expect(classifyHttp(400, "insert", { code: "23505" }).kind).toBe("duplicate");
+  });
+
+  it("patch 409 is rejected, not duplicate", () => {
+    expect(classifyHttp(409, "patch").kind).toBe("rejected");
+  });
+
+  it("401/403 stay queued via auth_expired", () => {
+    expect(classifyHttp(401, "insert").kind).toBe("auth_expired");
+    expect(classifyHttp(403, "patch").kind).toBe("auth_expired");
+  });
+
+  it("network-ish statuses stay queued", () => {
+    expect(classifyHttp(0, "insert").kind).toBe("unreachable");
+    expect(classifyHttp(503, "insert").kind).toBe("unreachable");
+  });
+});

--- a/src/core/sync/http-outcome.ts
+++ b/src/core/sync/http-outcome.ts
@@ -1,0 +1,35 @@
+/**
+ * Map an HTTP/PostgREST result onto the outbox `SendOutcome` (sync-protocol.md §4).
+ * Pure: the sender in `lib/` classifies, then `applyOutcome` advances state.
+ */
+import type { MutationOp, SendOutcome } from "./outbox";
+
+export function classifyHttp(
+  status: number,
+  op: MutationOp,
+  detail?: { code?: string | null; message?: string | null },
+): SendOutcome {
+  const message = detail?.message?.trim() || `HTTP ${status}`;
+  const code = detail?.code ?? "";
+
+  if (status >= 200 && status < 300) return { kind: "ok" };
+
+  // Unique violation / PostgREST duplicate: the row already landed.
+  if (op === "insert" && (status === 409 || code === "23505" || code === "PGRST116")) {
+    return { kind: "duplicate" };
+  }
+
+  if (status === 401 || status === 403) {
+    return { kind: "auth_expired", error: message };
+  }
+
+  if (status === 0 || status === 408 || status === 429 || status >= 500) {
+    return { kind: "unreachable", error: message };
+  }
+
+  if (status >= 400 && status < 500) {
+    return { kind: "rejected", error: message };
+  }
+
+  return { kind: "unreachable", error: message };
+}

--- a/src/features/catches/store.ts
+++ b/src/features/catches/store.ts
@@ -185,6 +185,14 @@ async function persist(
 ): Promise<void> {
   await commit(writes, mutations);
   await refresh();
+  // Fire-and-forget: the write is already durable. Flush never blocks the tap.
+  const { scheduleFlush } = await import("@/lib/sync/run-flush");
+  scheduleFlush();
+}
+
+/** Re-read IndexedDB into the in-memory snapshot. Used after a flush pass. */
+export async function refreshLog(): Promise<void> {
+  await refresh();
 }
 
 async function refresh(): Promise<void> {

--- a/src/features/shell/components/backup-badge.tsx
+++ b/src/features/shell/components/backup-badge.tsx
@@ -1,13 +1,22 @@
 "use client";
 
-import { describeBackupState, readBackupState } from "../queries/backup-state";
+import { useEffect } from "react";
+
+import { useLog } from "@/features/catches/store";
+import { installFlushListeners } from "@/lib/sync/run-flush";
+
+import { describeBackupState, fromOutboxBackup } from "../queries/backup-state";
 
 /**
  * The quiet backup indicator (ADR 004 §6). Never says "failed" while retries remain,
  * never blocks anything, never shows a spinner.
  */
 export function BackupBadge() {
-  const state = readBackupState();
+  const log = useLog();
+  useEffect(() => {
+    installFlushListeners();
+  }, []);
+  const state = fromOutboxBackup(log.backup, Boolean(process.env.NEXT_PUBLIC_SUPABASE_URL));
   const label = describeBackupState(state);
 
   // Green is earned only by `settled` — the server actually has the data. Local-only is

--- a/src/features/shell/queries/backup-state.test.ts
+++ b/src/features/shell/queries/backup-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { describeBackupState, readBackupState } from "./backup-state";
+import { describeBackupState, fromOutboxBackup, readBackupState } from "./backup-state";
 
 /*
  * ADR 004 §6 fixes this vocabulary deliberately: "Saved" and "Backed up" are different
@@ -21,8 +21,13 @@ describe("backup state vocabulary", () => {
 
   it("says saved on this device — never backed up — before anything has synced", () => {
     expect(describeBackupState({ kind: "local-only" })).toBe("Saved on this device");
-    // What the seam reports until the outbox store exists (ADR 004 §1): local-only.
     expect(readBackupState().kind).toBe("local-only");
+    expect(fromOutboxBackup({ kind: "backed_up" }, false).kind).toBe("local-only");
+    expect(fromOutboxBackup({ kind: "backed_up" }, true).kind).toBe("settled");
+    expect(fromOutboxBackup({ kind: "waiting", count: 2 }, true)).toEqual({
+      kind: "waiting",
+      count: 2,
+    });
   });
 
   it("uses the agreed words for the one state allowed to interrupt", () => {

--- a/src/features/shell/queries/backup-state.ts
+++ b/src/features/shell/queries/backup-state.ts
@@ -9,16 +9,22 @@
  * Offline is a normal state, not an error. An angler is offline for six hours by design.
  * There is no red banner here and there never will be.
  *
- * TODO(ADR 004 §1): read the real count from the outbox store once src/core/sync/store.ts
- * exists. Until then the only honest answer is `local-only`: every write lives on this
- * device and nothing has ever reached a server, so the glass says "Saved on this device"
- * — never "Backed up" next to a green dot while zero bytes have been backed up.
+ * Maps the outbox `BackupState` onto the badge vocabulary. "Backed up" is only
+ * earned when a server is configured *and* the queue is empty.
  */
+import type { BackupState as OutboxBackup } from "@/core/sync/outbox";
+
 export type BackupState =
   | { kind: "local-only" }
   | { kind: "settled" }
   | { kind: "waiting"; count: number }
   | { kind: "needs-attention"; count: number };
+
+export function fromOutboxBackup(outbox: OutboxBackup, serverConfigured: boolean): BackupState {
+  if (outbox.kind === "needs_attention") return { kind: "needs-attention", count: outbox.count };
+  if (outbox.kind === "waiting") return { kind: "waiting", count: outbox.count };
+  return serverConfigured ? { kind: "settled" } : { kind: "local-only" };
+}
 
 export function readBackupState(): BackupState {
   return { kind: "local-only" };

--- a/src/lib/sync/postgrest-send.ts
+++ b/src/lib/sync/postgrest-send.ts
@@ -1,0 +1,63 @@
+/**
+ * PostgREST sender for one outbox mutation. Lives in `lib/` so `core/sync` stays I/O-free.
+ */
+import type { Mutation, SendOutcome } from "@/core/sync/outbox";
+import { classifyHttp } from "@/core/sync/http-outcome";
+import { createClient } from "@/lib/supabase/client";
+
+const TABLES = new Set([
+  "trip",
+  "trip_rig",
+  "catch",
+  "catch_gear",
+  "condition_snapshot",
+  "location_condition",
+  "journal_entry",
+  "spot",
+  "tackle_item",
+]);
+
+export async function sendViaPostgrest(mutation: Mutation): Promise<SendOutcome> {
+  if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+    return { kind: "unreachable", error: "supabase not configured" };
+  }
+  if (!TABLES.has(mutation.entity)) {
+    return { kind: "rejected", error: `unknown entity ${mutation.entity}` };
+  }
+
+  try {
+    const supabase = createClient();
+    const table = mutation.entity;
+    let status = 0;
+    let code: string | null = null;
+    let message: string | null = null;
+
+    if (mutation.op === "insert") {
+      const { error } = await supabase.from(table).insert(mutation.payload);
+      if (!error) return { kind: "ok" };
+      status = (error as { status?: number }).status ?? 400;
+      code = error.code ?? null;
+      message = error.message;
+    } else if (mutation.op === "patch") {
+      const { error } = await supabase.from(table).update(mutation.payload).eq("id", mutation.entityId);
+      if (!error) return { kind: "ok" };
+      status = (error as { status?: number }).status ?? 400;
+      code = error.code ?? null;
+      message = error.message;
+    } else {
+      const { error } = await supabase
+        .from(table)
+        .update({ deleted_at: mutation.clientUpdatedAt, client_updated_at: mutation.clientUpdatedAt })
+        .eq("id", mutation.entityId);
+      if (!error) return { kind: "ok" };
+      status = (error as { status?: number }).status ?? 400;
+      code = error.code ?? null;
+      message = error.message;
+    }
+
+    return classifyHttp(status, mutation.op, { code, message });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "network";
+    return { kind: "unreachable", error: message };
+  }
+}

--- a/src/lib/sync/run-flush.ts
+++ b/src/lib/sync/run-flush.ts
@@ -1,0 +1,40 @@
+/**
+ * Drive one flush pass against IndexedDB. Safe to call from persist, `online`,
+ * and visibilitychange. Never throws into the logging UI.
+ */
+import { flushOnce } from "@/core/sync/flusher";
+import { allMutations, putMutation } from "@/lib/offline/db";
+import { sendViaPostgrest } from "./postgrest-send";
+
+let inFlight: Promise<void> | null = null;
+
+export function scheduleFlush(): void {
+  if (typeof navigator !== "undefined" && navigator.onLine === false) return;
+  if (inFlight) return;
+  inFlight = runFlush()
+    .catch(() => {
+      /* queued rows stay queued */
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+}
+
+export async function runFlush(): Promise<void> {
+  const before = await allMutations();
+  const result = await flushOnce(before, sendViaPostgrest);
+  await Promise.all(result.mutations.map((m) => putMutation(m)));
+  const { refreshLog } = await import("@/features/catches/store");
+  await refreshLog();
+}
+
+let listenersInstalled = false;
+
+export function installFlushListeners(): void {
+  if (typeof window === "undefined" || listenersInstalled) return;
+  listenersInstalled = true;
+  window.addEventListener("online", scheduleFlush);
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") scheduleFlush();
+  });
+}


### PR DESCRIPTION
Phase 1 sync: `flushOnce` now talks to PostgREST (insert/patch/soft-delete), persists outcomes in IndexedDB, and runs after every local write plus `online` / visibility. Backup badge reads the real outbox. Without `NEXT_PUBLIC_SUPABASE_*` it stays "Saved on this device"; 401 leaves rows queued.

469 vitest + tsc.