### PR TITLE
Fishing Passport Phase 1 — My Species, badges, and slams

### DIFF
--- a/docs/product/ROADMAP.md
+++ b/docs/product/ROADMAP.md
@@ -53,7 +53,7 @@ Rough effort: **S** = days, **M** = weeks, **L** = a month or more.
 | # | Feature | Why it might matter | Effort |
 |---|---|---|---|
 | A1 | **Voice note on a catch** — one tap to record, transcribed later | Hands wet, fish flapping, no time to type. Probably the single best fit for the actual moment of a catch. | M |
-| A2 | **Photo with EXIF stripped** | Already in the spec as V2. The privacy half matters: photos carry GPS, and anglers do not share spots. | S |
+| A2 | **Photo with EXIF stripped** | Already in the spec as V2. The privacy half matters: photos carry GPS, and anglers do not share spots. **❌ NOT NOW — 2026-09-03, founder, on cost.** No media table is scheduled; storage, EXIF stripping, size limits, offline upload and moderation are not being bought for a badge. This also removes verification levels 1–2 from Phase 2 of the passport spec — see its §45.2. Revisit as its own spec, not as a rider on another feature. | S |
 | A3 | **Length / weight** | Standard logbook data, and needed for any personal-best feature. | S |
 | A4 | **Fight time** | One tap start/stop. Anecdotally correlates with size; would be a genuinely novel variable. | S |
 | A5 | **Gear loadout** — rod, reel, line, leader | Ties to the two-level tackle model already designed. Bass anglers care a lot; surf anglers less. | M |

--- a/docs/product/ROADMAP.md
+++ b/docs/product/ROADMAP.md
@@ -73,7 +73,7 @@ Rough effort: **S** = days, **M** = weeks, **L** = a month or more.
 
 | # | Feature | Why it might matter | Effort |
 |---|---|---|---|
-| C1 | **"Find days like today"** — search history for matching conditions | The honest version of the alerting dream, and it works at any sample size because the angler judges the result, not the app. | M |
+| C1 | **"Find days like today"** — search history for matching conditions | The honest version of the alerting dream, and it works at any sample size because the angler judges the result, not the app. **✅ ACCEPTED 2026-09-03** (founder delegated the call to `coo`) → Phase 2 of `docs/specs/fishing-passport-wildlife-boat-games.md`, ahead of photo verification. It is the only accepted work that answers "should I go tomorrow" — see that spec's §47.1 and §47.4. | M |
 | C2 | **Catch heat map on the spot map** | Immediately legible, zero statistics required. | M |
 | C3 | **Season calendar** — what you caught this week, across years | Anglers think in seasons. Becomes valuable in year two and compounds. | M |
 | C4 | **Personal bests** | Cheap, and it is the thing people screenshot. | S |

--- a/docs/product/ROADMAP.md
+++ b/docs/product/ROADMAP.md
@@ -102,16 +102,30 @@ Rough effort: **S** = days, **M** = weeks, **L** = a month or more.
 
 Recorded so nobody proposes them again without reading why.
 
-- **Streaks, badges, gamified logging.** This is the dangerous one. Gamification would
-  bias the denominator — people log to protect a streak, and stop logging once it breaks.
-  Our entire statistical claim rests on the log being an unbiased record of when someone
+> **Partly reversed 2026-09-03 by the founder.** `docs/specs/fishing-passport-wildlife-boat-games.md`
+> proposes badges, a species collection, wildlife sighting logs, photo-assisted
+> identification, and private boat games. It is the newer founder document, so it stands;
+> the reasoning below is kept because the spec must keep answering it. That spec's §46
+> records which objections it answers and which one is still open. The bullets it touches
+> are marked below.
+
+- **Streaks, badges, gamified logging.** *(Revisited — passport spec §12–§14, §46. Streaks
+  stay dead by the founder's own choice; achievement badges are now in scope.)* This is the
+  dangerous one. Gamification would bias the denominator — people log to protect a streak,
+  and stop logging once it breaks. Our entire statistical claim rests on the log being an unbiased record of when someone
   fished. **Rewarding logging corrupts the data we are selling.** If any engagement
   mechanic is ever added, it must reward *confirming a trip honestly*, never reward
   catching or logging more.
-- **Social feed, following, public catches.** Anglers do not share spots.
-- **Leaderboards.** Same reason as streaks, worse.
+- **Social feed, following, public catches.** Anglers do not share spots. *(Still true.
+  The passport spec keeps games private and non-wagering, lists a public feed under its own
+  §41 non-goals, and gates public anything behind moderation and privacy controls — §30.)*
+- **Leaderboards.** Same reason as streaks, worse. *(Global leaderboards remain out —
+  passport spec §41. Private per-boat scoreboards inside one trip are Phase 4 and are not
+  the same thing.)*
 - **Fish identification from photos.** Different product, enormous effort, and wrong
-  answers are worse than no feature.
+  answers are worse than no feature. *(Revisited — passport spec §15–§17 keeps AI as a
+  ranked suggestion that never sets verification status or a legal conclusion. Phase 2+,
+  and it needs a media table that does not exist yet — see that spec's §45.2.)*
 - **A full Tide Alert clone.** Already in `SPEC.md` §6. We need tide *data*, not a
   competing tide *viewer*.
 - **Generic fishing advice.** Competes with every blog on the internet and trades away the

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,30 @@
+# Specs index
+
+Founder-supplied and team-written specifications. Each file is the detailed source of
+truth for one feature area. `docs/product/SPEC.md` remains the product-wide source of
+truth; ADRs in `docs/architecture/decisions/` record structural rulings that specs then
+implement.
+
+**Read the spec before touching its feature area.** If a spec and a roadmap entry
+disagree, the newer founder-dated document wins, and the conflict gets recorded in both
+files rather than silently resolved.
+
+| Spec | Status | What it covers |
+|---|---|---|
+| [fishing-passport-wildlife-boat-games.md](fishing-passport-wildlife-boat-games.md) | **Proposed** — planning only, nothing built | Fishing Passport / My Species, badges and verification levels, marine wildlife sightings, reusable Fin ID, private Boat Games. Phase 1 = Passport + starter badges. |
+| [tackle-box.md](tackle-box.md) | MVP / ready for implementation | Personal tackle inventory: two-level item model, search, and gear snapshots on a catch. |
+| [fish-legal-expansion.md](fish-legal-expansion.md) | Shipped (Phases 1–3, PR #24) | Region-aware rules and regulations surface: packs, verdicts, citation-or-nothing. |
+| [regulations-architecture.md](regulations-architecture.md) | Proposed architecture | How regulation data is packaged, versioned, and served offline. |
+| [regulations-data-model.md](regulations-data-model.md) | Proposed; SoCal dataset landed | `reg_area` / `reg_group` / `reg_pack` / `reg_rule` field meanings. |
+| [regulations-socal-research.md](regulations-socal-research.md) | Research findings | Sourced Southern California ocean sport fishing rules behind the SoCal pack. |
+| [rockfish-identification.md](rockfish-identification.md) | Draft for implementation | Rockfish reference data and decision tree. Biology only. Absorbed by Fin ID later — see the passport spec §17. |
+
+## Adding a spec
+
+1. File it here, in `docs/specs/`, not in a chat message.
+2. Give it the frontmatter block the newer specs use: `date`, `status`, `governs`,
+   `extends`, `supersedes`.
+3. Add a row to the table above.
+4. If it contradicts a decision already recorded in `docs/product/ROADMAP.md`,
+   `docs/product/SPEC.md`, or an ADR, say so in both documents.
+5. Tell the roles it affects through `docs/team/channel/`.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -11,7 +11,7 @@ files rather than silently resolved.
 
 | Spec | Status | What it covers |
 |---|---|---|
-| [fishing-passport-wildlife-boat-games.md](fishing-passport-wildlife-boat-games.md) | **Proposed** — planning only, nothing built | Fishing Passport / My Species, badges and verification levels, marine wildlife sightings, reusable Fin ID, private Boat Games. Phase 1 = Passport + starter badges. |
+| [fishing-passport-wildlife-boat-games.md](fishing-passport-wildlife-boat-games.md) | **Proposed** — planning only, nothing built | Fishing Passport / My Species, badges and verification levels, marine wildlife sightings, reusable Fin ID, private Boat Games. Phase 1 = Passport + starter badges. **Read §44–§47 first** — repo reality check, three blocked items, and the sequencing recommendation. |
 | [tackle-box.md](tackle-box.md) | MVP / ready for implementation | Personal tackle inventory: two-level item model, search, and gear snapshots on a catch. |
 | [fish-legal-expansion.md](fish-legal-expansion.md) | Shipped (Phases 1–3, PR #24) | Region-aware rules and regulations surface: packs, verdicts, citation-or-nothing. |
 | [regulations-architecture.md](regulations-architecture.md) | Proposed architecture | How regulation data is packaged, versioned, and served offline. |

--- a/docs/specs/fishing-passport-wildlife-boat-games.md
+++ b/docs/specs/fishing-passport-wildlife-boat-games.md
@@ -1023,3 +1023,121 @@ A phase is complete only when:
 > same pull request. Break the work into the Phase 1 tickets, verify each concern, and
 > preserve Fish Legal, region switching, Quick Mark, catch snapshots, calendar, tide, map,
 > and setup behavior.
+
+---
+
+# Appendix — repository reality check (added by `coo`, 2026-09-03)
+
+Everything above section 43 is the founder's document. This appendix is not: it is what
+the repository actually contains today, checked against the spec's assumptions so an
+implementing agent meets these facts in a document rather than halfway through Ticket 5.
+Nothing here changes the spec. Three items need a founder or architect ruling before
+Phase 1 code starts.
+
+## 44. What Phase 1 can already build on
+
+Checked in `src/core/rules/catch/types.ts` and
+`supabase/migrations/20260828120000_v1_core_schema.sql`.
+
+| Spec need | Exists today as |
+|---|---|
+| Unique-species counting (§10) | `catch.species_id` → `species.id` |
+| Generic-group rule (§10, "generic rockfish") | `species.is_group` + `species.rolls_up_to` — the roll-up is already modeled |
+| Protected/prohibited exclusion (§11) | `species.take_status` — `open` / `protected` / `regulated` |
+| Saltwater/freshwater filter (§9.1) | `species.water_class` — `salt` / `fresh` / `both` |
+| Kept vs released counts, Responsible Release I (§9.2, §12) | `catch.disposition` — `kept` / `released` / `n/a` |
+| Personal bests by length and weight (§9.2) | `catch.length_mm`, `catch.weight_g`, with `catch.size_estimated` to qualify the claim |
+| Quick Mark double-credit rule (§10, §37) | `catch.resolution_state` (`unresolved` / `confirmed` / `dismissed`) + `dismissed_reason` |
+| Manual historical catches (§10) | `catch.capture_mode` — `live` / `backfill` |
+| Night Bite badge (§12) | `catch.caught_at` + `caught_tz` + `lat`/`lng` |
+| Soft-delete recalculation (§10) | `catch.deleted_at` on every table |
+| Trip association for games and wildlife (§19, §29.8) | `trip` table with `trip.id` on every catch |
+| Legal context snapshot for game scoring (§26) | `catch.regulation_snapshot`, frozen at log time |
+
+The passport can therefore be computed as a pure projection over existing rows, exactly
+as §28 requires. No second catch table is needed for Phase 1.
+
+## 45. Three gaps that need a decision, not just code
+
+### 45.1 There is no region on a catch — and that is deliberate
+
+`src/core/ontology/regions.ts` states the current rule outright: *"no region is part of
+the data model"*. Region is a device-local preference that decides which species chips
+surface first; it never restricts search, never filters, and is never written to a catch.
+That principle comes from ADR 007 §4 and the founder's own 2026-09-01 requirement #4
+(`docs/product/requests/2026-09-01-expansion-requirements.md`).
+
+This spec needs region in four places: the §9.1 region filter, the §8.2 "current region
+collection progress" card, the §11 geographic collections, and the §12 **New Waters I**
+badge ("valid catches in 3 eligible fishing regions"). None of them can read a field that
+does not exist.
+
+Three ways out, in the order I would prefer them:
+
+1. **Derive region from `catch.lat`/`lng` at read time.** Keeps region out of the data
+   model, which honors the existing decision. Costs a point-in-region test and needs an
+   honest "region unknown" bucket, because `lat`/`lng` are nullable and shore/backfill
+   catches often have neither.
+2. **Snapshot the region preference onto the catch at log time**, the way
+   `regulation_snapshot` and the gear labels already snapshot context. Cheap and exact,
+   but it records where the angler *said* they fish, not where the fish was, and it does
+   put region in the data model.
+3. **Drop region from Phase 1.** Ship species, family, and habitat collections; defer
+   geographic collections and New Waters I to Phase 2.
+
+**Ruling needed from `architect`, with the founder's sign-off, because option 2 reverses
+a stated principle.**
+
+### 45.2 There is no media table, so nothing can hold a photo
+
+The schema has no `media`, `photo`, or `attachment` table — the current tables are
+`angler`, `trip`, `catch`, `catch_gear`, `spot`, `tackle_item`, `trip_rig`,
+`trip_rig_gear`, `journal_entry`, `condition_snapshot`, the `reg_*` set, and the
+vocabularies. `docs/product/ROADMAP.md` A2 still lists photos as an unaccepted V2
+candidate.
+
+That blocks, in Phase 1, the **Photo Journal I** badge (§12) and the species photo
+gallery (§9.2); and in Phase 2, verification levels 1 and 2 entirely (§15), since both are
+defined by attached media. Phase 3 wildlife photos and §17 Fin ID inherit the same gap.
+
+Recommendation: cut **Photo Journal I** from the Phase 1 catalog and leave the gallery as
+an empty state, rather than growing Phase 1 to include media capture, storage, EXIF
+stripping (ROADMAP A2 is explicit that the privacy half matters), size limits, and offline
+upload. Media is its own spec.
+
+### 45.3 `species` has no family or category column
+
+§9.1 requires a "species family or category" filter and §11 defines family collections
+(bass, tuna, rockfish, sharks and rays, salmon and trout, flatfish, crustaceans). The
+`species` table carries `is_group` and `rolls_up_to` — a roll-up, not a taxonomy.
+
+Cheapest correct answer: express families as `passport_collections` rows of type
+`family` (§29.1) and drive the filter from collection membership. That keeps the taxonomy
+versioned and data-driven per §11, and adds no column to `species`.
+
+## 46. This spec reverses part of ROADMAP Part 3
+
+`docs/product/ROADMAP.md` Part 3 — "Deliberately NOT building" — currently rules out
+badges and gamified logging, leaderboards, social feeds, and photo-based fish ID. That
+section exists so the arguments are read before anyone re-proposes them, and this spec
+re-proposes several. It is the founder's call to make and this document is the newer one,
+so the spec stands; both files now carry the cross-reference.
+
+The roadmap's substantive objection deserves a straight answer, because it is a good one:
+
+> Gamification would bias the denominator — people log to protect a streak, and stop
+> logging once it breaks. Our entire statistical claim rests on the log being an unbiased
+> record of when someone fished. If any engagement mechanic is ever added, it must reward
+> *confirming a trip honestly*, never reward catching or logging more.
+
+This spec already answers most of it, and says so in its own words: §12 refuses streak
+badges for the same reason the roadmap gives, §14 refuses to block or interrupt logging,
+§26 refuses to reward retention, and §34 closes with "do not optimize badge counts at the
+expense of accurate catch data".
+
+What is left unanswered is narrower: **Species Explorer I–III and Species Sprint reward
+catching more, which is the one thing the roadmap says an engagement mechanic must never
+do.** `biostat` should say whether a unique-species count actually biases the effort
+denominator the correlation engine depends on, or whether the bias is confined to
+frequency-based mechanics such as streaks. That answer is worth having before the badge
+catalog is finalized, not after anglers have a year of history under it.

--- a/docs/specs/fishing-passport-wildlife-boat-games.md
+++ b/docs/specs/fishing-passport-wildlife-boat-games.md
@@ -1,0 +1,1025 @@
+---
+date: 2026-09-03 (founder spec received)
+status: PROPOSED — ready for technical planning (nothing implemented)
+governs: (future) src/core/passport/, src/core/achievements/, src/core/identification/,
+  src/core/games/, src/features/passport/, src/features/achievements/,
+  src/features/wildlife/, src/features/boat-games/, src/app/passport/
+extends: docs/specs/rockfish-identification.md (Fin ID absorbs it), docs/specs/fish-legal-expansion.md
+supersedes: none
+---
+
+# Fish Passport, Wildlife ID, and Boat Games
+
+**Product:** Fish Log Book
+**Document type:** Product and implementation specification
+**Status:** Proposed — ready for technical planning
+**Version:** 1.0
+**Date:** 2026-09-03
+
+> Founder-supplied source of truth, captured verbatim in substance. Nothing here is
+> built yet. Phase 1 (§36) is the only slice cleared for implementation planning.
+
+---
+
+## 1. Executive summary
+
+This initiative expands Fish Log Book from a private catch journal into a connected
+collection, discovery, and on-the-water social experience.
+
+The initiative has four related feature families:
+
+1. **Fishing Passport and My Species** — automatically turn catch history into a visual
+   collection of species, regions, personal records, and progress.
+2. **Badges and verification** — reward exploration, skill, consistency, responsible
+   releases, and verified accomplishments without requiring a photo for ordinary use.
+3. **Marine Wildlife and Fin ID** — identify and log whales, marine mammals, sharks,
+   rays, and other wildlife as sightings rather than catches.
+4. **Boat Games** — let anglers on the same boat run friendly, offline-capable games
+   scored from their catch logs.
+
+The first implementation slice is intentionally limited to My Species, Fishing Passport,
+and a small foundational badge catalog. Photo verification, wildlife logging, and
+multiplayer games build on that foundation in later phases.
+
+The existing catch record remains the source of truth. Do not create a second catch
+system, duplicate a catch when awarding progress, or make the normal catch flow slower.
+
+## 2. Product objective
+
+Create a compelling reason for anglers to return after each trip by showing what they
+have discovered, what they have accomplished, and what they could pursue next.
+
+The feature must preserve the core Fish Log Book value proposition:
+
+> Every catch is a snapshot in time: species, time, GPS, spot, rod and rig, bait,
+> conditions, tide, environment, legal context, and media.
+
+Passport, badges, identification, and games consume that snapshot. They must not fork
+or weaken it.
+
+## 3. Success criteria
+
+The initiative succeeds when:
+
+- Existing users immediately see a species collection built from their prior catches.
+- Logging a new species produces a satisfying but brief progress moment.
+- A user can distinguish personal, photo-supported, and human-verified accomplishments.
+- Wildlife sightings live on the same trip timeline without being described as catches.
+- A group can run a boat game without dependable cell service.
+- Every scored catch still respects Fish Legal, bag-limit, boundary, and protected-species
+  safeguards.
+- The system never encourages illegal retention, wildlife harassment, or excessive
+  harvesting for points.
+
+## 4. Product principles
+
+### 4.1 Preserve fast logging
+
+The current species-first, local-first catch flow is the primary workflow. Passport and
+badge evaluation happen after save and must not add required fields to ordinary catch
+logging.
+
+### 4.2 One record, many uses
+
+A catch may contribute to personal analytics, passport progress, badges, and a game, but
+it remains one catch record with one stable ID.
+
+### 4.3 Personal progress is inclusive
+
+A self-reported catch counts toward a user's private passport. Stronger proof is only
+required for verified badges, public competitions, records, or prizes.
+
+### 4.4 Verification must be understandable
+
+AI identification confidence is not proof. Photo evidence, GPS evidence, captain
+approval, community review, and tournament verification are separate facts and must be
+displayed separately.
+
+### 4.5 Legal and ethical behavior comes before engagement
+
+No points or badges may reward exceeding limits, retaining prohibited fish, targeting
+protected wildlife, approaching marine mammals, or publishing sensitive wildlife
+locations.
+
+### 4.6 Offline is a primary state
+
+Passport viewing, badge progress, wildlife drafts, and active boat games must remain
+useful offshore. The UI must identify pending synchronization without blocking the user.
+
+### 4.7 Region-aware, not California-specific
+
+Collections and identification use the shared species ontology and selected fishing
+region. The implementation must support saltwater, freshwater, all U.S. coastal regions,
+Mexico, and later international packs without hard-coded California logic.
+
+## 5. System relationship
+
+```mermaid
+flowchart TD
+    C[Catch record] --> P[Fishing Passport]
+    C --> B[Badge engine]
+    C --> G[Boat-game scoring]
+    W[Wildlife sighting] --> T[Trip timeline]
+    I[Identification engine] --> C
+    I --> W
+    L[Fish Legal] --> C
+    L --> G
+```
+
+Passport, badges, and scores are projections of source records. They do not own or
+silently rewrite catches.
+
+## 6. Scope and phased delivery
+
+| Phase | Scope | Priority |
+|---|---|---|
+| 1 | My Species, Fishing Passport, personal records, starter badges | Build first |
+| 2 | Photo evidence, verification levels, AI-assisted ID boundary | Next |
+| 3 | Wildlife sightings, whale/marine-mammal ID, reusable Fin ID | Later |
+| 4 | Private Boat Battles with offline-capable game sessions | Later |
+| 5 | Clubs, public challenges, leaderboards, moderation, tournament verification | Future |
+
+Do not combine all phases into one pull request. Each phase must be independently
+shippable behind a feature flag.
+
+---
+
+# Part I — Fishing Passport and My Species
+
+## 7. User stories
+
+- As an angler, I can see every species I have logged in one place.
+- As an angler, I can see species I have not caught without being shown sensitive or
+  inappropriate targets.
+- As an angler, I can filter my collection by region, water type, species family,
+  verification status, and caught/uncaught status.
+- As an angler, I can open a species to see my first catch, most recent catch, personal
+  best, total catches, releases, retained catches, and photos.
+- As an angler, I can see progress toward regional and family-based collections.
+- As an angler, I receive a small celebration when I log a new species or unlock a badge,
+  without interrupting the next action.
+- As an angler with old catch records, I receive credit automatically without manually
+  rebuilding my history.
+
+## 8. Information architecture
+
+### 8.1 Proposed routes
+
+- `/passport` — passport overview and collections.
+- `/passport/species` — full My Species grid.
+- `/passport/species/[speciesId]` — personal species detail.
+- `/passport/badges` — earned badges and progress.
+- `/passport/collections/[collectionId]` — regional or family collection detail.
+
+Do not add another permanent primary-navigation item during Phase 1. The existing mobile
+navigation already has limited space. Enter Passport from the profile/account area, a
+dashboard collection card, and post-catch progress. A later navigation review may promote
+it based on usage.
+
+### 8.2 Passport overview
+
+The overview must include:
+
+- Total unique species caught.
+- Verified unique species count.
+- Total catches, releases, and retained catches.
+- Latest new species.
+- Current region collection progress.
+- Recently earned badges.
+- Three nearest-to-completion goals.
+- Link to the complete My Species grid.
+
+Avoid a feed of generic achievements. Every card should lead to a meaningful species,
+collection, catch, or badge detail page.
+
+## 9. My Species grid
+
+Each species card contains:
+
+- Species common name.
+- Local or alternate name when available.
+- Licensed/approved species image or existing bundled illustration.
+- Caught or uncaught state.
+- Verification indicator when applicable.
+- Total catch count.
+- Personal-best measurement when available.
+- First-caught date.
+
+Uncaught species use a silhouette or restrained treatment. Do not imply the user should
+target a protected, prohibited, threatened, or sensitive species. Such species can be
+shown for education but must be labeled appropriately and excluded from completion
+requirements.
+
+### 9.1 Filters and sorting
+
+Required filters:
+
+- Caught / uncaught / all.
+- Current fishing region / all regions.
+- Saltwater / freshwater / brackish when ontology supports it.
+- Species family or category.
+- Any verification / photo-supported / human-verified.
+
+Required sorting:
+
+- Recently caught.
+- First caught.
+- Most caught.
+- Name A–Z.
+- Personal-best size when comparable.
+
+### 9.2 Species detail
+
+The personal species page shows:
+
+- Species identity and educational summary.
+- Total caught, retained, and released.
+- First and most recent catch.
+- Personal best by length and weight, kept as distinct records.
+- Catch history list and map access.
+- Photo gallery.
+- Most-used rod/setup and bait when enough data exists.
+- Conditions/tide summary only when sample size is sufficient.
+- Applicable passport collections.
+- Fish Legal entry point for the selected region.
+
+Do not present a correlation from a single catch as a pattern. Existing analytics
+sample-size rules apply.
+
+## 10. Counting rules
+
+The catch table is authoritative. Adapt the names below to the repository's existing
+schema rather than creating parallel concepts.
+
+A catch counts toward the private passport when:
+
+- It belongs to the current user.
+- It is not deleted or invalidated.
+- It has a recognized species ontology ID.
+- Its disposition is a valid application value.
+
+Additional rules:
+
+- Multiple catches of one species increase catch count but add only one unique species.
+- Editing a catch from species A to species B recalculates both species.
+- Deleting the only catch of a species removes current caught status.
+- Historical achievements retain an audit trail but may become revoked if their only
+  qualifying source is removed or invalidated.
+- Quick Mark completion updates the original record and must not create double credit.
+- Manually entered historical catches count and are labeled as manual when relevant.
+- Group-only ontology entries such as generic rockfish may appear in history but do not
+  satisfy an individual-species collection until identified more precisely.
+
+## 11. Collections
+
+A collection is a versioned definition containing eligible species and completion rules.
+Initial collection types:
+
+- **Geographic:** Southern California, Northern California, Pacific Northwest, Gulf Coast,
+  Atlantic Coast, Hawaii, Alaska, Mexico, and later state-specific passports.
+- **Habitat:** freshwater, inshore, offshore, pelagic, reef, surf, and deepwater.
+- **Family/category:** bass, tuna, rockfish, sharks and rays, salmon and trout, flatfish,
+  crustaceans, and other curated groups.
+- **Experience:** night fishing, shore fishing, kayak fishing, and boat fishing when
+  source catch fields support those claims.
+
+Collection membership must be data-driven and versioned. Do not hard-code species lists
+inside React components.
+
+Protected or prohibited species must never be required for 100% completion. If they are
+shown educationally, mark them `informational_only`.
+
+## 12. Phase 1 badge catalog
+
+Ship a small catalog that is easy to understand and test:
+
+| Badge | Requirement |
+|---|---|
+| First Catch | Log one valid catch |
+| Species Explorer I | Catch 5 unique species |
+| Species Explorer II | Catch 10 unique species |
+| Species Explorer III | Catch 25 unique species |
+| Freshwater Explorer | Catch 5 eligible freshwater species |
+| Saltwater Explorer | Catch 10 eligible saltwater species |
+| Responsible Release I | Log 10 released fish |
+| New Waters I | Log valid catches in 3 eligible fishing regions |
+| Night Bite | Log a valid catch during local nighttime using recorded time and location |
+| Photo Journal I | Attach evidence photos to 10 distinct catches |
+
+Do not ship streak badges in Phase 1. Streak pressure is a poor fit for weather-dependent
+outdoor activity and may encourage unnecessary trips or low-quality logs.
+
+## 13. Badge engine requirements
+
+- Badge definitions are data, not component conditionals.
+- Evaluation is deterministic and idempotent.
+- The same catch event cannot award the same badge twice.
+- Progress recalculates after catch edit, deletion, verification change, and sync merge.
+- Store the rule version used for an award.
+- Store qualifying source IDs for auditability when reasonable.
+- An award can be active, revoked, or superseded.
+- Client-side evaluation may provide immediate feedback offline, but the server performs
+  authoritative reconciliation after synchronization.
+- No badge may depend on an unverifiable legal conclusion from AI.
+
+## 14. Celebration behavior
+
+After a catch saves:
+
+- Show at most one compact progress message immediately.
+- Prioritize "New species" over a routine count update.
+- Queue multiple badge unlocks in an inbox or summary rather than stacking modals.
+- Never block the user's ability to log another fish.
+- Respect reduced-motion settings.
+- Provide text and icon changes in addition to color.
+
+---
+
+# Part II — Evidence, Identification, and Verification
+
+## 15. Verification model
+
+Verification is composed from evidence. Do not use one ambiguous `verified: boolean`.
+
+| Level | Display label | Minimum evidence |
+|---|---|---|
+| 0 | Self logged | User-created catch record |
+| 1 | Photo supported | Original media attached to the catch |
+| 2 | Metadata supported | Photo plus compatible time/location metadata or in-app capture |
+| 3 | Human verified | Captain, approved reviewer, or defined community process confirms it |
+| 4 | Event verified | Tournament/event rules and reviewer approval satisfied |
+
+AI identification is stored separately:
+
+- Suggested species IDs and ranked alternatives.
+- Model/provider version.
+- Confidence score.
+- Input media ID.
+- User-confirmed species.
+- Human-review result when applicable.
+
+The UI may say "Likely California yellowtail — 87% confidence." It must not say the catch
+is verified solely because the model is confident.
+
+## 16. Photo policy
+
+- A photo is optional for an ordinary private catch and basic passport credit.
+- A photo is required for photo-supported badges and may be required by private game or
+  event rules.
+- Original media should remain associated with the catch's stable ID.
+- EXIF absence is not proof of fraud; many apps and devices strip metadata.
+- EXIF presence is supporting evidence, not absolute proof.
+- Uploaded images require size limits, safe content handling, and moderation/reporting
+  before public social features launch.
+- Public views must not expose precise private fishing coordinates through EXIF.
+
+## 17. Reusable Fin ID engine
+
+"Fin ID" is a reusable identification layer, not a separate engine for every animal.
+
+Supported observation traits may include:
+
+- Body shape and approximate size.
+- Dorsal, pectoral, pelvic, anal, and tail-fin shape or placement.
+- Tail/fluke shape.
+- Mouth position and tooth visibility.
+- Color, spots, bars, bands, and countershading.
+- Number of visible dorsal fins.
+- Fin clips, scars, or distinguishing marks.
+- Saltwater/freshwater context.
+- Geographic range and season.
+- Observed behavior.
+
+The engine returns ranked candidates, distinguishing traits, missing questions, and
+confidence. Location may narrow candidates but must not override contradictory visual
+traits.
+
+The existing rockfish identifier should eventually use this shared structure rather than
+become an isolated one-off wizard.
+
+---
+
+# Part III — Marine Wildlife Log
+
+## 18. Wildlife scope
+
+Wildlife observations are sightings, never catches. Initial categories:
+
+- Whales.
+- Dolphins and porpoises.
+- Seals and sea lions.
+- Sea turtles.
+- Sharks and rays observed but not caught.
+- Seabirds.
+- Other notable marine wildlife.
+
+## 19. Wildlife sighting flow
+
+Proposed entry: the existing quick-add/log menu gains **Log Wildlife Sighting**.
+
+The flow captures:
+
+- Species, ranked suggestion, or unknown.
+- Photo/video when available.
+- Date and time.
+- GPS location and accuracy.
+- Estimated count or range.
+- Behavior: traveling, feeding, breaching, resting, socializing, distressed, or other.
+- Direction of travel.
+- Observation platform: boat, kayak, shore, pier, or other.
+- Distance band rather than falsely precise distance.
+- Notes.
+- Trip association.
+- Sync state and identification state.
+
+A saved sighting appears on the trip timeline and private map using an icon distinct from
+catch markers.
+
+## 20. Whale identification levels
+
+### 20.1 Phase 3 target: species identification
+
+Use range, body size, blow shape, dorsal-fin position, coloration, fluke behavior, and
+photographs to suggest whale species.
+
+### 20.2 Future research feature: individual matching
+
+Matching a particular whale from fluke patterns, dorsal fins, scars, and catalogs is a
+separate research-grade feature. Do not promise individual identity in Phase 3. Pursue it
+later through an appropriate scientific database or conservation partnership.
+
+## 21. Wildlife safety and privacy
+
+- Never award points for close approach, pursuit, touching, feeding, or repeated
+  disturbance.
+- Show concise viewing-distance and non-harassment guidance appropriate to the region.
+- Exact sighting coordinates are private by default.
+- Public sharing uses coarse location, delayed location, or no location for sensitive
+  species.
+- The system may invite users to report distressed or entangled animals through an
+  official regional resource, but must not instruct untrained intervention.
+- Threatened, endangered, and protected species are excluded from competitive target lists
+  and catch-style language.
+
+---
+
+# Part IV — Boat Games
+
+## 22. Product concept
+
+A Boat Battle is a private game session associated with a fishing trip. One user is the
+host. Other anglers join using a short code or QR code. Eligible catches flow into the
+game after save and are scored from an immutable game snapshot.
+
+"Squid Game" must not be used as a product or mode name. Use **Last Angler Standing** to
+avoid confusion with an existing entertainment property.
+
+## 23. Core multiplayer flow
+
+1. Host creates or opens a trip.
+2. Host selects Start Boat Battle.
+3. Host selects a game template, duration, players/teams, target species, scoring, and
+   verification rule.
+4. The app validates targets against Fish Legal and protected-species restrictions.
+5. Players join by QR code, short code, or local invitation.
+6. Players log catches through the ordinary catch flow.
+7. Eligible catches become pending or accepted game events.
+8. The host resolves disputes or identification uncertainty.
+9. The game ends automatically or by the configured rule.
+10. A final scoreboard and trip recap are saved.
+
+No cash wagering, betting, or platform-facilitated gambling is in scope.
+
+## 24. Offline behavior
+
+- The host device maintains the authoritative local session while offline.
+- Each event has a stable UUID, device ID, local timestamp, server timestamp when
+  available, catch ID, and idempotency key.
+- Joined devices retain a local copy of rules and their submitted events.
+- The UI clearly labels unconfirmed scores while devices cannot synchronize.
+- Reconnection merges events deterministically and surfaces conflicts to the host.
+- Never award a catch twice after retry or reconnect.
+- Do not rely on continuous WebSockets as the only game path.
+
+Peer-to-peer transport may be explored later. Phase 4 may begin with same-device host
+entry plus delayed cloud synchronization if reliable local networking is not available.
+
+## 25. Initial game modes
+
+### 25.1 Species Cricket
+
+Inspired by darts cricket:
+
+- The host selects eligible target species.
+- Each target requires a configurable number of marks; default is three.
+- Catching a target adds one mark unless the host enables size-based marks.
+- After a player closes a species, additional eligible catches score points until every
+  opponent closes that species.
+- Highest score after all targets close or time expires wins.
+
+### 25.2 Fishing Bingo
+
+The host selects or generates a card containing legal and safe objectives, such as:
+
+- Catch a bass-family species.
+- Catch using live bait.
+- Catch during an incoming tide.
+- Catch three different species.
+- Properly release a legal target species.
+- Record catches on two different active setups.
+- Log a wildlife sighting from a safe distance.
+
+Wildlife squares reward observation, not proximity.
+
+### 25.3 Captain's Cup
+
+The host assigns points to eligible species or categories. Optional bonuses may include:
+
+- First eligible catch.
+- New personal species.
+- Personal-best legal catch.
+- Properly documented release.
+- Species diversity.
+
+### 25.4 Species Sprint
+
+The player or team with the most unique eligible species during the time window wins. This
+mode favors variety rather than harvesting volume.
+
+### 25.5 Grand Slam
+
+The host defines three to five legal target species. Completing the set wins, with time or
+points used as the tiebreaker.
+
+### 25.6 Last Angler Standing
+
+- The game uses fixed rounds, such as 30 or 60 minutes.
+- At each round boundary, the lowest eligible score is eliminated.
+- Eliminated players may keep logging catches, but those catches no longer change the
+  primary competition.
+- Tie handling is configured before the game begins.
+
+## 26. Scoring safeguards
+
+- Species points are configured by a host/template, not automatically inferred from
+  ecological rarity.
+- A protected, prohibited, illegally retained, or invalid catch receives zero points and
+  is flagged for review.
+- Fish Legal warnings remain visible inside the game flow.
+- A legal released catch may score the same as a retained catch.
+- Games must not reward cumulative retention beyond applicable limits.
+- Length/weight bonuses apply only where measurement is appropriate and the catch is
+  eligible.
+- Rule snapshots are frozen at game start so every player sees the same scoring rules.
+- The game snapshot does not override current law. A new Fish Legal warning can still
+  invalidate retention or scoring.
+- Host edits and adjudications require an audit entry.
+
+## 27. Game verification options
+
+Per-session options:
+
+- Honor system.
+- Photo required.
+- Host approval required.
+- Photo plus host approval.
+- Event/tournament verification, reserved for Phase 5.
+
+Casual games default to the honor system. Requiring photos for every private family or
+boat game would slow logging unnecessarily.
+
+---
+
+# Part V — Data and Technical Design
+
+## 28. Source-of-truth policy
+
+- Existing catch records remain authoritative for catch facts.
+- Existing species ontology remains authoritative for species identity.
+- Fish Legal remains authoritative for bundled legal guidance and regulation snapshots.
+- Passport summaries are derived projections.
+- Badge awards are persisted audit records backed by deterministic evaluation.
+- Game events reference catches; they do not copy an editable duplicate of a catch.
+- Wildlife sightings use a separate event type/table because they are not catches.
+
+## 29. Logical data model
+
+Names are conceptual. The implementation agent must inspect and follow existing table, ID,
+timestamp, RLS, and migration conventions.
+
+### 29.1 `passport_collections`
+
+- `id`
+- `slug`
+- `name`
+- `description`
+- `collection_type`
+- `region_id` nullable
+- `version`
+- `active`
+- `published_at`
+
+### 29.2 `passport_collection_species`
+
+- `collection_id`
+- `species_id`
+- `required`
+- `informational_only`
+- `sort_order`
+
+### 29.3 `badge_definitions`
+
+- `id`
+- `slug`
+- `name`
+- `description`
+- `category`
+- `tier`
+- `rule_type`
+- `rule_config` JSON
+- `rule_version`
+- `icon_key`
+- `active`
+- `published_at`
+
+### 29.4 `user_badge_awards`
+
+- `id`
+- `user_id`
+- `badge_definition_id`
+- `rule_version`
+- `status`: active, revoked, or superseded
+- `progress_snapshot` JSON
+- `qualifying_source_ids` JSON or normalized join, based on scale
+- `awarded_at`
+- `revoked_at` nullable
+- `created_offline_id` nullable
+
+Unique active-award constraints must prevent duplicate awards.
+
+### 29.5 `catch_verifications`
+
+- `id`
+- `catch_id`
+- `verification_type`
+- `status`
+- `reviewer_user_id` nullable
+- `evidence_media_ids`
+- `reason_code` nullable
+- `notes` nullable
+- `created_at`
+- `resolved_at` nullable
+
+### 29.6 `identification_suggestions`
+
+- `id`
+- `subject_type`: catch or wildlife_sighting
+- `subject_id`
+- `media_id`
+- `candidate_species` JSON
+- `model_name`
+- `model_version`
+- `created_at`
+- `user_selected_species_id` nullable
+- `human_review_status` nullable
+
+### 29.7 `wildlife_sightings`
+
+- `id`
+- `user_id`
+- `trip_id` nullable
+- `species_id` nullable
+- `identification_state`
+- `observed_at`
+- `latitude` and `longitude`, following existing privacy/storage policy
+- `location_accuracy_m` nullable
+- `count_min` nullable
+- `count_max` nullable
+- `behavior_codes`
+- `direction_of_travel` nullable
+- `platform`
+- `distance_band` nullable
+- `notes` nullable
+- `sensitivity_level`
+- `sync_state` local concern where appropriate
+- `created_at`, `updated_at`, and deletion/audit fields per project convention
+
+### 29.8 `game_sessions`
+
+- `id`
+- `trip_id`
+- `host_user_id`
+- `mode`
+- `status`: draft, lobby, active, paused, completed, or cancelled
+- `join_code_hash`
+- `rules_snapshot` JSON
+- `legal_context_snapshot` JSON
+- `starts_at`, `ends_at`
+- `created_at`, `updated_at`
+
+### 29.9 `game_participants`
+
+- `id`
+- `game_session_id`
+- `user_id` nullable for temporary guest
+- `display_name`
+- `team_id` nullable
+- `role`
+- `joined_at`
+- `eliminated_at` nullable
+
+### 29.10 `game_events`
+
+- `id`
+- `game_session_id`
+- `participant_id`
+- `catch_id` nullable
+- `event_type`
+- `round_number` nullable
+- `points_delta`
+- `eligibility_status`
+- `verification_status`
+- `reason_codes`
+- `idempotency_key`
+- `client_created_at`
+- `server_received_at` nullable
+- `adjudicated_by` nullable
+
+Derive leaderboards from immutable events. If a cache is added later, it must be
+rebuildable.
+
+## 30. RLS and authorization
+
+- Users can read and edit their own private passport inputs.
+- Passport projections expose only data the catch owner may access.
+- A game participant can read the session information required to play.
+- Only the host or explicitly assigned adjudicator can approve disputed game events.
+- A participant cannot alter another participant's catch.
+- Human verification actions identify the reviewer and create an audit trail.
+- Exact wildlife and catch coordinates remain protected by existing privacy rules.
+- Public profiles, leaderboards, and community review are out of scope until moderation,
+  blocking, reporting, and privacy controls exist.
+
+## 31. Offline and synchronization rules
+
+- Use stable client-generated UUIDs for offline-created records.
+- Every mutation has an idempotency key.
+- Passport progress can be computed locally from available catches.
+- Server reconciliation is authoritative after sync.
+- A pending catch may show provisional progress.
+- Sync rejection removes provisional credit with a plain-language explanation.
+- Conflicting catch edits follow the project's existing conflict policy.
+- Game scoring must retain both the submitted event and adjudication history.
+
+## 32. Proposed module boundaries
+
+Follow existing repository conventions after inspection. Suggested boundaries:
+
+```text
+src/core/passport/          Pure collection and progress rules
+src/core/achievements/      Deterministic badge evaluation
+src/core/identification/    Trait scoring and candidate ranking
+src/core/games/             Pure scoring and game state transitions
+src/features/passport/      Passport UI and application services
+src/features/achievements/  Badge UI and notifications
+src/features/wildlife/      Wildlife log and sighting UI
+src/features/boat-games/    Lobby, scoreboard, and game controls
+src/app/passport/           App Router pages
+```
+
+Core rules require vector tests and must not import React, browser-only APIs, or database
+clients.
+
+## 33. Accessibility and mobile UX
+
+- Design for 320-pixel-wide screens and one-handed use.
+- Minimum tap targets follow the existing design system.
+- Status uses words/icons in addition to color.
+- Respect reduced motion and device text scaling.
+- Do not stack celebration dialogs.
+- Scoreboards announce meaningful changes without continuous noisy screen-reader output.
+- Forms preserve drafts when the app backgrounds or loses service.
+- Maps and photos have useful text alternatives.
+
+## 34. Analytics and product measurement
+
+Capture privacy-conscious product events for:
+
+- Passport opened.
+- Species detail opened.
+- New species recorded.
+- Collection progress reached.
+- Badge awarded or revoked.
+- Evidence photo attached.
+- Wildlife sighting saved.
+- Game created, joined, completed, or abandoned.
+- Game mode selected.
+
+Primary measures:
+
+- Percentage of active catch loggers who open Passport.
+- Return rate after a new-species or badge event.
+- Average unique species per active user.
+- Photo attachment rate without forced prompts.
+- Completed private games per created game.
+- Catch-log completion time before and after launch.
+
+Do not optimize badge counts at the expense of accurate catch data.
+
+---
+
+# Part VI — Implementation Plan
+
+## 35. Feature flags
+
+- `passport_v1`
+- `catch_verification`
+- `wildlife_log`
+- `fin_id`
+- `boat_games`
+- `public_achievements` reserved for future use
+
+Flags must allow schema and rule deployment before broad UI exposure.
+
+## 36. Phase 1 ticket breakdown
+
+**Ticket 1 — Passport domain and selectors**
+
+- Define collection, progress, species-summary, and badge types.
+- Build pure selectors from existing catch and species data.
+- Handle edits, deletions, generic species groups, manual catches, and Quick Mark records.
+- Add vector tests.
+
+**Ticket 2 — Collection definitions**
+
+- Add versioned collection definitions and species membership.
+- Seed a small region/category set using the existing ontology.
+- Exclude protected/prohibited targets from required completion.
+- Add validation for missing and duplicate species IDs.
+
+**Ticket 3 — My Species page**
+
+- Build caught/uncaught grid, filters, sorting, loading, empty, and offline states.
+- Reuse licensed existing species artwork.
+- Add accessible status labels.
+
+**Ticket 4 — Personal species detail**
+
+- Add first/latest catch, totals, release/retention counts, personal bests, gallery, and
+  history access.
+- Link to Fish Legal without presenting stale legal data as current.
+
+**Ticket 5 — Starter badge engine**
+
+- Add data-driven definitions for the Phase 1 catalog.
+- Add idempotent local evaluation and server reconciliation.
+- Add badge list/progress UI and compact post-catch celebration.
+
+**Ticket 6 — Backfill and migration verification**
+
+- Confirm existing catches produce correct passport state without duplicate records.
+- Add migration/seed logic if persistence is required.
+- Validate RLS and rollback behavior.
+
+**Ticket 7 — Offline and sync hardening**
+
+- Test provisional progress, retry, duplicate events, catch edits, and deletion.
+- Confirm no duplicate awards after reconnect.
+
+**Ticket 8 — Product QA and rollout**
+
+- Validate 320-pixel screens, text scaling, reduced motion, dark/light/night modes, and
+  offline behavior.
+- Compare catch logging time before/after.
+- Roll out behind `passport_v1`.
+
+The first coding agent should implement or plan Tickets 1–5 only unless explicitly
+assigned the remaining tickets. Use small branches and pull requests by concern.
+
+## 37. Phase 1 acceptance criteria
+
+- Existing valid catches populate My Species with no manual backfill by the user.
+- A new valid species appears after catch save locally and after sync.
+- Repeated catches increment totals but do not duplicate unique-species credit.
+- Editing/deleting a qualifying catch recalculates progress correctly.
+- Quick Mark resolution never produces double credit.
+- Users can filter and sort the species grid as specified.
+- Species detail displays first/latest catch, counts, personal bests, and available media.
+- The Phase 1 badge catalog evaluates deterministically.
+- Re-running evaluation produces no duplicate awards.
+- Protected/prohibited species are not required for collection completion.
+- Passport works with no network using locally available data.
+- The catch flow gains no new required step.
+- Existing region switching, Fish Legal, catch snapshots, calendar, map, tide, and setup
+  behavior remain intact.
+- Unit tests, type checks, lint, build, and relevant browser/mobile checks pass.
+
+## 38. Later-phase acceptance highlights
+
+**Verification**
+
+- Self-logged, photo-supported, metadata-supported, human-verified, and event-verified
+  states are distinguishable.
+- AI confidence never silently changes verification status.
+- Public output strips or protects private coordinates and EXIF.
+
+**Wildlife**
+
+- Sightings are separate from catches but can share a trip timeline.
+- Unknown species can be saved and identified later.
+- Sensitive locations remain private/coarsened.
+- No engagement mechanic rewards wildlife approach.
+
+**Boat Games**
+
+- A host can create and finish a private game without dependable service.
+- Retried events do not score twice.
+- Illegal/ineligible catches score zero and remain auditable.
+- Host adjudication is recorded.
+- Fish Legal warnings remain available and cannot be overridden by game rules.
+
+## 39. Test strategy
+
+**Unit/vector tests**
+
+- Unique-species counting.
+- Catch edit/delete reconciliation.
+- Generic versus identified species.
+- Collection completion and informational-only exclusions.
+- Badge threshold boundaries and idempotency.
+- Verification-state composition.
+- Every game-mode state transition and tiebreak rule.
+- Duplicate/reordered offline game events.
+
+**Integration tests**
+
+- Existing catches to Passport projection.
+- Catch save to progress notification.
+- Offline catch to provisional progress to synchronized award.
+- RLS across private profiles and game participants.
+- Wildlife draft recovery and trip-timeline insertion.
+- Game join, score, dispute, adjudication, and completion.
+
+**End-to-end/mobile tests**
+
+- First-time user with no catches.
+- Existing user with years of catches.
+- Manual historical catch.
+- Quick Mark resolution.
+- 320-pixel layout and text scaling.
+- Airplane-mode passport and game flow.
+- App background/restore during wildlife and catch logging.
+
+## 40. Explicit product decisions
+
+These decisions are locked for the initial implementation unless the founder changes them:
+
+1. Self-logged catches count toward the private passport.
+2. Photos are optional for ordinary catches and basic passport progress.
+3. Verified/public accomplishments may require stronger evidence.
+4. AI suggests identity but does not independently verify a catch or legal status.
+5. Passport does not become a new primary-navigation tab in Phase 1.
+6. Wildlife records are called sightings, not catches.
+7. Exact wildlife locations are private by default.
+8. Protected species never become competitive targets or required collection entries.
+9. Boat Games are private and non-wagering in the initial release.
+10. The commercial mode name is Last Angler Standing, not Squid Game.
+11. The first implementation slice is Passport + My Species + starter badges.
+12. Existing catch logging and Fish Legal behavior must be preserved.
+
+## 41. Non-goals for the first release
+
+- Public social network or global activity feed.
+- Cash prizes, wagering, entry fees, or gambling mechanics.
+- Global leaderboards.
+- Automated tournament-grade fraud detection.
+- Individual whale catalog matching.
+- Scientific claims based only on crowdsourced sightings.
+- Real-time peer-to-peer networking as a hard launch dependency.
+- Requiring users to photograph every catch.
+- Replacing Fish Legal or treating AI identification as legal advice.
+
+## 42. Definition of done
+
+A phase is complete only when:
+
+- Scope-specific acceptance criteria pass.
+- Data migrations and RLS are reviewed.
+- Offline and synchronization behavior is tested.
+- Accessibility and 320-pixel mobile layout are inspected.
+- No existing catch, calendar, tide, map, setup, or Fish Legal workflow regresses.
+- Unit tests, type checks, lint, and production build pass.
+- The implementation is delivered in reviewable pull requests with what changed, why, and
+  how it was verified.
+- Any unimplemented portion remains explicitly documented rather than implied complete.
+
+## 43. Recommended starting instruction for the implementation agent
+
+> Implement Phase 1 of this specification only: the Passport domain/selectors, versioned
+> collection definitions, My Species grid, personal species detail, and starter badge
+> engine. Inspect and reuse the existing catch schema, species ontology, offline layer,
+> design tokens, and repository conventions. Do not create a parallel catch table, do not
+> add a new required catch-log step, and do not begin wildlife or multiplayer work in the
+> same pull request. Break the work into the Phase 1 tickets, verify each concern, and
+> preserve Fish Legal, region switching, Quick Mark, catch snapshots, calendar, tide, map,
+> and setup behavior.

--- a/docs/specs/fishing-passport-wildlife-boat-games.md
+++ b/docs/specs/fishing-passport-wildlife-boat-games.md
@@ -1,6 +1,8 @@
 ---
 date: 2026-09-03 (founder spec received)
-status: PROPOSED — ready for technical planning (nothing implemented)
+status: PROPOSED — ready for technical planning (nothing implemented).
+  Two blocking decisions resolved 2026-09-03 — see §45.1 (region: cut from Phase 1) and
+  §47.4 (ROADMAP C1 accepted into Phase 2). Media (§45.2) remains open.
 governs: (future) src/core/passport/, src/core/achievements/, src/core/identification/,
   src/core/games/, src/features/passport/, src/features/achievements/,
   src/features/wildlife/, src/features/boat-games/, src/app/passport/
@@ -1085,8 +1087,25 @@ Three ways out, in the order I would prefer them:
 3. **Drop region from Phase 1.** Ship species, family, and habitat collections; defer
    geographic collections and New Waters I to Phase 2.
 
-**Ruling needed from `architect`, with the founder's sign-off, because option 2 reverses
-a stated principle.**
+**RESOLVED 2026-09-03 — option 3.** The founder delegated the call; `architect` should
+review but is not blocking. Geographic collections, the §8.2 region progress card, the
+§9.1 region filter, and the **New Waters I** badge all come out of Phase 1.
+
+The deciding fact was checked, not assumed: `reg_area.boundary_geojson` exists in the
+schema but is effectively unpopulated, and `RegionId` in `src/core/ontology/regions.ts` is
+a label list with no geometry at all. So option 1 has nothing to derive *from* today —
+it is not a read-time computation, it is a project to source and verify polygons for every
+region, carrying the same citation-or-nothing burden Fish Legal already carries.
+
+Option 2 was rejected on merit rather than cost. Snapshotting the preference records where
+the angler *says* they fish, not where the fish was; a SoCal user who runs to Cabo without
+touching Settings gets silently mislabeled data. Buying that with a reversal of a stated
+founder principle, to enable one badge that §47.3 already classes as decoration, is a bad
+trade.
+
+Revisit in Phase 2 as option 1 — derived from `catch.lat`/`lng` — if and when region
+polygons become real data. Nothing in Phase 1 forecloses it, which is the point: cutting
+costs nothing later, snapshotting would have put a wrong column in the catch table forever.
 
 ### 45.2 There is no media table, so nothing can hold a photo
 
@@ -1193,9 +1212,9 @@ already have a source column, and three of which are blocked on decisions in §4
 | First Catch | A — count valid catches | `catch` rows | **Ship** |
 | Species Explorer I / II / III | B — count distinct `species_id` | `catch.species_id` | **Ship** (one rule, three thresholds — near-free tiering) |
 | Responsible Release I | C — count catches filtered by a catch column | `catch.disposition = 'released'` | **Ship** |
-| Freshwater Explorer | D — count distinct species filtered by a species column | `species.water_class` | **Ship** — decide how `both` counts |
-| Saltwater Explorer | D | `species.water_class` | **Ship** — same decision |
-| New Waters I | E — count distinct regions | **None.** No region on a catch | **Defer** — blocked on §45.1 |
+| Freshwater Explorer | D — count distinct species filtered by a species column | `species.water_class` + `trip.water_class` | **Ship** — see the `both` rule below |
+| Saltwater Explorer | D | `species.water_class` + `trip.water_class` | **Ship** — same rule |
+| New Waters I | E — count distinct regions | **None.** No region on a catch | **Cut from Phase 1** — §45.1 resolved: no region data to derive from |
 | Photo Journal I | F — count catches with attached media | **None.** No media table | **Cut from Phase 1** — blocked on §45.2 |
 | Night Bite | G — count catches passing a computed local-time test | `caught_at` + `lat`/`lng`, but needs a sunrise/sunset library. `astronomy-engine` is the cleared choice (SPEC.md O9); it is **not yet a dependency** | **Defer** — the only badge needing a new package |
 
@@ -1203,6 +1222,13 @@ So Phase 1 ships **seven badges on four rules**, and the three that look like or
 catalog entries are the three that carry an architectural decision, a missing table, and a
 new dependency respectively. An agent that starts at the top of the §12 table and works
 down will hit all three blockers in the last 30% of the ticket.
+
+**The `both` rule, resolved 2026-09-03:** `species.water_class` allows `salt`, `fresh`, or
+`both`, and striped bass caught in a river should not silently credit the saltwater
+collection. Resolve it from the trip, not the species: `trip.water_class` is already
+non-null on every trip and says which water the angler was actually in. A `both` species
+credits the collection matching its trip; `salt` and `fresh` species credit their own
+collection regardless. No new column, no new question at log time.
 
 One addition worth making while the engine is being written, per §46: **an honest blank
 trip should count for something.** A logged trip with zero fish is the most statistically
@@ -1222,9 +1248,16 @@ conditions — is the honest version of that, still unaccepted. The angler judge
 so it makes no statistical promise the sample size cannot support. It is the natural
 sibling of the species detail page and reuses the same selectors Ticket 1 builds.
 
-Recommendation: accept C1 and put it in Phase 2 ahead of verification. Verification
-(§15–§16) matters when accomplishments become public or competitive, and nothing is public
-until Phase 5.
+**ACCEPTED 2026-09-03** — the founder delegated the call. C1 enters **Phase 2, ahead of
+photo verification**. Verification (§15–§16) matters when accomplishments become public or
+competitive, and nothing is public until Phase 5; it is also blocked on the missing media
+table (§45.2), so it could not have gone first regardless.
+
+C1 is additionally the cheapest strong feature available right now: it reuses the Ticket 1
+selectors, needs no new table, no new dependency, and no new field on the catch flow. It is
+the only accepted item that addresses the **before** moment in §47.1.
+
+`docs/product/ROADMAP.md` Part 2C is annotated with this acceptance.
 
 ### 47.5 Do not quietly cut Boat Games
 

--- a/docs/specs/fishing-passport-wildlife-boat-games.md
+++ b/docs/specs/fishing-passport-wildlife-boat-games.md
@@ -2,7 +2,8 @@
 date: 2026-09-03 (founder spec received)
 status: PROPOSED — ready for technical planning (nothing implemented).
   Two blocking decisions resolved 2026-09-03 — see §45.1 (region: cut from Phase 1) and
-  §47.4 (ROADMAP C1 accepted into Phase 2). Media (§45.2) remains open.
+  §47.4 (ROADMAP C1 accepted into Phase 2). Media and Photo Journal I cut on cost
+  2026-09-03 — §45.2 carries what that removes from Phase 2.
 governs: (future) src/core/passport/, src/core/achievements/, src/core/identification/,
   src/core/games/, src/features/passport/, src/features/achievements/,
   src/features/wildlife/, src/features/boat-games/, src/app/passport/
@@ -1119,10 +1120,40 @@ That blocks, in Phase 1, the **Photo Journal I** badge (§12) and the species ph
 gallery (§9.2); and in Phase 2, verification levels 1 and 2 entirely (§15), since both are
 defined by attached media. Phase 3 wildlife photos and §17 Fin ID inherit the same gap.
 
-Recommendation: cut **Photo Journal I** from the Phase 1 catalog and leave the gallery as
-an empty state, rather than growing Phase 1 to include media capture, storage, EXIF
-stripping (ROADMAP A2 is explicit that the privacy half matters), size limits, and offline
-upload. Media is its own spec.
+**RESOLVED 2026-09-03 — the founder cut it, on cost.** Photo Journal I is removed from the
+badge catalog outright, and **no media table is scheduled.** This was a price decision, not
+a sequencing one: media means capture, storage, EXIF stripping (ROADMAP A2 is explicit that
+the privacy half is the point), size limits, offline upload, moderation before anything is
+public, and a recurring storage bill. None of that was going to be bought for one badge.
+
+Phase 1 is unaffected — it still ships seven badges on four rule shapes, because Photo
+Journal I was never among them. What this decides is **Phase 2**, and the consequences
+should be read now rather than discovered later:
+
+| Depends on media | Status while no media table exists |
+|---|---|
+| §12 Photo Journal I badge | **Cut.** Removed from the catalog |
+| §9.2 species photo gallery | **Cut.** The species page is text and numbers, and is still the Phase 1 hero without photos (§47.2) |
+| §15 verification **level 1** (photo supported) | **Unbuildable.** Defined as "original media attached" |
+| §15 verification **level 2** (metadata supported) | **Unbuildable.** Defined as photo plus metadata |
+| §16 photo policy | **Dormant.** Keep the text; it is the right policy for whenever media lands |
+| §27 game options "photo required" / "photo + host approval" | **Unavailable.** Honor system and host approval remain, which §27 already makes the casual default |
+| §29.5 `catch_verifications.evidence_media_ids`, §29.6 `identification_suggestions.media_id` | Columns presuppose media. Do not create them until it exists |
+
+So the §15 verification model reduces, for now, to **level 0 (self logged), level 3 (human
+verified), and level 4 (event verified)** — the two evidence levels in the middle are the
+ones that needed a photo. That is a coherent model, not a broken one: a captain confirming
+a fish is a stronger fact than a photograph anyway, and §4.3 already says self-logged
+catches count for the private passport, which is all Phase 1 needs.
+
+Two things are explicitly *not* cut:
+
+- **§17 Fin ID.** It is a trait-scoring engine — body shape, fin placement, coloration,
+  range, behavior — and answers from a questionnaire without a photograph. The existing
+  rockfish identifier already works this way. Photos would improve it; their absence does
+  not block it.
+- **The idea of photos.** This is "not now, and not for a badge," not "never." When media
+  is scheduled it gets its own spec, and §16 is already written for it.
 
 ### 45.3 `species` has no family or category column
 
@@ -1215,7 +1246,7 @@ already have a source column, and three of which are blocked on decisions in §4
 | Freshwater Explorer | D — count distinct species filtered by a species column | `species.water_class` + `trip.water_class` | **Ship** — see the `both` rule below |
 | Saltwater Explorer | D | `species.water_class` + `trip.water_class` | **Ship** — same rule |
 | New Waters I | E — count distinct regions | **None.** No region on a catch | **Cut from Phase 1** — §45.1 resolved: no region data to derive from |
-| Photo Journal I | F — count catches with attached media | **None.** No media table | **Cut from Phase 1** — blocked on §45.2 |
+| Photo Journal I | F — count catches with attached media | **None.** No media table | **CUT** — founder decision 2026-09-03, on cost. Not "deferred pending media"; removed from the catalog |
 | Night Bite | G — count catches passing a computed local-time test | `caught_at` + `lat`/`lng`, but needs a sunrise/sunset library. `astronomy-engine` is the cleared choice (SPEC.md O9); it is **not yet a dependency** | **Defer** — the only badge needing a new package |
 
 So Phase 1 ships **seven badges on four rules**, and the three that look like ordinary

--- a/docs/specs/fishing-passport-wildlife-boat-games.md
+++ b/docs/specs/fishing-passport-wildlife-boat-games.md
@@ -1141,3 +1141,118 @@ do.** `biostat` should say whether a unique-species count actually biases the ef
 denominator the correlation engine depends on, or whether the bias is confined to
 frequency-based mechanics such as streaks. That answer is worth having before the badge
 catalog is finalized, not after anglers have a year of history under it.
+
+## 47. Sequencing recommendation (added by `coo`, 2026-09-03)
+
+Advisory, not a change to the spec. Sections 1–43 stand as written and the founder
+overrules any of this at will. The purpose is to stop an implementing agent from reading
+the Phase 1 ticket list as eight equal buckets and the badge catalog as ten equal badges,
+because they are not.
+
+### 47.1 The frame: three moments, not one app
+
+Fishing is episodic. An angler fishes somewhere between twice and forty times a year, and
+the weather decides which. Any mechanic that assumes weekly opens is fighting the domain —
+which is the strongest argument against streaks, ahead of the data argument in §46.
+
+That leaves three moments where the app can earn an open:
+
+| Moment | What the app does today | What this spec adds |
+|---|---|---|
+| **Before** the trip — should I go, and where? | Tides. That is all. | **Nothing.** See §47.4. |
+| **During** the trip — logging, and the law | Strong. Fast catch flow, Fish Legal in hand | Boat games, later |
+| **After** the trip — what happened, what does it mean? | Almost nothing. There is no analytics surface in `src/app` | Passport. This is the gap it fills |
+
+Passport is worth building because it fills the **after** hole, not because it adds badges.
+Read the rest of this section through that.
+
+### 47.2 The Phase 1 hero is the species detail page, not the badge grid
+
+Ticket 4 (§9.2, `/passport/species/[speciesId]`) is the highest-value screen in this
+document. It is the first place the app pays an angler back for the work of logging:
+*23 calico bass, best 19 inches, mostly incoming tide at Rocky Point, mostly a green
+swimbait.* It works retroactively on catches already in the database, needs no new field
+on the catch flow, and is the smallest honest version of the correlation engine the whole
+product is premised on — one species, one angler, where a small sample is still readable.
+
+Build Tickets 1, 3, and 4 to a high finish. If Phase 1 has to be cut for time, cut
+depth from Ticket 5, not from Ticket 4.
+
+Its close second is the **uncaught silhouette** in §9. A grid with visible gaps is the
+strongest pull mechanic in the document, and unlike a badge it points at something real —
+a fish the angler has not caught, in the region they actually fish. It costs almost nothing
+on top of the grid Ticket 3 already builds. Do not drop the uncaught state to save time.
+
+### 47.3 The badge catalog is four rules, not ten badges
+
+The §12 catalog looks like ten units of work. It is four rule shapes, seven of which
+already have a source column, and three of which are blocked on decisions in §45.
+
+| Badge | Rule shape | Source available today | Verdict |
+|---|---|---|---|
+| First Catch | A — count valid catches | `catch` rows | **Ship** |
+| Species Explorer I / II / III | B — count distinct `species_id` | `catch.species_id` | **Ship** (one rule, three thresholds — near-free tiering) |
+| Responsible Release I | C — count catches filtered by a catch column | `catch.disposition = 'released'` | **Ship** |
+| Freshwater Explorer | D — count distinct species filtered by a species column | `species.water_class` | **Ship** — decide how `both` counts |
+| Saltwater Explorer | D | `species.water_class` | **Ship** — same decision |
+| New Waters I | E — count distinct regions | **None.** No region on a catch | **Defer** — blocked on §45.1 |
+| Photo Journal I | F — count catches with attached media | **None.** No media table | **Cut from Phase 1** — blocked on §45.2 |
+| Night Bite | G — count catches passing a computed local-time test | `caught_at` + `lat`/`lng`, but needs a sunrise/sunset library. `astronomy-engine` is the cleared choice (SPEC.md O9); it is **not yet a dependency** | **Defer** — the only badge needing a new package |
+
+So Phase 1 ships **seven badges on four rules**, and the three that look like ordinary
+catalog entries are the three that carry an architectural decision, a missing table, and a
+new dependency respectively. An agent that starts at the top of the §12 table and works
+down will hit all three blockers in the last 30% of the ticket.
+
+One addition worth making while the engine is being written, per §46: **an honest blank
+trip should count for something.** A logged trip with zero fish is the most statistically
+valuable record the product owns, and a passport that only lights up on a catch quietly
+teaches anglers not to record blanks. Rule shape A already covers it — count trips, not
+catches. This is precisely the mechanic ROADMAP Part 3 says is the only safe kind:
+rewarding an honestly confirmed trip rather than a bigger haul.
+
+### 47.4 The gap this spec does not fill, and should — Phase 2
+
+Every one of the 43 sections above is retrospective. Nothing here answers *"should I go
+tomorrow, and where?"* — the question that gets the app opened on a Thursday night by
+someone who is not fishing.
+
+`docs/product/ROADMAP.md` C1, **"Find days like today"** — search history for matching
+conditions — is the honest version of that, still unaccepted. The angler judges the match,
+so it makes no statistical promise the sample size cannot support. It is the natural
+sibling of the species detail page and reuses the same selectors Ticket 1 builds.
+
+Recommendation: accept C1 and put it in Phase 2 ahead of verification. Verification
+(§15–§16) matters when accomplishments become public or competitive, and nothing is public
+until Phase 5.
+
+### 47.5 Do not quietly cut Boat Games
+
+Worth stating because it is easy to lose as "the fun extra": **every other feature in this
+document is single-player.** A boat game is the only mechanic proposed anywhere that puts
+the app in front of people who do not have it — four anglers, one QR code, on a day they
+are already enjoying. It is also the hardest engineering here, and worthless before the
+core is good. Keep it at Phase 4, keep it on the roadmap, and do not let it fall off.
+
+### 47.6 Wildlife is the lowest leverage per unit of work
+
+Charming and genuinely differentiating, but Phase 3 asks for a new record type, a new
+identification engine, a new privacy and sensitivity model, and a new map layer, in
+exchange for something that does not bring an angler back next weekend. It is correctly
+placed after games in effort terms even though it is listed before them. If the calendar
+gets tight, this is the phase to slip.
+
+### 47.7 Revised Phase 1 ticket order
+
+Same eight tickets from §36, resequenced by value and unblocked-ness:
+
+1. **Ticket 1** — domain and selectors. Everything else depends on it.
+2. **Ticket 3** — My Species grid, uncaught silhouettes included.
+3. **Ticket 4** — species detail. *The hero. Finish this one properly.*
+4. **Ticket 2** — collections, family/habitat only. Geographic collections wait on §45.1.
+5. **Ticket 5** — badge engine, four rule shapes and seven badges, plus the blank-trip rule.
+6. **Tickets 6 and 7** — backfill and offline hardening, unchanged.
+7. **Ticket 8** — QA and rollout behind `passport_v1`, unchanged.
+
+Blocked before code starts: the region ruling (§45.1) gates part of Ticket 2 and one badge;
+the media decision (§45.2) removes one badge from Ticket 5.

--- a/docs/team/channel/2026-09-03-01-coo-to-architect-ceo-biostat.md
+++ b/docs/team/channel/2026-09-03-01-coo-to-architect-ceo-biostat.md
@@ -1,0 +1,25 @@
+### 2026-09-03 | coo -> architect, ceo, biostat
+
+A new founder spec landed: `docs/specs/fishing-passport-wildlife-boat-games.md` (Fishing
+Passport, badges, wildlife sightings, Fin ID, boat games). Nothing is built; Phase 1 is
+Passport + My Species + starter badges. `docs/specs/README.md` now indexes every spec, and
+`ROADMAP.md` Part 3 is annotated where this spec reverses it.
+
+Three things need you before any Phase 1 code, all written up in that spec's §45–§46:
+
+**`architect`** — the spec needs a fishing region on a catch in four places, and
+`src/core/ontology/regions.ts` says flatly that "no region is part of the data model"
+(ADR 007 §4, founder requirement 2026-09-01 #4). Derive it from `lat`/`lng` at read time,
+snapshot the preference at log time, or cut geographic collections from Phase 1 — my order
+of preference is exactly that, but option 2 reverses a stated principle, so it is yours.
+
+**`ceo`** — there is no media table in the schema, so the Photo Journal I badge and the
+species photo gallery have no source, and verification levels 1–2 (Phase 2) are blocked
+outright. I recommend cutting Photo Journal I from Phase 1 rather than growing Phase 1 to
+include capture, storage, EXIF stripping, and offline upload. Media wants its own spec.
+
+**`biostat`** — ROADMAP Part 3 kills gamification because it biases the effort denominator.
+The spec answers most of that itself (no streaks, no blocking, no rewarding retention), but
+Species Explorer I–III and Species Sprint still reward catching more. Does a unique-species
+count actually bias the denominator the correlation engine depends on, or is that risk
+confined to frequency mechanics like streaks? Worth settling before the catalog is fixed.

--- a/docs/team/channel/2026-09-03-02-coo-to-ceo-ux-ui.md
+++ b/docs/team/channel/2026-09-03-02-coo-to-ceo-ux-ui.md
@@ -1,0 +1,21 @@
+### 2026-09-03 | coo -> ceo, ux-ui
+
+Added a sequencing recommendation as §47 of `docs/specs/fishing-passport-wildlife-boat-games.md`.
+Two things in it need you specifically.
+
+**`ux-ui`** — the Phase 1 hero is the species detail page (§9.2), not the badge grid. It is
+the first screen that pays an angler back for logging, and it works on catches already in
+the database. Spend the design effort there and on the uncaught silhouettes in the grid;
+the badge surface can be plain. If Phase 1 gets cut for time, cut badge depth, not that page.
+
+**`ceo`** — a scope call. Nothing in the founder's 43 sections answers "should I go
+tomorrow, and where?", which is the only question that gets the app opened by someone who
+is not currently fishing. ROADMAP C1 ("find days like today") is the honest version and is
+still sitting unaccepted in Part 2. I recommend accepting it into Phase 2 ahead of photo
+verification — verification only earns its keep once accomplishments are public, and
+nothing is public until Phase 5. Your call, not mine.
+
+Also worth knowing before anyone estimates: the §12 badge catalog is four rule shapes, not
+ten badges. Seven ship on existing columns; the other three are each blocked on something
+real (no region on a catch, no media table, a sunrise library that is not yet a dependency).
+The table is in §47.3.

--- a/docs/team/channel/2026-09-03-03-coo-to-all.md
+++ b/docs/team/channel/2026-09-03-03-coo-to-all.md
@@ -1,0 +1,25 @@
+### 2026-09-03 | coo -> all
+
+Two decisions that were blocking Phase 1 of `docs/specs/fishing-passport-wildlife-boat-games.md`
+are now resolved. The founder delegated both calls; either can be reopened by them.
+
+**1. Region stays out of the data model. Geographic collections are cut from Phase 1.**
+(§45.1.) `architect` — please review, but nothing is waiting on you. The deciding fact:
+`reg_area.boundary_geojson` is effectively unpopulated and `RegionId` in
+`src/core/ontology/regions.ts` has no geometry, so "derive region from the catch's GPS"
+has nothing to derive from. It is a polygon-sourcing project with a Fish-Legal-grade
+verification burden, not a read-time computation. Snapshotting the Settings preference onto
+the catch was rejected on merit — it records where someone *says* they fish, so a SoCal
+angler running to Cabo gets mislabeled — and it would have reversed ADR 007 §4 to buy one
+badge. Out of Phase 1: geographic collections, the region progress card, the region filter,
+and the **New Waters I** badge. Revisit in Phase 2 if region polygons ever become real data.
+
+**2. ROADMAP C1 "find days like today" is accepted into Phase 2**, ahead of photo
+verification (§47.4). It is the only accepted work that answers "should I go tomorrow" —
+the moment the product currently has nothing for. It reuses the Ticket 1 selectors and needs
+no new table, dependency, or catch field. Verification could not have gone first anyway;
+it is blocked on the missing media table.
+
+**Still open, and it is `ceo`'s:** whether a media table gets scheduled at all (§45.2).
+Until it does, Photo Journal I and the photo gallery stay cut and Phase 2 verification
+cannot start.

--- a/docs/team/channel/2026-09-03-04-coo-to-all.md
+++ b/docs/team/channel/2026-09-03-04-coo-to-all.md
@@ -1,0 +1,26 @@
+### 2026-09-03 | coo -> all
+
+**Photos are cut, and no media table is scheduled.** Founder decision 2026-09-03, on cost.
+Written up in §45.2 of `docs/specs/fishing-passport-wildlife-boat-games.md`; ROADMAP A2 is
+annotated to match.
+
+Phase 1 is unaffected — still seven badges on four rule shapes, since Photo Journal I was
+never among them. The effect is on **Phase 2**, and it is worth reading before anyone plans
+that work: verification levels 1 (photo supported) and 2 (metadata supported) are both
+defined as "media attached", so they are unbuildable. The §15 model reduces to level 0
+self-logged, level 3 human-verified, level 4 event-verified. That is coherent — a captain
+confirming a fish is a stronger fact than a photograph — and §4.3 already says self-logged
+catches count toward the private passport, which is all Phase 1 needs.
+
+`head-dev` — do **not** create `catch_verifications.evidence_media_ids` or
+`identification_suggestions.media_id` (§29.5, §29.6). Those columns presuppose a table that
+is not coming.
+
+`ux-ui` — the species detail page has no photo gallery. It is text and numbers, and it is
+still the Phase 1 hero without them (§47.2). Design it that way rather than leaving a
+placeholder.
+
+Not cut: **Fin ID** (§17). It scores observed traits — body shape, fin placement, coloration,
+range, behavior — and answers from a questionnaire without a photograph, exactly as the
+existing rockfish identifier already does. Photos would improve it; their absence does not
+block it.

--- a/docs/team/worklog/2026-09-03-06-coo.md
+++ b/docs/team/worklog/2026-09-03-06-coo.md
@@ -1,0 +1,15 @@
+### 2026-09-03 | coo | 15m
+
+- The founder sent a large idea document covering four future features: a Fishing
+  Passport that turns your catch history into a species collection, badges and proof
+  levels for catches, a log for whale and other wildlife sightings, and friendly
+  fishing games played between people on the same boat.
+- Filed it as a written specification so it stops living in a chat message. Nothing was
+  built and no existing screen changed — this is a plan on paper only.
+- The document keeps the founder's own phasing: the Passport and a small set of starter
+  badges come first; photo proof, wildlife, and the boat games come later, each behind
+  its own on/off switch.
+- File: docs/specs/fishing-passport-wildlife-boat-games.md
+- Next: nobody has costed this yet. Before any code, the architect should confirm the
+  Passport really can be computed from the existing catch records without a second catch
+  table, and the CEO should confirm the four families are still wanted in this order.

--- a/docs/team/worklog/2026-09-03-07-coo.md
+++ b/docs/team/worklog/2026-09-03-07-coo.md
@@ -1,0 +1,31 @@
+### 2026-09-03 | coo | 35m
+
+- Made yesterday's new idea document findable instead of leaving it as a file only
+  someone who already knew the path could reach.
+- Added a contents page for the specs folder: every specification, its status, and one
+  line on what it covers, plus the rules for adding the next one.
+- Checked the new plan against what the app actually has today. Most of it lines up
+  better than expected — the catch record already knows the species, whether the fish was
+  kept or released, its length and weight, whether the record was a quick mark that was
+  later confirmed, and which trip it belonged to. The species list already flags
+  protected fish and salt versus fresh. So the collection can be built from records we
+  already have, with no second catch list.
+- Found three things that cannot be built as written, and wrote them into the document so
+  nobody discovers them halfway through:
+  1. The app deliberately does not record which region a catch happened in. Four parts of
+     the new plan need it. Three ways out are written up; the architect has to choose,
+     because one of them reverses a decision the founder made on 1 September.
+  2. There is nowhere to store a photo. No photo table exists. That blocks the photo
+     badge and the photo gallery now, and the whole "proof" idea later.
+  3. The species list has no notion of a fish family, so family collections need to come
+     from the new collection data rather than a new column.
+- The roadmap has a section listing badges and leaderboards as things we deliberately
+  would not build. The new founder document proposes badges, so I marked those entries as
+  revisited rather than quietly leaving the two documents contradicting each other. The
+  old objection — that rewarding people for logging spoils the honesty of the log — is
+  mostly answered by the new document itself. One piece is not, and I asked the
+  statistician for a straight answer on it.
+- Files: docs/specs/README.md, docs/specs/fishing-passport-wildlife-boat-games.md,
+  docs/product/ROADMAP.md, docs/team/channel/2026-09-03-01-coo-to-architect-ceo-biostat.md
+- Next: still nobody has ruled on the region question, and it blocks two of the eight
+  Phase 1 tickets. Nothing should be coded until that comes back.

--- a/docs/team/worklog/2026-09-03-08-coo.md
+++ b/docs/team/worklog/2026-09-03-08-coo.md
@@ -1,0 +1,25 @@
+### 2026-09-03 | coo | 30m
+
+- The founder asked which parts of the new passport plan would actually add value, so I
+  wrote the answer into the plan itself as a new section rather than leaving it in a chat.
+- The main point: the app is good at the moment you are on the water and has almost
+  nothing for the moment after you get home, or the evening before you go. The passport
+  fills the "after" hole. That is why it is worth building — not because of badges.
+- Named the single most valuable screen: the page for one fish species, showing how many
+  you have caught, your biggest, where and when they came, and what you caught them on.
+  It works on records people already have. If time runs short, that page keeps its polish
+  and the badges lose theirs.
+- Took apart the badge list. It reads like ten pieces of work; it is really four patterns,
+  seven of which can be built today. The other three each hide a problem: one needs a
+  decision about regions nobody has made, one needs somewhere to store photos which does
+  not exist, and one needs a sunrise-and-sunset library we have not installed. Anyone
+  working top-to-bottom down that list would have hit all three at the very end.
+- Flagged that nothing in the whole plan helps someone decide whether to go fishing
+  tomorrow. There is an old unaccepted idea on the roadmap that does exactly that; asked
+  the CEO to consider it for the second phase.
+- Also said plainly that the boat games are the only part of this that could bring in new
+  users, and that the wildlife log — while lovely — buys the least for the effort.
+- Files: docs/specs/fishing-passport-wildlife-boat-games.md, docs/specs/README.md,
+  docs/team/channel/2026-09-03-02-coo-to-ceo-ux-ui.md
+- Next: two decisions are still open and both block work — the region question for the
+  architect, and whether to accept the "days like today" idea for the CEO.

--- a/docs/team/worklog/2026-09-03-09-coo.md
+++ b/docs/team/worklog/2026-09-03-09-coo.md
@@ -1,0 +1,24 @@
+### 2026-09-03 | coo | 25m
+
+- The founder handed me the two decisions that were holding up the passport work, so I
+  made them and wrote both into the plan with the reasoning, so nobody has to guess later.
+- **Regions are out of the first phase.** Before deciding I checked whether the database
+  actually knows the shape of a fishing region. It does not — there is a field for map
+  boundaries but almost nothing in it, and the region list is just labels. So working out
+  which region a fish was caught in is not a quick calculation; it is a project to draw
+  and verify boundaries for every region. The alternative — stamping whichever region the
+  angler picked in Settings onto the catch — records where someone says they fish, not
+  where they were, so a Southern California user on a trip to Cabo would get wrong data
+  forever. Dropped the region parts of phase one instead. Nothing is lost permanently.
+- This reverses what I told the founder earlier today. I had listed deriving-from-GPS as
+  my preferred option before checking whether the map data existed. It does not.
+- **Accepted an older idea off the roadmap:** "find days like today", which searches your
+  own history for trips with similar conditions. Everything in the new plan looks
+  backwards at what you did; nothing helps you decide whether to go tomorrow. This is the
+  cheapest thing that does, and it reuses work already planned for phase one.
+- One decision still open and it belongs to the CEO: whether we ever build somewhere to
+  store photos. Until that happens the photo badge and the photo gallery stay cut, and the
+  whole "proof" idea in phase two cannot start.
+- Files: docs/specs/fishing-passport-wildlife-boat-games.md, docs/product/ROADMAP.md,
+  docs/team/channel/2026-09-03-03-coo-to-all.md
+- Next: phase one is now unblocked and can be built. Seven badges, not ten.

--- a/docs/team/worklog/2026-09-03-10-coo.md
+++ b/docs/team/worklog/2026-09-03-10-coo.md
@@ -1,0 +1,19 @@
+### 2026-09-03 | coo | 15m
+
+- The founder cut photos on cost. Recorded it properly rather than just deleting one badge.
+- The badge itself was already out of the first phase, so nothing changes there — still
+  seven badges. What this really decides is the second phase, so I wrote down what it takes
+  with it: the "photo attached" and "photo with matching time and place" levels of proof
+  both disappear, because both were defined as having a photo.
+- That leaves three kinds of proof: you said so, a captain or reviewer confirmed it, or a
+  tournament confirmed it. That is a sound ladder, not a broken one — a captain vouching
+  for a fish is worth more than a photograph anyway.
+- Told the developer not to build the two photo-shaped database columns, and the designer
+  that the species page has no gallery and should be designed as text and numbers rather
+  than with a hole in it.
+- Made a point of protecting the fish identification feature, which people will assume died
+  with this. It did not: it works by asking about the fish's shape, fins, and colouring, the
+  way the rockfish tool already does. It never needed a camera.
+- Files: docs/specs/fishing-passport-wildlife-boat-games.md, docs/product/ROADMAP.md,
+  docs/team/channel/2026-09-03-04-coo-to-all.md
+- Next: phase one has no open questions left. It can be built.

--- a/docs/team/worklog/2026-09-03-11-head-dev.md
+++ b/docs/team/worklog/2026-09-03-11-head-dev.md
@@ -1,0 +1,31 @@
+### 2026-09-03 | head-dev | 2h
+
+- Built the first phase of the Fishing Passport. It is live behind a switch and reachable
+  from Settings; nothing that already existed changed behaviour.
+- What an angler gets: a page showing every species they have caught and every one they
+  have not, filters for water and family, a page for each fish with their totals, biggest
+  by length and by weight, first and latest, and every catch of it, and eight badges.
+- The important part is that it is all worked out from catches people have already
+  logged. There is no new question at the water, no new box to tick, and nothing to
+  back-fill. Someone with three years of history opens it and it is already full.
+- The rules are written as plain functions with no screen or database attached, and they
+  are checked against a file of worked examples — the same file a future iPhone app can be
+  checked against, so the two can never quietly disagree about what counts.
+- Things I made sure of: an unfinished quick mark is not a fish yet, and finishing one
+  later does not count it twice; deleting a catch takes its credit away again; catching
+  the same fish twice does not make it two species; and logging "rockfish" when you cannot
+  tell which rockfish keeps the individual slot open.
+- No badge can ever require a protected fish. That falls out of the data rather than being
+  remembered by hand — a fish marked protected is shown in its family, labelled, and left
+  out of the count.
+- Added one badge that was not in the founder's list: finishing five trips, fish or no
+  fish. A blank day is the most valuable record the app collects and the passport should
+  not quietly teach people to stop recording them.
+- Looked at all five screens in a real browser at the width of a small phone. Fixed the
+  filters, which were pushing every fish off the bottom of the screen. Screens were viewed
+  with an empty log; the counting itself is covered by the worked examples, not by clicking.
+- Checks: tokens, tripwires, lint, types, 513 tests, production build. All pass.
+- Files: src/core/rules/passport/, src/core/rules/achievements/, src/features/passport/,
+  src/app/(app)/passport/, src/app/(app)/settings/page.tsx, two vector files.
+- Next: nobody has used this with a real log yet. The sensible next step is one angler
+  with real history opening it and saying whether the species page tells them anything.

--- a/src/app/(app)/passport/badges/page.tsx
+++ b/src/app/(app)/passport/badges/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { BadgeList } from "@/features/passport/components/badge-list";
+import { PASSPORT_V1 } from "@/features/passport/flag";
+
+export const metadata: Metadata = { title: "Badges | Fish Log Book" };
+
+export default function BadgesPage() {
+  if (!PASSPORT_V1) notFound();
+  return <BadgeList />;
+}

--- a/src/app/(app)/passport/collections/[collectionId]/page.tsx
+++ b/src/app/(app)/passport/collections/[collectionId]/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { CollectionDetail } from "@/features/passport/components/collection-detail";
+import { PASSPORT_V1 } from "@/features/passport/flag";
+
+type Params = Promise<{ collectionId: string }>;
+
+export const metadata: Metadata = { title: "Collection | Fish Log Book" };
+
+export default async function CollectionPage({ params }: { params: Params }) {
+  if (!PASSPORT_V1) notFound();
+  const { collectionId } = await params;
+  return <CollectionDetail collectionId={collectionId} />;
+}

--- a/src/app/(app)/passport/page.tsx
+++ b/src/app/(app)/passport/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { PassportOverview } from "@/features/passport/components/passport-overview";
+import { PASSPORT_V1 } from "@/features/passport/flag";
+
+export const metadata: Metadata = { title: "Passport | Fish Log Book" };
+
+/**
+ * /passport — the overview (spec §8.1, §8.2).
+ *
+ * Reached from Settings and from a species, deliberately not from the nav bar: spec §8.1
+ * keeps Phase 1 out of the six-destination bar, and `shell-nav.test.ts` pins that count so
+ * a seventh tab needs a decision rather than a patch.
+ */
+export default function PassportPage() {
+  if (!PASSPORT_V1) notFound();
+  return <PassportOverview />;
+}

--- a/src/app/(app)/passport/species/[speciesId]/page.tsx
+++ b/src/app/(app)/passport/species/[speciesId]/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { SpeciesDetail } from "@/features/passport/components/species-detail";
+import { PASSPORT_V1 } from "@/features/passport/flag";
+
+type Params = Promise<{ speciesId: string }>;
+
+export const metadata: Metadata = { title: "Species | Fish Log Book" };
+
+/**
+ * One species, for one angler (spec §9.2).
+ *
+ * An unknown id renders an honest "not in the vocabulary" rather than a 404, matching the
+ * catch detail route: the species may simply be newer than this device's copy.
+ */
+export default async function PassportSpeciesPage({ params }: { params: Params }) {
+  if (!PASSPORT_V1) notFound();
+  const { speciesId } = await params;
+  return <SpeciesDetail speciesId={speciesId} unitSystem="imperial" />;
+}

--- a/src/app/(app)/passport/species/page.tsx
+++ b/src/app/(app)/passport/species/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { SpeciesGrid } from "@/features/passport/components/species-grid";
+import { PASSPORT_V1 } from "@/features/passport/flag";
+
+export const metadata: Metadata = { title: "My Species | Fish Log Book" };
+
+export default function MySpeciesPage() {
+  if (!PASSPORT_V1) notFound();
+
+  return (
+    <div className="flex flex-col gap-4">
+      <nav>
+        <Link
+          href="/passport"
+          className="inline-flex min-h-touch-floor items-center text-label text-text-link focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+        >
+          ← Passport
+        </Link>
+      </nav>
+      <h1 className="text-h1">My Species</h1>
+      <SpeciesGrid />
+    </div>
+  );
+}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
+import { PASSPORT_V1 } from "@/features/passport/flag";
 import { BackendDiagnostics } from "@/features/settings/components/backend-diagnostics";
 import { QuickMarkToggle } from "@/features/settings/components/quick-mark-toggle";
 import { RegionSelect } from "@/features/settings/components/region-select";
@@ -17,6 +18,27 @@ export default function SettingsPage() {
           Account and the platform selector (D26) land with the rest of the settings feature.
         </p>
       </section>
+
+      {/*
+        Passport's entry point. Spec §8.1 keeps it out of the nav bar in Phase 1 — the bar
+        is full at six and `shell-nav.test.ts` pins that — so it is reached from here, and
+        from a species' own page.
+      */}
+      {PASSPORT_V1 ? (
+        <section className="rounded-lg border border-hairline bg-surface p-4">
+          <h2 className="text-h3">Passport</h2>
+          <p className="mt-2 text-body text-text-muted">
+            Every species you have caught, your personal bests, and how far along each family is.
+            Built from catches you have already logged.
+          </p>
+          <Link
+            href="/passport"
+            className="mt-4 inline-flex min-h-touch-floor items-center justify-center rounded-md border border-border-interactive px-4 text-label text-text-link transition-colors hover:bg-surface-raised focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring active:scale-95 motion-reduce:transition-none"
+          >
+            Open Passport
+          </Link>
+        </section>
+      ) : null}
 
       <section className="rounded-lg border border-hairline bg-surface p-4">
         <h2 className="text-h3">Tackle</h2>

--- a/src/core/rules/achievements/catalog.ts
+++ b/src/core/rules/achievements/catalog.ts
@@ -1,0 +1,118 @@
+/**
+ * The Phase 1 badge catalog (passport spec §12, as trimmed by §47.3).
+ *
+ * Seven of the founder's ten ship here. The three that do not are not oversights:
+ *
+ * - **New Waters I** needs a fishing region on a catch. There is none, and no geometry to
+ *   derive one from — §45.1 cut it from Phase 1.
+ * - **Photo Journal I** was cut on cost with the media table (§45.2).
+ * - **Night Bite** needs a sunrise/sunset library that is not yet a dependency (§47.3).
+ *   `src/core/rules/astro/` can already do the arithmetic; wiring it is a later slice.
+ *
+ * The eighth badge here is not the founder's — **Days on the Water** is the blank-trip
+ * rule from §46, added so an honest fishless day is worth recording.
+ *
+ * No streak badges, ever (spec §12): weather decides whether an angler fishes this week,
+ * and a mechanic that punishes a blown-out weekend is a mechanic that teaches people to
+ * stop logging.
+ */
+
+import type { BadgeDefinition } from "./types";
+
+export const BADGE_RULE_VERSION = 1;
+
+const badge = (
+  definition: Omit<BadgeDefinition, "slug" | "ruleVersion" | "active">,
+): BadgeDefinition => ({
+  ...definition,
+  slug: definition.id,
+  ruleVersion: BADGE_RULE_VERSION,
+  active: true,
+});
+
+export const BADGES: readonly BadgeDefinition[] = [
+  badge({
+    id: "first-catch",
+    name: "First catch",
+    description: "Log your first fish.",
+    category: "milestone",
+    tier: 1,
+    ruleType: "catch_count",
+    ruleConfig: { threshold: 1 },
+    iconKey: "hook",
+  }),
+  badge({
+    id: "species-explorer-i",
+    name: "Species Explorer I",
+    description: "Catch 5 different species.",
+    category: "exploration",
+    tier: 1,
+    ruleType: "unique_species",
+    ruleConfig: { threshold: 5 },
+    iconKey: "compass",
+  }),
+  badge({
+    id: "species-explorer-ii",
+    name: "Species Explorer II",
+    description: "Catch 10 different species.",
+    category: "exploration",
+    tier: 2,
+    ruleType: "unique_species",
+    ruleConfig: { threshold: 10 },
+    iconKey: "compass",
+  }),
+  badge({
+    id: "species-explorer-iii",
+    name: "Species Explorer III",
+    description: "Catch 25 different species.",
+    category: "exploration",
+    tier: 3,
+    ruleType: "unique_species",
+    ruleConfig: { threshold: 25 },
+    iconKey: "compass",
+  }),
+  badge({
+    id: "freshwater-explorer",
+    name: "Freshwater Explorer",
+    description: "Catch 5 different freshwater species.",
+    category: "exploration",
+    tier: 1,
+    ruleType: "unique_species_in_water",
+    ruleConfig: { threshold: 5, waterClass: "fresh" },
+    iconKey: "river",
+  }),
+  badge({
+    id: "saltwater-explorer",
+    name: "Saltwater Explorer",
+    description: "Catch 10 different saltwater species.",
+    category: "exploration",
+    tier: 1,
+    ruleType: "unique_species_in_water",
+    ruleConfig: { threshold: 10, waterClass: "salt" },
+    iconKey: "wave",
+  }),
+  badge({
+    id: "responsible-release-i",
+    name: "Responsible Release I",
+    description: "Release 10 fish.",
+    category: "stewardship",
+    tier: 1,
+    ruleType: "released_count",
+    ruleConfig: { threshold: 10 },
+    iconKey: "release",
+  }),
+  badge({
+    id: "days-on-the-water-i",
+    name: "Days on the Water I",
+    description: "Finish 5 trips. Blank days count — they are still fishing.",
+    category: "stewardship",
+    tier: 1,
+    ruleType: "trip_count",
+    ruleConfig: { threshold: 5 },
+    iconKey: "boat",
+  }),
+];
+
+export function badgeById(id: string): BadgeDefinition | null {
+  return BADGES.find((b) => b.id === id) ?? null;
+}

--- a/src/core/rules/achievements/evaluate.test.ts
+++ b/src/core/rules/achievements/evaluate.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+
+import vectors from "../vectors/achievements.json";
+import type { CatchRecord, Disposition, Outcome, ResolutionState, TripRecord } from "../catch/types";
+import { BADGES, badgeById } from "./catalog";
+import { evaluateBadge, evaluateBadges, newlyEarned, type EvaluationInput } from "./evaluate";
+
+interface VectorCatch {
+  id: string;
+  species: string | null;
+  at: string;
+  disposition?: string | null;
+  state?: string;
+  outcome?: string;
+  deleted?: boolean;
+}
+
+interface VectorTrip {
+  id: string;
+  started: string;
+  ended?: string;
+  open?: boolean;
+  deleted?: boolean;
+}
+
+function expandCatch(v: VectorCatch): CatchRecord {
+  return {
+    id: v.id,
+    angler_id: "angler",
+    trip_id: "trip",
+    caught_at: v.at,
+    caught_tz: "America/Los_Angeles",
+    local_date: v.at.slice(0, 10),
+    lat: null,
+    lng: null,
+    gps_accuracy_m: null,
+    resolution_state: (v.state ?? "confirmed") as ResolutionState,
+    dismissed_reason: null,
+    resolved_at: null,
+    species_id: v.species,
+    species_other: null,
+    outcome: (v.outcome ?? "landed") as Outcome,
+    disposition: (v.disposition ?? null) as Disposition | null,
+    quantity: 1,
+    length_mm: null,
+    weight_g: null,
+    size_estimated: false,
+    spot_id: null,
+    platform: null,
+    depth_fished_m: null,
+    rig_id: null,
+    rig_revision: null,
+    rig_slot: null,
+    inherited_fields: [],
+    location_condition_id: null,
+    location_name: null,
+    current_term: null,
+    current_strength: null,
+    structure_type_ids: [],
+    bottom_depth_m: null,
+    water_color_id: null,
+    water_clarity_id: null,
+    presentation: null,
+    notes: null,
+    tags: [],
+    favorite: false,
+    regulation_snapshot: null,
+    capture_mode: "live",
+    client_created_at: v.at,
+    created_at: v.at,
+    client_updated_at: v.at,
+    deleted_at: v.deleted === true ? v.at : null,
+  };
+}
+
+function expandTrip(v: VectorTrip): TripRecord {
+  return {
+    id: v.id,
+    angler_id: "angler",
+    spot_id: null,
+    water_class: "salt",
+    started_at: v.started,
+    started_tz: "America/Los_Angeles",
+    ended_at: v.open === true ? null : (v.ended ?? null),
+    ended_tz: null,
+    local_date: v.started.slice(0, 10),
+    platform: null,
+    notes: null,
+    capture_mode: "live",
+    client_created_at: v.started,
+    created_at: v.started,
+    client_updated_at: v.started,
+    deleted_at: v.deleted === true ? v.started : null,
+  };
+}
+
+const WATER = vectors.waterClass as Record<string, "salt" | "fresh">;
+
+function inputFor(catches: VectorCatch[], trips: VectorTrip[]): EvaluationInput {
+  return {
+    catches: catches.map(expandCatch),
+    trips: trips.map(expandTrip),
+    knownSpeciesIds: new Set(Object.keys(WATER)),
+    waterClassOf: (id) => WATER[id] ?? null,
+  };
+}
+
+describe("badge evaluation", () => {
+  for (const vector of vectors.cases) {
+    it(vector.name, () => {
+      const definition = badgeById(vector.badge);
+      expect(definition).not.toBeNull();
+
+      const standing = evaluateBadge(definition!, inputFor(vector.catches, vector.trips));
+      expect(standing.earned).toBe(vector.expect.earned);
+      expect(standing.current).toBe(vector.expect.current);
+      expect(standing.threshold).toBe(vector.expect.threshold);
+      expect(standing.awardedAt).toBe(vector.expect.awardedAt);
+      expect(standing.qualifyingSourceIds).toEqual(vector.expect.sources);
+    });
+  }
+
+  it("re-running produces an identical result — no duplicate awards (spec §13, §37)", () => {
+    const vector = vectors.cases[3];
+    const input = inputFor(vector.catches, vector.trips);
+    expect(evaluateBadges(BADGES, input)).toEqual(evaluateBadges(BADGES, input));
+  });
+
+  it("does not care what order the records arrive in, which is what makes sync merges safe", () => {
+    const vector = vectors.cases[3];
+    const forwards = inputFor(vector.catches, vector.trips);
+    const backwards = inputFor([...vector.catches].reverse(), [...vector.trips].reverse());
+    expect(evaluateBadges(BADGES, backwards)).toEqual(evaluateBadges(BADGES, forwards));
+  });
+
+  it("revokes an award when its only qualifying catch is deleted (spec §13)", () => {
+    const earned = evaluateBadge(badgeById("first-catch")!, inputFor(
+      [{ id: "c1", species: "kelp_bass", at: "2026-03-01T14:00:00.000Z" }], [],
+    ));
+    expect(earned.earned).toBe(true);
+
+    const revoked = evaluateBadge(badgeById("first-catch")!, inputFor(
+      [{ id: "c1", species: "kelp_bass", at: "2026-03-01T14:00:00.000Z", deleted: true }], [],
+    ));
+    expect(revoked.earned).toBe(false);
+    expect(revoked.awardedAt).toBeNull();
+  });
+
+  it("keeps the award's real date, not the moment it was evaluated", () => {
+    const standing = evaluateBadge(badgeById("first-catch")!, inputFor(
+      [{ id: "c1", species: "kelp_bass", at: "2020-07-04T14:00:00.000Z" }], [],
+    ));
+    expect(standing.awardedAt).toBe("2020-07-04T14:00:00.000Z");
+  });
+});
+
+describe("newlyEarned", () => {
+  it("reports only what crossed the line on this save (spec §14)", () => {
+    const before = evaluateBadges(BADGES, inputFor([], []));
+    const after = evaluateBadges(BADGES, inputFor(
+      [{ id: "c1", species: "kelp_bass", at: "2026-03-01T14:00:00.000Z" }], [],
+    ));
+
+    const fresh = newlyEarned(before, after);
+    expect(fresh.map((s) => s.badgeId)).toEqual(["first-catch"]);
+  });
+
+  it("stays silent when nothing changed, so no modal stacks on a repeat catch", () => {
+    const standing = evaluateBadges(BADGES, inputFor(
+      [{ id: "c1", species: "kelp_bass", at: "2026-03-01T14:00:00.000Z" }], [],
+    ));
+    expect(newlyEarned(standing, standing)).toEqual([]);
+  });
+});
+
+describe("the catalog", () => {
+  it("ships eight badges on five rule shapes (spec §47.3 plus the blank-trip rule)", () => {
+    expect(BADGES).toHaveLength(8);
+    expect(new Set(BADGES.map((b) => b.ruleType)).size).toBe(5);
+  });
+
+  it("has no streak badge, and never will (spec §12)", () => {
+    for (const badge of BADGES) {
+      expect(badge.ruleType).not.toContain("streak");
+      expect(badge.description.toLowerCase()).not.toContain("streak");
+    }
+  });
+
+  it("rewards an honest blank day, which is what ROADMAP Part 3 asked for", () => {
+    const trips = badgeById("days-on-the-water-i");
+    expect(trips?.ruleType).toBe("trip_count");
+
+    // Five finished trips, not one fish between them.
+    const standing = evaluateBadge(trips!, inputFor([], [
+      { id: "t1", started: "2026-03-01T06:00:00.000Z", ended: "2026-03-01T12:00:00.000Z" },
+      { id: "t2", started: "2026-03-08T06:00:00.000Z", ended: "2026-03-08T12:00:00.000Z" },
+      { id: "t3", started: "2026-03-15T06:00:00.000Z", ended: "2026-03-15T12:00:00.000Z" },
+      { id: "t4", started: "2026-03-22T06:00:00.000Z", ended: "2026-03-22T12:00:00.000Z" },
+      { id: "t5", started: "2026-03-29T06:00:00.000Z", ended: "2026-03-29T12:00:00.000Z" },
+    ]));
+    expect(standing.earned).toBe(true);
+  });
+
+  it("carries no badge that needs a photo, a region, or a package we do not have", () => {
+    const ids = BADGES.map((b) => b.id);
+    expect(ids).not.toContain("photo-journal-i");
+    expect(ids).not.toContain("new-waters-i");
+    expect(ids).not.toContain("night-bite");
+  });
+});

--- a/src/core/rules/achievements/evaluate.ts
+++ b/src/core/rules/achievements/evaluate.ts
@@ -1,0 +1,143 @@
+/**
+ * Badge evaluation (passport spec §13).
+ *
+ * Deterministic and idempotent by construction: this is a pure function of the records
+ * handed in, with no stored progress to reconcile. Running it twice cannot award twice,
+ * an edit or a delete recalculates rather than patches, and a sync merge is just another
+ * evaluation over the merged set — which is spec §13's whole list of requirements met by
+ * not keeping state rather than by defending it.
+ *
+ * The client may run this offline for immediate feedback; the server runs the same rules
+ * over the reconciled log and its answer wins (spec §13, §31).
+ */
+
+import { isCountable } from "../catch/rules";
+import type { CatchRecord, TripRecord } from "../catch/types";
+import type { BadgeDefinition, BadgeStanding } from "./types";
+
+export interface EvaluationInput {
+  readonly catches: readonly CatchRecord[];
+  readonly trips: readonly TripRecord[];
+  readonly knownSpeciesIds: ReadonlySet<string>;
+  /**
+   * Water class per species id. Absent ids simply never match, which is the safe
+   * direction: a species we cannot classify does not silently credit either explorer.
+   *
+   * The SQL vocabulary allows a third value, `both`, that the TypeScript ontology does not
+   * yet express. If it ever lands, spec §47.3 resolves it from `trip.water_class` — the
+   * water the angler was actually in — rather than from the species.
+   */
+  readonly waterClassOf: (speciesId: string) => "salt" | "fresh" | null;
+}
+
+/** Chronological, ties broken on id. UUIDv7 ids are time-ordered, so this is stable. */
+function chronological<T extends { id: string }>(records: readonly T[], at: (r: T) => string): T[] {
+  return [...records].sort((a, b) => {
+    const delta = Date.parse(at(a)) - Date.parse(at(b));
+    if (Number.isNaN(delta)) return a.id < b.id ? -1 : 1;
+    return delta === 0 ? (a.id < b.id ? -1 : 1) : delta;
+  });
+}
+
+/**
+ * A trip that counts (the §46 blank-trip rule).
+ *
+ * Not deleted, and ended — the angler closed it out rather than leaving it open on the
+ * dashboard. Whether it produced a fish is deliberately not asked.
+ */
+function tripCounts(trip: TripRecord): boolean {
+  return trip.deleted_at === null && trip.ended_at !== null;
+}
+
+/**
+ * The ordered list of record ids that qualify for one badge, and the timestamp of each.
+ * Every rule shape reduces to this, which is why five shapes cover the whole catalog.
+ */
+function qualifiers(
+  definition: BadgeDefinition,
+  input: EvaluationInput,
+): readonly { id: string; at: string }[] {
+  const { catches, trips, knownSpeciesIds, waterClassOf } = input;
+
+  if (definition.ruleType === "trip_count") {
+    return chronological(trips.filter(tripCounts), (t) => t.started_at).map((t) => ({
+      id: t.id,
+      at: t.ended_at ?? t.started_at,
+    }));
+  }
+
+  const valid = chronological(catches.filter(isCountable), (c) => c.caught_at);
+
+  if (definition.ruleType === "catch_count") {
+    return valid.map((c) => ({ id: c.id, at: c.caught_at }));
+  }
+
+  if (definition.ruleType === "released_count") {
+    return valid
+      .filter((c) => c.disposition === "released")
+      .map((c) => ({ id: c.id, at: c.caught_at }));
+  }
+
+  // The two unique-species shapes: the *first* catch of each species is the qualifier, so
+  // the award lands on the day the angler actually met that fish.
+  const seen = new Set<string>();
+  const firsts: { id: string; at: string }[] = [];
+  for (const record of valid) {
+    const speciesId = record.species_id;
+    if (speciesId === null || !knownSpeciesIds.has(speciesId) || seen.has(speciesId)) continue;
+    if (
+      definition.ruleType === "unique_species_in_water" &&
+      waterClassOf(speciesId) !== definition.ruleConfig.waterClass
+    ) {
+      continue;
+    }
+    seen.add(speciesId);
+    firsts.push({ id: record.id, at: record.caught_at });
+  }
+  return firsts;
+}
+
+/** One badge's standing. */
+export function evaluateBadge(
+  definition: BadgeDefinition,
+  input: EvaluationInput,
+): BadgeStanding {
+  const matched = qualifiers(definition, input);
+  const { threshold } = definition.ruleConfig;
+  const earned = matched.length >= threshold;
+
+  return {
+    badgeId: definition.id,
+    ruleVersion: definition.ruleVersion,
+    earned,
+    current: matched.length,
+    threshold,
+    // The record that crossed the line, not the moment the evaluation ran.
+    awardedAt: earned ? matched[threshold - 1].at : null,
+    qualifyingSourceIds: matched.slice(0, threshold).map((m) => m.id),
+  };
+}
+
+/** Every active badge's standing, in catalog order. */
+export function evaluateBadges(
+  definitions: readonly BadgeDefinition[],
+  input: EvaluationInput,
+): readonly BadgeStanding[] {
+  return definitions.filter((d) => d.active).map((d) => evaluateBadge(d, input));
+}
+
+/**
+ * Badges earned by the second reading that were not earned by the first — the post-catch
+ * celebration's input (spec §14).
+ *
+ * Returned in catalog order and deliberately as a list: §14 says queue multiple unlocks
+ * into one summary rather than stacking modals on someone who is trying to log the next
+ * fish.
+ */
+export function newlyEarned(
+  before: readonly BadgeStanding[],
+  after: readonly BadgeStanding[],
+): readonly BadgeStanding[] {
+  const had = new Set(before.filter((s) => s.earned).map((s) => s.badgeId));
+  return after.filter((s) => s.earned && !had.has(s.badgeId));
+}

--- a/src/core/rules/achievements/types.ts
+++ b/src/core/rules/achievements/types.ts
@@ -1,0 +1,70 @@
+/**
+ * Badge definitions and awards (passport spec §13, §29.3, §29.4).
+ *
+ * Spec §13's first requirement is that badge definitions are data, not component
+ * conditionals. That is why a badge is a row-shaped object with a `ruleType` and a
+ * `ruleConfig` rather than a function: the catalog can grow without touching the engine,
+ * and the same catalog can be handed to a second client and produce the same answers.
+ *
+ * There are only five rule shapes in Phase 1 and they cover eight badges (spec §47.3).
+ */
+
+/**
+ * - `catch_count` — count valid catches. "Log one valid catch."
+ * - `unique_species` — count distinct recognised species.
+ * - `released_count` — count valid catches released rather than kept.
+ * - `unique_species_in_water` — count distinct species of one water class.
+ * - `trip_count` — count honestly completed trips, **fish or no fish**.
+ *
+ * That last shape is the one ROADMAP Part 3 asked for by name: an engagement mechanic
+ * must "reward confirming a trip honestly, never reward catching or logging more". A
+ * blank day is the most statistically valuable record the product owns, and a passport
+ * that only lights up on a fish quietly teaches anglers not to record one.
+ */
+export type BadgeRuleType =
+  | "catch_count"
+  | "unique_species"
+  | "released_count"
+  | "unique_species_in_water"
+  | "trip_count";
+
+export interface BadgeRuleConfig {
+  readonly threshold: number;
+  /** `unique_species_in_water` only. */
+  readonly waterClass?: "salt" | "fresh";
+}
+
+export interface BadgeDefinition {
+  readonly id: string;
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string;
+  readonly category: "milestone" | "exploration" | "stewardship";
+  readonly tier: number;
+  readonly ruleType: BadgeRuleType;
+  readonly ruleConfig: BadgeRuleConfig;
+  readonly ruleVersion: number;
+  readonly iconKey: string;
+  readonly active: boolean;
+}
+
+/**
+ * One badge's standing for one angler.
+ *
+ * `awardedAt` is the timestamp of the record that crossed the threshold, not the time the
+ * evaluation ran — so re-running produces the same answer, and an award keeps its real
+ * date after a reinstall (spec §13: deterministic and idempotent).
+ *
+ * `qualifyingSourceIds` holds the records that earned it, in order, up to the threshold.
+ * Spec §13 asks for auditability "when reasonable"; the ones after the threshold add
+ * nothing an auditor needs and would grow without bound.
+ */
+export interface BadgeStanding {
+  readonly badgeId: string;
+  readonly ruleVersion: number;
+  readonly earned: boolean;
+  readonly current: number;
+  readonly threshold: number;
+  readonly awardedAt: string | null;
+  readonly qualifyingSourceIds: readonly string[];
+}

--- a/src/core/rules/passport/collections.test.ts
+++ b/src/core/rules/passport/collections.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { speciesById } from "@/core/ontology/species";
+
+import { COLLECTIONS, GROUP_SPECIES_IDS, collectionById, validateCollections } from "./collections";
+import { collectionProgress } from "./selectors";
+
+describe("collection definitions", () => {
+  it("names no species the ontology does not have, and no species twice (Ticket 2)", () => {
+    expect(validateCollections()).toEqual([]);
+  });
+
+  it("ships something to collect", () => {
+    expect(COLLECTIONS.length).toBeGreaterThan(0);
+    for (const collection of COLLECTIONS) {
+      expect(collection.species.length).toBeGreaterThan(1);
+    }
+  });
+
+  it("never puts a group entry in a collection — 'Rockfish' is history, not a slot", () => {
+    for (const collection of COLLECTIONS) {
+      for (const entry of collection.species) {
+        expect(GROUP_SPECIES_IDS.has(entry.speciesId)).toBe(false);
+      }
+    }
+  });
+
+  it("never requires a protected species, so every collection is legally completable (spec §11)", () => {
+    for (const collection of COLLECTIONS) {
+      for (const entry of collection.species) {
+        const species = speciesById(entry.speciesId);
+        expect(species).not.toBeNull();
+        if (species?.takeStatus === "protected") {
+          expect(entry.required).toBe(false);
+          expect(entry.informationalOnly).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("carries the protected fish it knows about rather than hiding them", () => {
+    // If this ever reaches zero the derivation above has quietly stopped working.
+    const informational = COLLECTIONS.flatMap((c) => c.species).filter((s) => s.informationalOnly);
+    expect(informational.length).toBeGreaterThan(0);
+  });
+
+  it("has no geographic collections — spec §45.1 cut them from Phase 1", () => {
+    for (const collection of COLLECTIONS) {
+      expect(["family", "habitat"]).toContain(collection.collectionType);
+    }
+  });
+
+  it("completes when every required species is caught, protected ones notwithstanding", () => {
+    const bass = collectionById("bass");
+    expect(bass).not.toBeNull();
+
+    const required = bass!.species.filter((s) => s.required).map((s) => s.speciesId);
+    const progress = collectionProgress(bass!, new Set(required), GROUP_SPECIES_IDS);
+    expect(progress.complete).toBe(true);
+    expect(progress.caught).toBe(required.length);
+  });
+
+  it("is versioned, so finishing a collection cannot be undone by a later edit", () => {
+    for (const collection of COLLECTIONS) {
+      expect(collection.version).toBeGreaterThanOrEqual(1);
+    }
+  });
+});

--- a/src/core/rules/passport/collections.ts
+++ b/src/core/rules/passport/collections.ts
@@ -1,0 +1,224 @@
+/**
+ * The Phase 1 collection definitions (passport spec §11, Ticket 2).
+ *
+ * Two rules shape this file.
+ *
+ * **Membership is data, computed from the ontology.** Spec §11 forbids hard-coding species
+ * lists inside components; it does not ask for a second copy of the taxonomy. So the
+ * roll-up families (rockfish, croaker, surfperch) are *derived* from `species.rollsUpTo`,
+ * which the ontology already carries, and only the families the ontology cannot express —
+ * bass, tuna, flatfish, and the rest — are named by id. Those named ids are validated
+ * against the ontology by `validateCollections`, which the test runs: a typo or a species
+ * deleted from the vocabulary fails the build rather than producing a slot nobody can fill.
+ *
+ * **Nobody is ever asked to catch a fish they may not take.** `informationalOnly` is not
+ * hand-maintained — it is derived from `takeStatus === "protected"`. A protected fish still
+ * appears in its family so an angler learns it exists, and it is excluded from the
+ * denominator, so every collection here can be finished legally (spec §11, §4.5).
+ *
+ * Geographic collections are absent on purpose. Spec §45.1 cut them from Phase 1: there is
+ * no region on a catch and no region geometry to derive one from.
+ */
+
+import { SPECIES, speciesById, type Species } from "@/core/ontology/species";
+
+import type { CollectionDefinition, CollectionSpecies } from "./types";
+
+/** Bumped when a definition's membership changes. Progress readings record it. */
+export const COLLECTION_RULE_VERSION = 1;
+
+/** Group entries ("Rockfish") are history, never a collection slot — spec §10. */
+export const GROUP_SPECIES_IDS: ReadonlySet<string> = new Set(
+  SPECIES.filter((s) => s.isGroup).map((s) => s.id),
+);
+
+const eligible = (s: Species): boolean => !s.isGroup;
+
+function toEntries(species: readonly Species[]): readonly CollectionSpecies[] {
+  return species
+    .slice()
+    .sort((a, b) => a.sortOrder - b.sortOrder || (a.id < b.id ? -1 : 1))
+    .map((s, i) => ({
+      speciesId: s.id,
+      // Derived, never hand-set: a protected fish is shown but never required.
+      required: s.takeStatus !== "protected",
+      informationalOnly: s.takeStatus === "protected",
+      sortOrder: i,
+    }));
+}
+
+/** Everything that rolls up to a group id — the ontology's own family relationship. */
+function rollUpFamily(groupId: string): readonly Species[] {
+  return SPECIES.filter((s) => eligible(s) && s.rollsUpTo === groupId);
+}
+
+/** A family the ontology cannot express, named by id and validated against it. */
+function namedFamily(ids: readonly string[]): readonly Species[] {
+  return ids
+    .map((id) => speciesById(id))
+    .filter((s): s is Species => s !== null && eligible(s));
+}
+
+interface Definition {
+  id: string;
+  name: string;
+  description: string;
+  type: "family" | "habitat";
+  members: readonly Species[];
+  /** Ids asserted by hand, kept for validation. Empty for derived families. */
+  asserted?: readonly string[];
+}
+
+const BASS = [
+  "kelp_bass", "barred_sand_bass", "spotted_sand_bass", "largemouth_bass",
+  "smallmouth_bass", "striped_bass", "black_sea_bass", "white_seabass", "giant_sea_bass",
+];
+const TUNA = ["bluefin_tuna", "yellowfin_tuna", "bigeye_tuna", "skipjack_tuna"];
+const SALMON_TROUT = [
+  "chinook_salmon", "coho_salmon", "pink_salmon", "chum_salmon", "sockeye_salmon",
+  "steelhead", "lake_trout", "brown_trout", "dolly_varden",
+];
+const SHARKS_RAYS = [
+  "leopard_shark", "horn_shark", "thresher_shark", "spiny_dogfish", "sixgill_shark",
+  "bat_ray", "round_stingray", "shovelnose_guitarfish",
+];
+const FLATFISH = [
+  "california_halibut", "pacific_halibut", "atlantic_halibut", "pacific_sanddab",
+  "summer_flounder", "southern_flounder", "winter_flounder", "yellowtail_flounder",
+  "american_plaice", "witch_flounder", "windowpane_flounder",
+];
+
+const DEFINITIONS: readonly Definition[] = [
+  {
+    id: "bass",
+    name: "Bass",
+    description: "The bass an angler meets across salt and fresh water.",
+    type: "family",
+    members: namedFamily(BASS),
+    asserted: BASS,
+  },
+  {
+    id: "rockfish",
+    name: "Rockfish",
+    description: "The rockfish complex, one species at a time.",
+    type: "family",
+    members: rollUpFamily("rockfish"),
+  },
+  {
+    id: "tuna",
+    name: "Tuna",
+    description: "The tunas, for the days the water goes blue.",
+    type: "family",
+    members: namedFamily(TUNA),
+    asserted: TUNA,
+  },
+  {
+    id: "salmon-and-trout",
+    name: "Salmon and trout",
+    description: "Salmon, steelhead, and the larger trout.",
+    type: "family",
+    members: namedFamily(SALMON_TROUT),
+    asserted: SALMON_TROUT,
+  },
+  {
+    id: "flatfish",
+    name: "Flatfish",
+    description: "Halibut, flounder, sanddab, and the rest of the flat ones.",
+    type: "family",
+    members: namedFamily(FLATFISH),
+    asserted: FLATFISH,
+  },
+  {
+    id: "sharks-and-rays",
+    name: "Sharks and rays",
+    description: "Sharks, rays, and skates.",
+    type: "family",
+    members: namedFamily(SHARKS_RAYS),
+    asserted: SHARKS_RAYS,
+  },
+  {
+    id: "croaker",
+    name: "Croaker",
+    description: "The croaker family, corbina included.",
+    type: "family",
+    members: rollUpFamily("croaker"),
+  },
+  {
+    id: "surfperch",
+    name: "Surfperch",
+    description: "The surfperch, for anglers who fish the sand.",
+    type: "family",
+    members: rollUpFamily("surfperch"),
+  },
+  {
+    id: "freshwater",
+    name: "Freshwater",
+    description: "Everything the lakes and rivers hold.",
+    type: "habitat",
+    members: SPECIES.filter((s) => eligible(s) && s.waterClass === "fresh"),
+  },
+];
+
+export const COLLECTIONS: readonly CollectionDefinition[] = DEFINITIONS.filter(
+  // A one-species collection is not a collection.
+  (d) => d.members.length > 1,
+).map(
+  (d): CollectionDefinition => ({
+    id: d.id,
+    slug: d.id,
+    name: d.name,
+    description: d.description,
+    collectionType: d.type,
+    version: COLLECTION_RULE_VERSION,
+    active: true,
+    species: toEntries(d.members),
+  }),
+);
+
+export function collectionById(id: string): CollectionDefinition | null {
+  return COLLECTIONS.find((c) => c.id === id) ?? null;
+}
+
+/** Every species that appears in any collection, for the grid's family filter. */
+export function collectionsForSpecies(speciesId: string): readonly CollectionDefinition[] {
+  return COLLECTIONS.filter((c) => c.species.some((s) => s.speciesId === speciesId));
+}
+
+/**
+ * Ticket 2's validation. Run by the test, not at import time — a definition problem should
+ * fail a build with a readable list, not blank the app on a boat.
+ */
+export function validateCollections(): readonly string[] {
+  const problems: string[] = [];
+
+  for (const definition of DEFINITIONS) {
+    for (const id of definition.asserted ?? []) {
+      const species = speciesById(id);
+      if (species === null) {
+        problems.push(`${definition.id}: "${id}" is not in the species ontology`);
+      } else if (species.isGroup) {
+        problems.push(`${definition.id}: "${id}" is a group entry and cannot fill a slot`);
+      }
+    }
+  }
+
+  for (const collection of COLLECTIONS) {
+    const seen = new Set<string>();
+    for (const entry of collection.species) {
+      if (seen.has(entry.speciesId)) {
+        problems.push(`${collection.id}: "${entry.speciesId}" appears twice`);
+      }
+      seen.add(entry.speciesId);
+    }
+    if (!collection.species.some((s) => s.required)) {
+      problems.push(`${collection.id}: nothing is required, so it can never be completed`);
+    }
+  }
+
+  const ids = COLLECTIONS.map((c) => c.id);
+  for (const id of ids) {
+    if (ids.indexOf(id) !== ids.lastIndexOf(id)) problems.push(`duplicate collection id "${id}"`);
+  }
+
+  return problems;
+}

--- a/src/core/rules/passport/selectors.test.ts
+++ b/src/core/rules/passport/selectors.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+
+import vectors from "../vectors/passport.json";
+import type { CatchRecord, Disposition, Outcome, ResolutionState } from "../catch/types";
+import { collectionProgress, passportTotals, speciesSummaries } from "./selectors";
+import type { CollectionDefinition } from "./types";
+
+/**
+ * The compact catch shape the vectors are written in. A full CatchRecord is forty fields
+ * and none of the other thirty-odd change any answer here, so the vector states what
+ * matters and this expands it. A second client reproduces the vectors by writing the same
+ * twenty lines.
+ */
+interface VectorCatch {
+  id: string;
+  species: string | null;
+  at: string;
+  quantity?: number;
+  disposition?: string | null;
+  lengthMm?: number | null;
+  weightG?: number | null;
+  estimated?: boolean;
+  state?: string;
+  outcome?: string;
+  deleted?: boolean;
+}
+
+function expand(v: VectorCatch): CatchRecord {
+  return {
+    id: v.id,
+    angler_id: "angler",
+    trip_id: "trip",
+    caught_at: v.at,
+    caught_tz: "America/Los_Angeles",
+    local_date: v.at.slice(0, 10),
+    lat: null,
+    lng: null,
+    gps_accuracy_m: null,
+    resolution_state: (v.state ?? "confirmed") as ResolutionState,
+    dismissed_reason: null,
+    resolved_at: null,
+    species_id: v.species,
+    species_other: null,
+    outcome: (v.outcome ?? "landed") as Outcome,
+    disposition: (v.disposition ?? null) as Disposition | null,
+    quantity: v.quantity ?? 1,
+    length_mm: v.lengthMm ?? null,
+    weight_g: v.weightG ?? null,
+    size_estimated: v.estimated ?? false,
+    spot_id: null,
+    platform: null,
+    depth_fished_m: null,
+    rig_id: null,
+    rig_revision: null,
+    rig_slot: null,
+    inherited_fields: [],
+    location_condition_id: null,
+    location_name: null,
+    current_term: null,
+    current_strength: null,
+    structure_type_ids: [],
+    bottom_depth_m: null,
+    water_color_id: null,
+    water_clarity_id: null,
+    presentation: null,
+    notes: null,
+    tags: [],
+    favorite: false,
+    regulation_snapshot: null,
+    capture_mode: "live",
+    client_created_at: v.at,
+    created_at: v.at,
+    client_updated_at: v.at,
+    deleted_at: v.deleted === true ? v.at : null,
+  };
+}
+
+const KNOWN = new Set(vectors.knownSpecies);
+const GROUPS = new Set(vectors.groupSpecies);
+
+describe("speciesSummaries", () => {
+  for (const vector of vectors.summaries) {
+    it(vector.name, () => {
+      const summaries = speciesSummaries(vector.catches.map(expand), KNOWN);
+      expect(summaries).toHaveLength(vector.expect.length);
+
+      vector.expect.forEach((want, i) => {
+        const got = summaries[i];
+        expect(got.speciesId).toBe(want.speciesId);
+        expect(got.catchCount).toBe(want.catchCount);
+        expect(got.fishCount).toBe(want.fishCount);
+        expect(got.keptCount).toBe(want.keptCount);
+        expect(got.releasedCount).toBe(want.releasedCount);
+        expect(got.firstCatchId).toBe(want.firstCatchId);
+        expect(got.latestCatchId).toBe(want.latestCatchId);
+        expect(got.bestLength?.catchId ?? null).toBe(want.bestLengthCatchId);
+        expect(got.bestLength?.value ?? null).toBe(want.bestLengthValue);
+        expect(got.bestWeight?.catchId ?? null).toBe(want.bestWeightCatchId);
+        expect(got.bestWeight?.value ?? null).toBe(want.bestWeightValue);
+      });
+    });
+  }
+
+  it("is deterministic regardless of input order — the same log gives the same passport", () => {
+    const catches = vectors.summaries[0].catches.map(expand);
+    const forwards = speciesSummaries(catches, KNOWN);
+    const backwards = speciesSummaries([...catches].reverse(), KNOWN);
+    expect(backwards).toEqual(forwards);
+  });
+
+  it("re-running over the same catches changes nothing (spec §37: no duplicate credit)", () => {
+    const catches = vectors.summaries[0].catches.map(expand);
+    expect(speciesSummaries(catches, KNOWN)).toEqual(speciesSummaries(catches, KNOWN));
+  });
+
+  it("deleting the only catch of a species removes it from the passport (spec §10)", () => {
+    const [only] = vectors.summaries[0].catches;
+    const live = speciesSummaries([expand(only)], KNOWN);
+    expect(live).toHaveLength(1);
+
+    const deleted = speciesSummaries([expand({ ...only, deleted: true })], KNOWN);
+    expect(deleted).toHaveLength(0);
+  });
+
+  it("editing a catch from one species to another recalculates both (spec §10)", () => {
+    const [original] = vectors.summaries[0].catches;
+    const before = speciesSummaries([expand(original)], KNOWN);
+    expect(before[0].speciesId).toBe("kelp_bass");
+
+    const after = speciesSummaries([expand({ ...original, species: "largemouth_bass" })], KNOWN);
+    expect(after).toHaveLength(1);
+    expect(after[0].speciesId).toBe("largemouth_bass");
+  });
+});
+
+describe("passportTotals", () => {
+  for (const vector of vectors.totals) {
+    it(vector.name, () => {
+      const totals = passportTotals(speciesSummaries(vector.catches.map(expand), KNOWN));
+      expect(totals.uniqueSpecies).toBe(vector.expect.uniqueSpecies);
+      expect(totals.totalCatches).toBe(vector.expect.totalCatches);
+      expect(totals.totalFish).toBe(vector.expect.totalFish);
+      expect(totals.keptCount).toBe(vector.expect.keptCount);
+      expect(totals.releasedCount).toBe(vector.expect.releasedCount);
+      expect(totals.latestNewSpecies?.speciesId ?? null).toBe(vector.expect.latestNewSpeciesId);
+    });
+  }
+});
+
+describe("collectionProgress", () => {
+  for (const vector of vectors.collectionProgress) {
+    it(vector.name, () => {
+      const definition: CollectionDefinition = {
+        id: vector.definition.id,
+        slug: vector.definition.id,
+        name: vector.definition.id,
+        description: "",
+        collectionType: "family",
+        version: 1,
+        active: true,
+        species: [
+          ...vector.definition.required.map((speciesId, i) => ({
+            speciesId,
+            required: true,
+            informationalOnly: false,
+            sortOrder: i,
+          })),
+          ...vector.definition.informational.map((speciesId, i) => ({
+            speciesId,
+            required: false,
+            informationalOnly: true,
+            sortOrder: 100 + i,
+          })),
+        ],
+      };
+
+      const progress = collectionProgress(definition, new Set(vector.caught), GROUPS);
+      expect(progress.caught).toBe(vector.expect.caught);
+      expect(progress.required).toBe(vector.expect.required);
+      expect(progress.informationalCaught).toBe(vector.expect.informationalCaught);
+      expect(progress.complete).toBe(vector.expect.complete);
+    });
+  }
+
+  it("a collection with nothing required is never silently complete", () => {
+    const empty: CollectionDefinition = {
+      id: "empty",
+      slug: "empty",
+      name: "Empty",
+      description: "",
+      collectionType: "family",
+      version: 1,
+      active: true,
+      species: [],
+    };
+    expect(collectionProgress(empty, new Set(), GROUPS).complete).toBe(false);
+  });
+});

--- a/src/core/rules/passport/selectors.ts
+++ b/src/core/rules/passport/selectors.ts
@@ -1,0 +1,221 @@
+/**
+ * The passport projection (spec §10, §37).
+ *
+ * Pure by law (ADR 003): no React, no browser, no database client. Everything is a
+ * function of the catches handed in, which is what makes recalculation after an edit,
+ * a delete, or a sync merge free — there is no stored progress to migrate, so it cannot
+ * be wrong. It is also what lets the same rules be checked against the Swift client
+ * later, from the vectors beside this file.
+ */
+
+import { isCountable } from "../catch/rules";
+import type { CatchRecord } from "../catch/types";
+import type {
+  CollectionDefinition,
+  CollectionProgress,
+  PassportTotals,
+  PersonalBest,
+  SpeciesSummary,
+} from "./types";
+
+/**
+ * Does this catch count toward the passport (spec §10)?
+ *
+ * `isCountable` already carries three quarters of the rule and is already tested: not
+ * deleted, resolution confirmed, outcome landed. Reusing it is what keeps Quick Mark
+ * honest — an unresolved quick mark is not yet a fish, so resolving one later credits
+ * the species exactly once, on the record that already existed. That is spec §10's
+ * "must not create double credit", enforced by construction rather than by a guard.
+ *
+ * The passport adds one condition of its own: the fish must be a species we recognise.
+ * `species_other` free text is deliberately not enough (spec §5 keeps it a separate
+ * column precisely so it can never be mistaken for an id), and an id we have never heard
+ * of would produce a collection entry pointing at nothing.
+ */
+export function countsTowardPassport(
+  record: CatchRecord,
+  knownSpeciesIds: ReadonlySet<string>,
+): boolean {
+  return (
+    isCountable(record) && record.species_id !== null && knownSpeciesIds.has(record.species_id)
+  );
+}
+
+/** Milliseconds, for ordering. Unparseable timestamps sort last rather than throwing. */
+const instant = (iso: string): number => {
+  const ms = Date.parse(iso);
+  return Number.isNaN(ms) ? Number.POSITIVE_INFINITY : ms;
+};
+
+/**
+ * Earlier wins; ties break on id. Ids are UUIDv7 and therefore time-ordered, so this is
+ * both stable and meaningful — two fish logged in the same second keep the order they
+ * were logged in.
+ */
+const earlier = (a: CatchRecord, b: CatchRecord): boolean => {
+  const delta = instant(a.caught_at) - instant(b.caught_at);
+  return delta === 0 ? a.id < b.id : delta < 0;
+};
+
+/** A bigger measurement wins; an equal one keeps the fish that got there first. */
+function betterBest(
+  current: PersonalBest | null,
+  record: CatchRecord,
+  value: number | null,
+): PersonalBest | null {
+  if (value === null) return current;
+  if (current !== null && current.value >= value) return current;
+  return {
+    catchId: record.id,
+    value,
+    estimated: record.size_estimated,
+    caughtAt: record.caught_at,
+  };
+}
+
+/**
+ * Summarise every species the angler has actually caught, one entry per species.
+ *
+ * Sorted by species id so the output is deterministic — the vectors depend on it, and so
+ * does any diff a reviewer reads. Callers sort for display.
+ *
+ * Group entries (`rockfish` rather than `vermilion_rockfish`) are summarised like any
+ * other species: spec §10 says they belong in history. What they do *not* do is satisfy a
+ * collection, and that rule lives in `collectionProgress` below, not here.
+ */
+export function speciesSummaries(
+  catches: readonly CatchRecord[],
+  knownSpeciesIds: ReadonlySet<string>,
+): readonly SpeciesSummary[] {
+  const drafts = new Map<
+    string,
+    {
+      speciesId: string;
+      catchCount: number;
+      fishCount: number;
+      keptCount: number;
+      releasedCount: number;
+      first: CatchRecord;
+      latest: CatchRecord;
+      bestLength: PersonalBest | null;
+      bestWeight: PersonalBest | null;
+    }
+  >();
+
+  for (const record of catches) {
+    if (!countsTowardPassport(record, knownSpeciesIds)) continue;
+    const speciesId = record.species_id as string;
+    const draft = drafts.get(speciesId);
+
+    if (draft === undefined) {
+      drafts.set(speciesId, {
+        speciesId,
+        catchCount: 1,
+        fishCount: record.quantity,
+        keptCount: record.disposition === "kept" ? 1 : 0,
+        releasedCount: record.disposition === "released" ? 1 : 0,
+        first: record,
+        latest: record,
+        bestLength: betterBest(null, record, record.length_mm),
+        bestWeight: betterBest(null, record, record.weight_g),
+      });
+      continue;
+    }
+
+    draft.catchCount += 1;
+    draft.fishCount += record.quantity;
+    if (record.disposition === "kept") draft.keptCount += 1;
+    if (record.disposition === "released") draft.releasedCount += 1;
+    if (earlier(record, draft.first)) draft.first = record;
+    if (earlier(draft.latest, record)) draft.latest = record;
+    draft.bestLength = betterBest(draft.bestLength, record, record.length_mm);
+    draft.bestWeight = betterBest(draft.bestWeight, record, record.weight_g);
+  }
+
+  return [...drafts.values()]
+    .sort((a, b) => (a.speciesId < b.speciesId ? -1 : a.speciesId > b.speciesId ? 1 : 0))
+    .map(
+      (draft): SpeciesSummary => ({
+        speciesId: draft.speciesId,
+        catchCount: draft.catchCount,
+        fishCount: draft.fishCount,
+        keptCount: draft.keptCount,
+        releasedCount: draft.releasedCount,
+        firstCatchId: draft.first.id,
+        firstCaughtAt: draft.first.caught_at,
+        latestCatchId: draft.latest.id,
+        latestCaughtAt: draft.latest.caught_at,
+        bestLength: draft.bestLength,
+        bestWeight: draft.bestWeight,
+      }),
+    );
+}
+
+/** The overview numbers (spec §8.2), computed from the summaries so they cannot disagree. */
+export function passportTotals(summaries: readonly SpeciesSummary[]): PassportTotals {
+  let totalCatches = 0;
+  let totalFish = 0;
+  let keptCount = 0;
+  let releasedCount = 0;
+  let latestNewSpecies: PassportTotals["latestNewSpecies"] = null;
+
+  for (const summary of summaries) {
+    totalCatches += summary.catchCount;
+    totalFish += summary.fishCount;
+    keptCount += summary.keptCount;
+    releasedCount += summary.releasedCount;
+
+    // "Newest species" is the most recent *first* catch, not the most recent catch.
+    const at = instant(summary.firstCaughtAt);
+    if (latestNewSpecies === null || at > instant(latestNewSpecies.caughtAt)) {
+      latestNewSpecies = { speciesId: summary.speciesId, caughtAt: summary.firstCaughtAt };
+    }
+  }
+
+  return {
+    uniqueSpecies: summaries.length,
+    totalCatches,
+    totalFish,
+    keptCount,
+    releasedCount,
+    latestNewSpecies,
+  };
+}
+
+/**
+ * Progress against one collection (spec §11).
+ *
+ * Two rules earn their place here. Informational-only species — the protected and
+ * prohibited ones — are counted separately and never enter the denominator, so a
+ * collection can always be finished legally. And a *group* entry never satisfies a
+ * collection slot: catching "rockfish" is a real catch and shows in history, but the
+ * vermilion slot stays open until the angler says which rockfish it was (spec §10).
+ * The caller supplies `groupSpeciesIds`; the rule is not the ontology's to enforce.
+ */
+export function collectionProgress(
+  definition: CollectionDefinition,
+  caughtSpeciesIds: ReadonlySet<string>,
+  groupSpeciesIds: ReadonlySet<string>,
+): CollectionProgress {
+  let caught = 0;
+  let required = 0;
+  let informationalCaught = 0;
+
+  for (const entry of definition.species) {
+    const has = caughtSpeciesIds.has(entry.speciesId) && !groupSpeciesIds.has(entry.speciesId);
+    if (entry.informationalOnly) {
+      if (has) informationalCaught += 1;
+      continue;
+    }
+    if (entry.required) required += 1;
+    if (has && entry.required) caught += 1;
+  }
+
+  return {
+    collectionId: definition.id,
+    caught,
+    required,
+    informationalCaught,
+    complete: required > 0 && caught === required,
+  };
+}

--- a/src/core/rules/passport/types.ts
+++ b/src/core/rules/passport/types.ts
@@ -1,0 +1,100 @@
+/**
+ * The passport's own vocabulary (passport spec §9.2, §10, §11).
+ *
+ * Nothing here is stored. Every value in this file is *derived* from catches that already
+ * exist, which is the whole of spec §28: the catch table stays authoritative and the
+ * passport is a projection over it. That is also why there is no `caught: boolean` on a
+ * species — caught-ness is the presence of a summary, so it cannot drift out of step with
+ * the catches it was computed from.
+ */
+
+/**
+ * One end of a personal best. Length and weight are deliberately separate records
+ * (spec §9.2): the longest fish and the heaviest fish are frequently not the same fish,
+ * and collapsing them into one "biggest" loses the angler's actual history.
+ *
+ * `estimated` carries `catch.size_estimated` forward so the UI can say so. A guessed
+ * 30-inch fish is still that angler's best; it is just not a measured one, and the screen
+ * should not imply otherwise.
+ */
+export interface PersonalBest {
+  readonly catchId: string;
+  /** Millimetres for length, grams for weight — the units the catch row already stores. */
+  readonly value: number;
+  readonly estimated: boolean;
+  readonly caughtAt: string;
+}
+
+/** Everything the passport knows about one species for one angler. */
+export interface SpeciesSummary {
+  readonly speciesId: string;
+  /** Catches that count (spec §10). Not the number of fish — see `fishCount`. */
+  readonly catchCount: number;
+  /**
+   * Fish, summing `catch.quantity`. A bass-on-every-cast session logged as one catch of
+   * twelve is twelve fish and one catch, and the two numbers answer different questions.
+   */
+  readonly fishCount: number;
+  readonly keptCount: number;
+  readonly releasedCount: number;
+  readonly firstCatchId: string;
+  readonly firstCaughtAt: string;
+  readonly latestCatchId: string;
+  readonly latestCaughtAt: string;
+  readonly bestLength: PersonalBest | null;
+  readonly bestWeight: PersonalBest | null;
+}
+
+/** The overview numbers (spec §8.2). */
+export interface PassportTotals {
+  readonly uniqueSpecies: number;
+  readonly totalCatches: number;
+  readonly totalFish: number;
+  readonly keptCount: number;
+  readonly releasedCount: number;
+  /** The most recent species caught for the first time, or null on an empty log. */
+  readonly latestNewSpecies: { readonly speciesId: string; readonly caughtAt: string } | null;
+}
+
+export type CollectionType = "family" | "habitat";
+
+/**
+ * One species' place in a collection (spec §29.2).
+ *
+ * `informationalOnly` is the §11 safeguard: a protected or prohibited fish may appear in a
+ * collection so an angler learns it exists, but it can never be required to reach 100%.
+ * Nobody should be nudged toward a fish they are not allowed to take.
+ */
+export interface CollectionSpecies {
+  readonly speciesId: string;
+  readonly required: boolean;
+  readonly informationalOnly: boolean;
+  readonly sortOrder: number;
+}
+
+/**
+ * A versioned collection definition (spec §11, §29.1).
+ *
+ * `version` exists so an award or a progress reading can say which definition it was made
+ * against. Adding a species to a collection changes what 100% means, and an angler who
+ * finished it last season should not silently become incomplete.
+ */
+export interface CollectionDefinition {
+  readonly id: string;
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string;
+  readonly collectionType: CollectionType;
+  readonly version: number;
+  readonly active: boolean;
+  readonly species: readonly CollectionSpecies[];
+}
+
+/** Progress against one collection. `required` excludes informational-only entries. */
+export interface CollectionProgress {
+  readonly collectionId: string;
+  readonly caught: number;
+  readonly required: number;
+  readonly informationalCaught: number;
+  readonly complete: boolean;
+}

--- a/src/core/rules/vectors/achievements.json
+++ b/src/core/rules/vectors/achievements.json
@@ -1,0 +1,97 @@
+{
+  "$comment": "Vectors for src/core/rules/achievements/ (ADR 003 §4). Catches and trips use the compact shape documented in evaluate.test.ts. Defaults: state 'confirmed', outcome 'landed', deleted false, disposition null; trips end unless 'open' is true.",
+  "waterClass": {
+    "kelp_bass": "salt", "barred_sand_bass": "salt", "yellowtail": "salt", "lingcod": "salt", "cabezon": "salt",
+    "largemouth_bass": "fresh", "bluegill": "fresh", "walleye": "fresh", "black_crappie": "fresh", "northern_pike": "fresh"
+  },
+  "cases": [
+    {
+      "name": "first catch lands on the first valid fish",
+      "badge": "first-catch",
+      "catches": [{ "id": "c1", "species": "kelp_bass", "at": "2026-03-01T14:00:00.000Z" }],
+      "trips": [],
+      "expect": { "earned": true, "current": 1, "threshold": 1, "awardedAt": "2026-03-01T14:00:00.000Z", "sources": ["c1"] }
+    },
+    {
+      "name": "an unresolved quick mark does not earn first catch",
+      "badge": "first-catch",
+      "catches": [{ "id": "c1", "species": "kelp_bass", "at": "2026-03-01T14:00:00.000Z", "state": "unresolved" }],
+      "trips": [],
+      "expect": { "earned": false, "current": 0, "threshold": 1, "awardedAt": null, "sources": [] }
+    },
+    {
+      "name": "species explorer I counts distinct species, not catches",
+      "badge": "species-explorer-i",
+      "catches": [
+        { "id": "a", "species": "kelp_bass", "at": "2026-03-01T10:00:00.000Z" },
+        { "id": "b", "species": "kelp_bass", "at": "2026-03-01T11:00:00.000Z" },
+        { "id": "c", "species": "kelp_bass", "at": "2026-03-01T12:00:00.000Z" },
+        { "id": "d", "species": "kelp_bass", "at": "2026-03-01T13:00:00.000Z" },
+        { "id": "e", "species": "kelp_bass", "at": "2026-03-01T14:00:00.000Z" }
+      ],
+      "trips": [],
+      "expect": { "earned": false, "current": 1, "threshold": 5, "awardedAt": null, "sources": ["a"] }
+    },
+    {
+      "name": "five species earns it, dated to the fish that crossed the line",
+      "badge": "species-explorer-i",
+      "catches": [
+        { "id": "a", "species": "kelp_bass", "at": "2026-03-01T10:00:00.000Z" },
+        { "id": "b", "species": "barred_sand_bass", "at": "2026-03-02T10:00:00.000Z" },
+        { "id": "c", "species": "yellowtail", "at": "2026-03-03T10:00:00.000Z" },
+        { "id": "d", "species": "lingcod", "at": "2026-03-04T10:00:00.000Z" },
+        { "id": "e", "species": "cabezon", "at": "2026-03-05T10:00:00.000Z" },
+        { "id": "f", "species": "largemouth_bass", "at": "2026-03-06T10:00:00.000Z" }
+      ],
+      "trips": [],
+      "expect": { "earned": true, "current": 6, "threshold": 5, "awardedAt": "2026-03-05T10:00:00.000Z", "sources": ["a", "b", "c", "d", "e"] }
+    },
+    {
+      "name": "freshwater explorer ignores saltwater species entirely",
+      "badge": "freshwater-explorer",
+      "catches": [
+        { "id": "s1", "species": "kelp_bass", "at": "2026-03-01T10:00:00.000Z" },
+        { "id": "s2", "species": "yellowtail", "at": "2026-03-02T10:00:00.000Z" },
+        { "id": "f1", "species": "largemouth_bass", "at": "2026-03-03T10:00:00.000Z" },
+        { "id": "f2", "species": "bluegill", "at": "2026-03-04T10:00:00.000Z" },
+        { "id": "f3", "species": "walleye", "at": "2026-03-05T10:00:00.000Z" }
+      ],
+      "trips": [],
+      "expect": { "earned": false, "current": 3, "threshold": 5, "awardedAt": null, "sources": ["f1", "f2", "f3"] }
+    },
+    {
+      "name": "responsible release counts released fish, not kept ones",
+      "badge": "responsible-release-i",
+      "catches": [
+        { "id": "r1", "species": "kelp_bass", "at": "2026-03-01T10:00:00.000Z", "disposition": "released" },
+        { "id": "r2", "species": "kelp_bass", "at": "2026-03-01T11:00:00.000Z", "disposition": "released" },
+        { "id": "k1", "species": "kelp_bass", "at": "2026-03-01T12:00:00.000Z", "disposition": "kept" }
+      ],
+      "trips": [],
+      "expect": { "earned": false, "current": 2, "threshold": 10, "awardedAt": null, "sources": ["r1", "r2"] }
+    },
+    {
+      "name": "a blank day counts — the trip badge never asks about fish",
+      "badge": "days-on-the-water-i",
+      "catches": [],
+      "trips": [
+        { "id": "t1", "started": "2026-03-01T06:00:00.000Z", "ended": "2026-03-01T12:00:00.000Z" },
+        { "id": "t2", "started": "2026-03-08T06:00:00.000Z", "ended": "2026-03-08T12:00:00.000Z" },
+        { "id": "t3", "started": "2026-03-15T06:00:00.000Z", "ended": "2026-03-15T12:00:00.000Z" },
+        { "id": "t4", "started": "2026-03-22T06:00:00.000Z", "ended": "2026-03-22T12:00:00.000Z" },
+        { "id": "t5", "started": "2026-03-29T06:00:00.000Z", "ended": "2026-03-29T12:00:00.000Z" }
+      ],
+      "expect": { "earned": true, "current": 5, "threshold": 5, "awardedAt": "2026-03-29T12:00:00.000Z", "sources": ["t1", "t2", "t3", "t4", "t5"] }
+    },
+    {
+      "name": "a trip still open on the boat has not been confirmed yet",
+      "badge": "days-on-the-water-i",
+      "catches": [],
+      "trips": [
+        { "id": "t1", "started": "2026-03-01T06:00:00.000Z", "open": true },
+        { "id": "t2", "started": "2026-03-08T06:00:00.000Z", "ended": "2026-03-08T12:00:00.000Z" }
+      ],
+      "expect": { "earned": false, "current": 1, "threshold": 5, "awardedAt": null, "sources": ["t2"] }
+    }
+  ]
+}

--- a/src/core/rules/vectors/passport.json
+++ b/src/core/rules/vectors/passport.json
@@ -1,0 +1,152 @@
+{
+  "$comment": "Vectors for src/core/rules/passport/ (ADR 003 §4). Catches are written in the compact shape documented in passport.test.ts and expanded into full CatchRecords there, so a second client can reproduce these results without copying a 40-field row into JSON. Defaults when a key is absent: quantity 1, state 'confirmed', outcome 'landed', deleted false, estimated false, disposition null.",
+  "knownSpecies": ["kelp_bass", "barred_sand_bass", "rockfish", "vermilion_rockfish", "largemouth_bass"],
+  "groupSpecies": ["rockfish"],
+
+  "summaries": [
+    {
+      "name": "repeat catches of one species add up but stay one unique species",
+      "catches": [
+        { "id": "c1", "species": "kelp_bass", "at": "2026-03-01T14:00:00.000Z", "disposition": "released", "lengthMm": 300 },
+        { "id": "c2", "species": "kelp_bass", "at": "2026-03-02T14:00:00.000Z", "disposition": "kept", "lengthMm": 420, "weightG": 1200 },
+        { "id": "c3", "species": "kelp_bass", "at": "2026-03-03T14:00:00.000Z", "disposition": "released", "quantity": 3 }
+      ],
+      "expect": [
+        {
+          "speciesId": "kelp_bass", "catchCount": 3, "fishCount": 5, "keptCount": 1, "releasedCount": 2,
+          "firstCatchId": "c1", "latestCatchId": "c3",
+          "bestLengthCatchId": "c2", "bestLengthValue": 420,
+          "bestWeightCatchId": "c2", "bestWeightValue": 1200
+        }
+      ]
+    },
+    {
+      "name": "an unresolved quick mark is not yet a fish, and resolving it credits exactly once",
+      "catches": [
+        { "id": "q1", "species": "kelp_bass", "at": "2026-03-01T14:00:00.000Z", "state": "unresolved" }
+      ],
+      "expect": []
+    },
+    {
+      "name": "deleted, dismissed and lost fish never count",
+      "catches": [
+        { "id": "d1", "species": "kelp_bass", "at": "2026-03-01T14:00:00.000Z", "deleted": true },
+        { "id": "d2", "species": "kelp_bass", "at": "2026-03-02T14:00:00.000Z", "state": "dismissed" },
+        { "id": "d3", "species": "kelp_bass", "at": "2026-03-03T14:00:00.000Z", "outcome": "lost" }
+      ],
+      "expect": []
+    },
+    {
+      "name": "a species id we do not recognise is not a collection entry",
+      "catches": [
+        { "id": "u1", "species": "not_a_real_species", "at": "2026-03-01T14:00:00.000Z" },
+        { "id": "u2", "species": null, "at": "2026-03-02T14:00:00.000Z" }
+      ],
+      "expect": []
+    },
+    {
+      "name": "longest and heaviest are tracked separately because they are rarely the same fish",
+      "catches": [
+        { "id": "b1", "species": "largemouth_bass", "at": "2026-04-01T12:00:00.000Z", "lengthMm": 520, "weightG": 1800 },
+        { "id": "b2", "species": "largemouth_bass", "at": "2026-04-02T12:00:00.000Z", "lengthMm": 480, "weightG": 2400, "estimated": true }
+      ],
+      "expect": [
+        {
+          "speciesId": "largemouth_bass", "catchCount": 2, "fishCount": 2, "keptCount": 0, "releasedCount": 0,
+          "firstCatchId": "b1", "latestCatchId": "b2",
+          "bestLengthCatchId": "b1", "bestLengthValue": 520,
+          "bestWeightCatchId": "b2", "bestWeightValue": 2400
+        }
+      ]
+    },
+    {
+      "name": "an equal measurement keeps the fish that got there first",
+      "catches": [
+        { "id": "t1", "species": "kelp_bass", "at": "2026-05-01T12:00:00.000Z", "lengthMm": 400 },
+        { "id": "t2", "species": "kelp_bass", "at": "2026-05-02T12:00:00.000Z", "lengthMm": 400 }
+      ],
+      "expect": [
+        {
+          "speciesId": "kelp_bass", "catchCount": 2, "fishCount": 2, "keptCount": 0, "releasedCount": 0,
+          "firstCatchId": "t1", "latestCatchId": "t2",
+          "bestLengthCatchId": "t1", "bestLengthValue": 400,
+          "bestWeightCatchId": null, "bestWeightValue": null
+        }
+      ]
+    },
+    {
+      "name": "out-of-order input still finds the true first and latest",
+      "catches": [
+        { "id": "o2", "species": "kelp_bass", "at": "2026-06-05T12:00:00.000Z" },
+        { "id": "o1", "species": "kelp_bass", "at": "2026-06-01T12:00:00.000Z" },
+        { "id": "o3", "species": "kelp_bass", "at": "2026-06-03T12:00:00.000Z" }
+      ],
+      "expect": [
+        {
+          "speciesId": "kelp_bass", "catchCount": 3, "fishCount": 3, "keptCount": 0, "releasedCount": 0,
+          "firstCatchId": "o1", "latestCatchId": "o2",
+          "bestLengthCatchId": null, "bestLengthValue": null,
+          "bestWeightCatchId": null, "bestWeightValue": null
+        }
+      ]
+    }
+  ],
+
+  "totals": [
+    {
+      "name": "newest species is the most recent first-catch, not the most recent catch",
+      "catches": [
+        { "id": "n1", "species": "kelp_bass", "at": "2026-01-01T12:00:00.000Z", "disposition": "kept" },
+        { "id": "n2", "species": "barred_sand_bass", "at": "2026-02-01T12:00:00.000Z", "disposition": "released" },
+        { "id": "n3", "species": "kelp_bass", "at": "2026-03-01T12:00:00.000Z", "disposition": "released", "quantity": 2 }
+      ],
+      "expect": {
+        "uniqueSpecies": 2, "totalCatches": 3, "totalFish": 4, "keptCount": 1, "releasedCount": 2,
+        "latestNewSpeciesId": "barred_sand_bass"
+      }
+    },
+    {
+      "name": "an empty log is an empty passport, not an error",
+      "catches": [],
+      "expect": {
+        "uniqueSpecies": 0, "totalCatches": 0, "totalFish": 0, "keptCount": 0, "releasedCount": 0,
+        "latestNewSpeciesId": null
+      }
+    }
+  ],
+
+  "collectionProgress": [
+    {
+      "name": "a group catch does not close an individual species slot",
+      "definition": {
+        "id": "rockfish", "required": ["vermilion_rockfish"], "informational": []
+      },
+      "caught": ["rockfish"],
+      "expect": { "caught": 0, "required": 1, "informationalCaught": 0, "complete": false }
+    },
+    {
+      "name": "naming the fish closes the slot",
+      "definition": {
+        "id": "rockfish", "required": ["vermilion_rockfish"], "informational": []
+      },
+      "caught": ["rockfish", "vermilion_rockfish"],
+      "expect": { "caught": 1, "required": 1, "informationalCaught": 0, "complete": true }
+    },
+    {
+      "name": "a protected species is shown but never required, so 100% stays reachable legally",
+      "definition": {
+        "id": "bass", "required": ["kelp_bass", "barred_sand_bass"], "informational": ["giant_sea_bass"]
+      },
+      "caught": ["kelp_bass", "barred_sand_bass"],
+      "expect": { "caught": 2, "required": 2, "informationalCaught": 0, "complete": true }
+    },
+    {
+      "name": "catching the protected one is recorded without changing completion",
+      "definition": {
+        "id": "bass", "required": ["kelp_bass", "barred_sand_bass"], "informational": ["giant_sea_bass"]
+      },
+      "caught": ["kelp_bass", "barred_sand_bass", "giant_sea_bass"],
+      "expect": { "caught": 2, "required": 2, "informationalCaught": 1, "complete": true }
+    }
+  ]
+}

--- a/src/features/passport/components/badge-list.tsx
+++ b/src/features/passport/components/badge-list.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import Link from "next/link";
+
+import { BADGES } from "@/core/rules/achievements/catalog";
+
+import { usePassport } from "../data";
+import { CARD_CLASS, SECONDARY_BUTTON } from "../ui-classes";
+
+/**
+ * Badges and progress (spec §12–§13).
+ *
+ * Earned state is carried by a word and a border, never by colour alone (spec §33), and
+ * progress is stated as a plain fraction rather than a bar an angler has to interpret at
+ * arm's length on a moving boat.
+ */
+export function BadgeList() {
+  const { hydrated, badges } = usePassport();
+  const earned = badges.filter((b) => b.earned).length;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <nav>
+        <Link
+          href="/passport"
+          className="inline-flex min-h-touch-floor items-center text-label text-text-link focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+        >
+          ← Passport
+        </Link>
+      </nav>
+
+      <section className={`${CARD_CLASS} p-4`}>
+        <h1 className="text-h1">Badges</h1>
+        <p className="mt-1 text-body text-text-muted" aria-live="polite">
+          {hydrated ? `${earned} of ${badges.length} earned.` : "Reading your log…"}
+        </p>
+      </section>
+
+      <ul className="flex flex-col gap-3">
+        {badges.map((standing) => {
+          const definition = BADGES.find((b) => b.id === standing.badgeId);
+          if (definition === undefined) return null;
+
+          return (
+            <li
+              key={standing.badgeId}
+              className={`rounded-lg border p-4 ${
+                standing.earned
+                  ? "border-signal-orange bg-surface"
+                  : "border-dashed border-border-interactive bg-background"
+              }`}
+            >
+              <div className="flex items-baseline justify-between gap-3">
+                <h2 className="text-body-strong text-text-primary">{definition.name}</h2>
+                <span className="text-caption text-text-muted">
+                  {standing.earned ? "Earned" : `${standing.current} of ${standing.threshold}`}
+                </span>
+              </div>
+              <p className="mt-1 text-body text-text-muted">{definition.description}</p>
+              {standing.earned && standing.awardedAt !== null ? (
+                <p className="mt-1 text-caption text-text-muted">
+                  Earned {standing.awardedAt.slice(0, 10)}
+                </p>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+
+      <p className="text-caption text-text-muted">
+        There are no streaks here, and there will not be. Weather decides whether you fish this
+        week; a badge should not.
+      </p>
+
+      <Link href="/passport/species" className={SECONDARY_BUTTON}>
+        My Species
+      </Link>
+    </div>
+  );
+}

--- a/src/features/passport/components/collection-detail.tsx
+++ b/src/features/passport/components/collection-detail.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import Link from "next/link";
+
+import { speciesById } from "@/core/ontology/species";
+
+import { usePassport } from "../data";
+import { CARD_CLASS, SECONDARY_BUTTON } from "../ui-classes";
+
+/**
+ * One collection (spec §11).
+ *
+ * Informational-only species are listed apart from the required ones and labelled, so the
+ * screen can never read as "go and catch this protected fish to finish the set".
+ */
+export function CollectionDetail({ collectionId }: { collectionId: string }) {
+  const { hydrated, collections, caughtSpeciesIds } = usePassport();
+  const standing = collections.find((c) => c.definition.id === collectionId);
+
+  if (standing === undefined) {
+    return (
+      <div className={`${CARD_CLASS} p-4`}>
+        <h1 className="text-h1">Collection not found</h1>
+        <Link href="/passport" className={`${SECONDARY_BUTTON} mt-4`}>
+          Back to Passport
+        </Link>
+      </div>
+    );
+  }
+
+  const { definition, progress } = standing;
+  const required = definition.species.filter((s) => !s.informationalOnly);
+  const informational = definition.species.filter((s) => s.informationalOnly);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <nav>
+        <Link
+          href="/passport"
+          className="inline-flex min-h-touch-floor items-center text-label text-text-link focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+        >
+          ← Passport
+        </Link>
+      </nav>
+
+      <section className={`${CARD_CLASS} p-4`}>
+        <h1 className="text-h1">{definition.name}</h1>
+        <p className="mt-1 text-body text-text-muted">{definition.description}</p>
+        <p className="mt-3 text-body-strong" aria-live="polite">
+          {hydrated
+            ? `${progress.caught} of ${progress.required}${progress.complete ? " · complete" : ""}`
+            : "Reading your log…"}
+        </p>
+      </section>
+
+      <section className={`${CARD_CLASS} p-4`}>
+        <h2 className="text-h3">In this collection</h2>
+        <ul className="mt-3 flex flex-col gap-2">
+          {required.map((entry) => (
+            <SpeciesRow
+              key={entry.speciesId}
+              speciesId={entry.speciesId}
+              caught={caughtSpeciesIds.has(entry.speciesId)}
+            />
+          ))}
+        </ul>
+      </section>
+
+      {informational.length > 0 ? (
+        <section className={`${CARD_CLASS} p-4`}>
+          <h2 className="text-h3">Protected</h2>
+          <p className="mt-2 text-body text-text-muted">
+            These are in the family but never count toward finishing it. If you hook one, let it
+            go.
+          </p>
+          <ul className="mt-3 flex flex-col gap-2">
+            {informational.map((entry) => (
+              <SpeciesRow
+                key={entry.speciesId}
+                speciesId={entry.speciesId}
+                caught={caughtSpeciesIds.has(entry.speciesId)}
+                protectedSpecies
+              />
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+function SpeciesRow({
+  speciesId,
+  caught,
+  protectedSpecies = false,
+}: {
+  speciesId: string;
+  caught: boolean;
+  protectedSpecies?: boolean;
+}) {
+  const species = speciesById(speciesId);
+  if (species === null) return null;
+
+  return (
+    <li>
+      <Link
+        href={`/passport/species/${speciesId}`}
+        className="flex min-h-touch-floor items-center justify-between gap-3 rounded-md border border-hairline px-3 text-body transition-colors hover:bg-surface-raised focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+      >
+        <span className={caught ? "text-text-primary" : "text-text-muted"}>
+          {species.commonName}
+        </span>
+        <span className="text-caption text-text-muted">
+          {protectedSpecies ? "Protected" : caught ? "Caught" : "Not yet"}
+        </span>
+      </Link>
+    </li>
+  );
+}

--- a/src/features/passport/components/passport-overview.tsx
+++ b/src/features/passport/components/passport-overview.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import Link from "next/link";
+
+import { speciesById } from "@/core/ontology/species";
+
+import { usePassport } from "../data";
+import { CARD_CLASS, SECONDARY_BUTTON } from "../ui-classes";
+
+/**
+ * The passport overview (spec §8.2).
+ *
+ * Every card here leads somewhere real — a species, a collection, a badge. Spec §8.2 is
+ * explicit that this must not become a feed of generic achievements, so there is no
+ * activity list and no "you're on a roll" copy.
+ */
+export function PassportOverview() {
+  const { hydrated, totals, collections, badges, nearestGoals } = usePassport();
+  const earned = badges.filter((b) => b.earned);
+  const newest = totals.latestNewSpecies;
+  const newestName =
+    newest !== null ? (speciesById(newest.speciesId)?.commonName ?? newest.speciesId) : null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <section className={`${CARD_CLASS} p-4`}>
+        <h1 className="text-h1">Passport</h1>
+        <p className="mt-1 text-body text-text-muted">
+          Everything you have caught, built from your log.
+        </p>
+
+        {!hydrated ? (
+          <p className="mt-3 text-body text-text-muted">Reading your log…</p>
+        ) : (
+          <dl className="mt-4 grid grid-cols-2 gap-3">
+            <Stat label="Species" value={String(totals.uniqueSpecies)} />
+            <Stat label="Catches" value={String(totals.totalCatches)} />
+            <Stat label="Released" value={String(totals.releasedCount)} />
+            <Stat label="Kept" value={String(totals.keptCount)} />
+          </dl>
+        )}
+      </section>
+
+      {hydrated && totals.uniqueSpecies === 0 ? (
+        <section className={`${CARD_CLASS} p-4`}>
+          <h2 className="text-h3">Nothing here yet</h2>
+          <p className="mt-2 text-body text-text-muted">
+            Log a fish and it appears here. Everything on this page is built from catches you
+            have already recorded — there is nothing extra to fill in.
+          </p>
+          <Link href="/log" className={`${SECONDARY_BUTTON} mt-3`}>
+            Open the log
+          </Link>
+        </section>
+      ) : null}
+
+      {newestName !== null ? (
+        <section className={`${CARD_CLASS} p-4`}>
+          <h2 className="text-h3">Newest species</h2>
+          <p className="mt-2 text-body">
+            <Link
+              href={`/passport/species/${newest?.speciesId}`}
+              className="text-text-link focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+            >
+              {newestName}
+            </Link>{" "}
+            <span className="text-text-muted">· {newest?.caughtAt.slice(0, 10)}</span>
+          </p>
+        </section>
+      ) : null}
+
+      {nearestGoals.length > 0 ? (
+        <section className={`${CARD_CLASS} p-4`}>
+          <h2 className="text-h3">Closest to done</h2>
+          <ul className="mt-3 flex flex-col gap-3">
+            {nearestGoals.map((goal) => (
+              <li key={`${goal.kind}-${goal.id}`}>
+                <Link
+                  href={goal.href}
+                  className="flex min-h-touch-floor items-center justify-between gap-3 rounded-md border border-hairline px-3 text-body transition-colors hover:bg-surface-raised focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+                >
+                  <span>{goal.name}</span>
+                  <span className="text-caption text-text-muted">
+                    {goal.current} of {goal.target}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <section className={`${CARD_CLASS} p-4`}>
+        <h2 className="text-h3">Collections</h2>
+        <ul className="mt-3 flex flex-col gap-2">
+          {collections.map(({ definition, progress }) => (
+            <li key={definition.id}>
+              <Link
+                href={`/passport/collections/${definition.id}`}
+                className="flex min-h-touch-floor items-center justify-between gap-3 rounded-md border border-hairline px-3 text-body transition-colors hover:bg-surface-raised focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+              >
+                <span>{definition.name}</span>
+                <span className="text-caption text-text-muted">
+                  {progress.caught} of {progress.required}
+                  {progress.complete ? " · complete" : ""}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className={`${CARD_CLASS} p-4`}>
+        <h2 className="text-h3">Badges</h2>
+        <p className="mt-2 text-body text-text-muted">
+          {earned.length} of {badges.length} earned.
+        </p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <Link href="/passport/badges" className={SECONDARY_BUTTON}>
+            See badges
+          </Link>
+          <Link href="/passport/species" className={SECONDARY_BUTTON}>
+            My Species
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-caption text-text-muted">{label}</dt>
+      <dd className="text-h2 text-text-primary">{value}</dd>
+    </div>
+  );
+}

--- a/src/features/passport/components/species-detail.tsx
+++ b/src/features/passport/components/species-detail.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo } from "react";
+
+import { speciesById } from "@/core/ontology/species";
+import { collectionsForSpecies } from "@/core/rules/passport/collections";
+import { formatLength, formatWeight, type UnitSystem } from "@/features/catches/format";
+import { currentZone, useLog } from "@/features/catches/store";
+import { speciesPhoto } from "@/features/fish-legal/species-photos";
+
+import { usePassport } from "../data";
+import { CARD_CLASS, SECONDARY_BUTTON } from "../ui-classes";
+
+/**
+ * One species, for one angler (passport spec §9.2, Ticket 4).
+ *
+ * This is the page the passport exists for. It is the first screen in the app that pays
+ * an angler back for the work of logging: how many, how big, when they started, what the
+ * fish came on. Everything on it is read from catches that are already in the log — no
+ * new field, no new prompt, no new step at the water.
+ *
+ * What it does NOT do is draw conclusions from three fish. The most-used bait line only
+ * appears once there is enough history to mean something; below that the honest answer is
+ * to show the catches and let the angler read them. Existing sample-size stance (spec §9.2).
+ */
+
+/** Below this, "you mostly catch these on X" is a coincidence, not a pattern. */
+const PATTERN_MINIMUM = 5;
+
+export function SpeciesDetail({
+  speciesId,
+  unitSystem,
+}: {
+  speciesId: string;
+  /**
+   * Passed in the way `FishLog` takes it. The ft/m setting in Settings is the *depth*
+   * preference and deliberately not this — a fish is reported the way the log reports it,
+   * so the two screens can never disagree about the same fish.
+   */
+  unitSystem: UnitSystem;
+}) {
+  const species = speciesById(speciesId);
+  const { hydrated, summaryOf } = usePassport();
+  const log = useLog();
+
+  const summary = summaryOf(speciesId);
+  const photo = useMemo(() => speciesPhoto(speciesId), [speciesId]);
+  const zone = currentZone();
+
+  const catches = useMemo(
+    () =>
+      log.catches
+        .filter((c) => c.species_id === speciesId && c.deleted_at === null)
+        .sort((a, b) => Date.parse(b.caught_at) - Date.parse(a.caught_at)),
+    [log.catches, speciesId],
+  );
+
+  const topBait = useMemo(() => {
+    if (catches.length < PATTERN_MINIMUM) return null;
+    const counts = new Map<string, number>();
+    for (const record of catches) {
+      for (const item of log.gear.filter((g) => g.catch_id === record.id && g.deleted_at === null)) {
+        if (item.role !== "bait" && item.role !== "lure" && item.role !== "jig") continue;
+        counts.set(item.label, (counts.get(item.label) ?? 0) + 1);
+      }
+    }
+    const ranked = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+    return ranked.length > 0 ? ranked[0] : null;
+  }, [catches, log.gear]);
+
+  if (species === null) {
+    return (
+      <div className={`${CARD_CLASS} p-4`}>
+        <h1 className="text-h1">Species not found</h1>
+        <p className="mt-2 text-body text-text-muted">
+          This species is not in the vocabulary. It may have been renamed.
+        </p>
+        <Link href="/passport/species" className={`${SECONDARY_BUTTON} mt-4`}>
+          Back to My Species
+        </Link>
+      </div>
+    );
+  }
+
+  const collections = collectionsForSpecies(speciesId);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <nav>
+        <Link
+          href="/passport/species"
+          className="inline-flex min-h-touch-floor items-center text-label text-text-link focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+        >
+          ← My Species
+        </Link>
+      </nav>
+
+      <section className={`${CARD_CLASS} p-4`}>
+        {photo !== null ? (
+          <figure className="mb-3">
+            {/* eslint-disable-next-line @next/next/no-img-element -- bundled local asset, offline-first */}
+            <img
+              src={photo.src}
+              alt={`Identification photo: ${species.commonName}`}
+              className="h-40 w-full rounded-md object-cover"
+              width={640}
+              height={320}
+            />
+            <figcaption className="mt-1 text-caption text-text-muted">
+              {photo.credit} · {photo.license}
+            </figcaption>
+          </figure>
+        ) : null}
+
+        <h1 className="text-h1">{species.commonName}</h1>
+        {species.scientificName !== null ? (
+          <p className="mt-1 text-caption italic text-text-muted">{species.scientificName}</p>
+        ) : null}
+
+        <p className="mt-2 text-caption text-text-muted">
+          {species.waterClass === "salt" ? "Saltwater" : "Freshwater"}
+          {species.takeStatus === "protected" ? " · Protected — release it" : ""}
+          {species.takeStatus === "regulated" ? " · Limits apply" : ""}
+        </p>
+
+        {!hydrated ? (
+          <p className="mt-3 text-body text-text-muted">Reading your log…</p>
+        ) : summary === null ? (
+          <p className="mt-3 text-body text-text-muted">
+            You have not logged one of these yet.
+          </p>
+        ) : null}
+      </section>
+
+      {summary !== null ? (
+        <>
+          <section className={`${CARD_CLASS} p-4`}>
+            <h2 className="text-h3">Your record</h2>
+            <dl className="mt-3 grid grid-cols-2 gap-3">
+              <Stat label="Catches" value={String(summary.catchCount)} />
+              <Stat label="Fish" value={String(summary.fishCount)} />
+              <Stat label="Released" value={String(summary.releasedCount)} />
+              <Stat label="Kept" value={String(summary.keptCount)} />
+            </dl>
+
+            <dl className="mt-4 flex flex-col gap-3">
+              <Stat
+                label="Longest"
+                value={
+                  summary.bestLength !== null
+                    ? `${formatLength(summary.bestLength.value, unitSystem) ?? "—"}${
+                        summary.bestLength.estimated ? " (estimated)" : ""
+                      }`
+                    : "Not measured yet"
+                }
+              />
+              <Stat
+                label="Heaviest"
+                value={
+                  summary.bestWeight !== null
+                    ? `${formatWeight(summary.bestWeight.value, unitSystem) ?? "—"}${
+                        summary.bestWeight.estimated ? " (estimated)" : ""
+                      }`
+                    : "Not weighed yet"
+                }
+              />
+              <Stat label="First caught" value={summary.firstCaughtAt.slice(0, 10)} />
+              <Stat label="Most recent" value={summary.latestCaughtAt.slice(0, 10)} />
+            </dl>
+
+            {topBait !== null ? (
+              <p className="mt-4 text-body text-text-muted">
+                Most often on <span className="text-text-primary">{topBait[0]}</span> — {topBait[1]}{" "}
+                of {catches.length} catches.
+              </p>
+            ) : (
+              <p className="mt-4 text-caption text-text-muted">
+                Once you have {PATTERN_MINIMUM} of these logged, this is where what they came on
+                will show.
+              </p>
+            )}
+          </section>
+
+          <section className={`${CARD_CLASS} p-4`}>
+            <h2 className="text-h3">Every one you have caught</h2>
+            <ul className="mt-3 flex flex-col gap-2">
+              {catches.slice(0, 50).map((record) => (
+                <li key={record.id}>
+                  <Link
+                    href={`/catch/${record.id}`}
+                    className="flex min-h-touch-floor items-center justify-between gap-3 rounded-md border border-hairline px-3 text-body transition-colors hover:bg-surface-raised focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+                  >
+                    <span>{record.local_date}</span>
+                    <span className="text-caption text-text-muted">
+                      {record.disposition === "released"
+                        ? "Released"
+                        : record.disposition === "kept"
+                          ? "Kept"
+                          : "Logged"}
+                      {record.length_mm !== null
+                        ? ` · ${formatLength(record.length_mm, unitSystem) ?? ""}`
+                        : ""}
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+            {catches.length > 50 ? (
+              <p className="mt-2 text-caption text-text-muted">
+                Showing the 50 most recent of {catches.length}.
+              </p>
+            ) : null}
+          </section>
+        </>
+      ) : null}
+
+      {collections.length > 0 ? (
+        <section className={`${CARD_CLASS} p-4`}>
+          <h2 className="text-h3">Collections</h2>
+          <ul className="mt-3 flex flex-wrap gap-2">
+            {collections.map((collection) => (
+              <li key={collection.id}>
+                <Link href={`/passport/collections/${collection.id}`} className={SECONDARY_BUTTON}>
+                  {collection.name}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <section className={`${CARD_CLASS} p-4`}>
+        <h2 className="text-h3">Before you keep one</h2>
+        <p className="mt-2 text-body text-text-muted">
+          Limits and seasons change. Check the current rules for where you are fishing.
+        </p>
+        <Link href={`/fish-legal/species/${species.id}`} className={`${SECONDARY_BUTTON} mt-3`}>
+          Open Fish Legal
+        </Link>
+      </section>
+
+      <p className="text-caption text-text-muted">Zone: {zone}</p>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-caption text-text-muted">{label}</dt>
+      <dd className="text-body-strong text-text-primary">{value}</dd>
+    </div>
+  );
+}

--- a/src/features/passport/components/species-grid.tsx
+++ b/src/features/passport/components/species-grid.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+
+import { SPECIES, type Species } from "@/core/ontology/species";
+import { COLLECTIONS } from "@/core/rules/passport/collections";
+import type { SpeciesSummary } from "@/core/rules/passport/types";
+
+import { usePassport } from "../data";
+import { CARD_CLASS, CHIP_CLASS, CHIP_OFF, CHIP_ON, SELECT_CLASS } from "../ui-classes";
+
+/**
+ * My Species (passport spec §9, Ticket 3).
+ *
+ * The gaps are the point. A grid that showed only what an angler has caught would be a
+ * trophy cabinet; showing the fish they have *not* caught, in the families they already
+ * fish, is what makes someone try a new spot. Uncaught cards are deliberately quiet —
+ * a dashed outline and muted type, never a locked padlock or a nag.
+ *
+ * Protected species carry a label and are never presented as something to go and get
+ * (spec §9, §11). They are here so an angler learns the fish exists and knows to let it go.
+ *
+ * Photos live on the detail page, not here. Only 51 of 178 species have a bundled image
+ * and each carries an attribution line it must be shown with, so a grid of them would be
+ * both patchy and non-compliant. Text at 320px is also simply faster to read.
+ */
+
+type CaughtFilter = "all" | "caught" | "uncaught";
+type WaterFilter = "all" | "salt" | "fresh";
+type SortKey = "recent" | "first" | "most" | "name" | "best-length";
+
+const SORT_LABELS: Record<SortKey, string> = {
+  recent: "Recently caught",
+  first: "First caught",
+  most: "Most caught",
+  name: "Name A–Z",
+  "best-length": "Personal best",
+};
+
+function millisOf(iso: string | undefined): number {
+  if (iso === undefined) return -1;
+  const ms = Date.parse(iso);
+  return Number.isNaN(ms) ? -1 : ms;
+}
+
+export function SpeciesGrid() {
+  const { hydrated, summaryOf, caughtSpeciesIds } = usePassport();
+  const [caught, setCaught] = useState<CaughtFilter>("all");
+  const [water, setWater] = useState<WaterFilter>("all");
+  const [family, setFamily] = useState<string>("all");
+  const [sort, setSort] = useState<SortKey>("recent");
+
+  const familyMembers = useMemo(() => {
+    const map = new Map<string, ReadonlySet<string>>();
+    for (const collection of COLLECTIONS) {
+      map.set(collection.id, new Set(collection.species.map((s) => s.speciesId)));
+    }
+    return map;
+  }, []);
+
+  const rows = useMemo(() => {
+    const members = family === "all" ? null : familyMembers.get(family);
+
+    const visible = SPECIES.filter((species) => {
+      // Group entries ("Rockfish") are a way to log a fish you cannot name, not a
+      // collectible. Spec §10 keeps them in history and out of the collection.
+      if (species.isGroup) return false;
+      if (members !== null && members !== undefined && !members.has(species.id)) return false;
+      if (water !== "all" && species.waterClass !== water) return false;
+
+      const has = caughtSpeciesIds.has(species.id);
+      if (caught === "caught" && !has) return false;
+      if (caught === "uncaught" && has) return false;
+      return true;
+    });
+
+    const withSummary = visible.map((species) => ({
+      species,
+      summary: summaryOf(species.id),
+    }));
+
+    const byName = (a: { species: Species }, b: { species: Species }) =>
+      a.species.commonName.localeCompare(b.species.commonName);
+
+    return withSummary.sort((a, b) => {
+      // An uncaught species has nothing to sort by, so it falls to the bottom by name
+      // rather than jumbling through the middle of the list.
+      if (sort === "name") return byName(a, b);
+      if (a.summary === null && b.summary === null) return byName(a, b);
+      if (a.summary === null) return 1;
+      if (b.summary === null) return -1;
+
+      if (sort === "recent") {
+        return millisOf(b.summary.latestCaughtAt) - millisOf(a.summary.latestCaughtAt) || byName(a, b);
+      }
+      if (sort === "first") {
+        return millisOf(a.summary.firstCaughtAt) - millisOf(b.summary.firstCaughtAt) || byName(a, b);
+      }
+      if (sort === "most") return b.summary.catchCount - a.summary.catchCount || byName(a, b);
+      return (b.summary.bestLength?.value ?? 0) - (a.summary.bestLength?.value ?? 0) || byName(a, b);
+    });
+  }, [caught, water, family, sort, familyMembers, caughtSpeciesIds, summaryOf]);
+
+  const caughtCount = rows.filter((r) => r.summary !== null).length;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-wrap gap-2" role="group" aria-label="Show">
+          {(["all", "caught", "uncaught"] as const).map((value) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setCaught(value)}
+              aria-pressed={caught === value}
+              className={`${CHIP_CLASS} ${caught === value ? CHIP_ON : CHIP_OFF}`}
+            >
+              {value === "all" ? "All" : value === "caught" ? "Caught" : "Not yet"}
+            </button>
+          ))}
+        </div>
+
+        {/*
+          Two up, then sort across the bottom. Stacked, these three ate the whole first
+          screen at 320px and pushed every fish below the fold — the grid is the page, not
+          the controls.
+        */}
+        <div className="grid grid-cols-2 gap-2">
+          <label className="flex flex-col gap-1">
+            <span className="text-caption text-text-muted">Water</span>
+            <select
+              value={water}
+              onChange={(e) => setWater(e.target.value as WaterFilter)}
+              className={`${SELECT_CLASS} w-full`}
+            >
+              <option value="all">All water</option>
+              <option value="salt">Saltwater</option>
+              <option value="fresh">Freshwater</option>
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span className="text-caption text-text-muted">Family</span>
+            <select
+              value={family}
+              onChange={(e) => setFamily(e.target.value)}
+              className={`${SELECT_CLASS} w-full`}
+            >
+              <option value="all">All families</option>
+              {COLLECTIONS.map((collection) => (
+                <option key={collection.id} value={collection.id}>
+                  {collection.name}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="col-span-2 flex flex-col gap-1">
+            <span className="text-caption text-text-muted">Sort</span>
+            <select
+              value={sort}
+              onChange={(e) => setSort(e.target.value as SortKey)}
+              className={`${SELECT_CLASS} w-full`}
+            >
+              {(Object.keys(SORT_LABELS) as SortKey[]).map((key) => (
+                <option key={key} value={key}>
+                  {SORT_LABELS[key]}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </div>
+
+      <p className="text-caption text-text-muted" aria-live="polite">
+        {!hydrated
+          ? "Reading your log…"
+          : `${caughtCount} caught of ${rows.length} shown`}
+      </p>
+
+      {rows.length === 0 ? (
+        <p className={`${CARD_CLASS} p-4 text-body text-text-muted`}>
+          Nothing matches those filters. Try widening them.
+        </p>
+      ) : (
+        <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          {rows.map(({ species, summary }) => (
+            <li key={species.id}>
+              <SpeciesCard species={species} summary={summary} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function SpeciesCard({
+  species,
+  summary,
+}: {
+  species: Species;
+  summary: SpeciesSummary | null;
+}) {
+  const caught = summary !== null;
+
+  return (
+    <Link
+      href={`/passport/species/${species.id}`}
+      className={`flex h-full min-h-touch-floor flex-col gap-1 rounded-lg border p-3 transition-colors focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring ${
+        caught
+          ? "border-hairline bg-surface hover:bg-surface-raised"
+          : "border-dashed border-border-interactive bg-background hover:bg-surface"
+      }`}
+    >
+      <span className={`text-body-strong ${caught ? "text-text-primary" : "text-text-muted"}`}>
+        {species.commonName}
+      </span>
+
+      {species.scientificName !== null ? (
+        <span className="text-caption italic text-text-muted">{species.scientificName}</span>
+      ) : null}
+
+      {/* Status is words as well as colour and weight — spec §33. */}
+      {caught ? (
+        <span className="mt-auto text-caption text-text-muted">
+          {summary.catchCount === 1 ? "1 catch" : `${summary.catchCount} catches`}
+          {summary.bestLength !== null ? ` · best ${Math.round(summary.bestLength.value / 10)} cm` : ""}
+        </span>
+      ) : (
+        <span className="mt-auto text-caption text-text-muted">Not yet caught</span>
+      )}
+
+      {species.takeStatus === "protected" ? (
+        <span className="text-caption text-amber-flag">Protected — release it</span>
+      ) : null}
+    </Link>
+  );
+}

--- a/src/features/passport/data.ts
+++ b/src/features/passport/data.ts
@@ -1,0 +1,127 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { BADGES } from "@/core/rules/achievements/catalog";
+import { evaluateBadges } from "@/core/rules/achievements/evaluate";
+import type { BadgeStanding } from "@/core/rules/achievements/types";
+import { COLLECTIONS, GROUP_SPECIES_IDS } from "@/core/rules/passport/collections";
+import {
+  collectionProgress,
+  passportTotals,
+  speciesSummaries,
+} from "@/core/rules/passport/selectors";
+import type {
+  CollectionDefinition,
+  CollectionProgress,
+  PassportTotals,
+  SpeciesSummary,
+} from "@/core/rules/passport/types";
+import { SPECIES, speciesById } from "@/core/ontology/species";
+import { useLog } from "@/features/catches/store";
+
+/**
+ * The passport's application layer: the one place the pure rules meet the local log.
+ *
+ * Reading `features/catches/store` across a feature boundary follows the precedent set by
+ * the tide screen — the log store is the app's single source of catches, not an internal
+ * of the catch UI, and a second copy of it would be the actual ADR 005 §3 violation.
+ *
+ * Everything below is derived on the client from records already in IndexedDB, which is
+ * why the passport works in airplane mode (spec §4.6, §37): there is nothing to fetch.
+ */
+
+const KNOWN_SPECIES_IDS: ReadonlySet<string> = new Set(SPECIES.map((s) => s.id));
+
+const waterClassOf = (speciesId: string): "salt" | "fresh" | null =>
+  speciesById(speciesId)?.waterClass ?? null;
+
+export interface CollectionStanding {
+  readonly definition: CollectionDefinition;
+  readonly progress: CollectionProgress;
+}
+
+/** A goal an angler is close to finishing — a collection or a badge (spec §8.2). */
+export interface Goal {
+  readonly kind: "collection" | "badge";
+  readonly id: string;
+  readonly name: string;
+  readonly current: number;
+  readonly target: number;
+  readonly href: string;
+}
+
+export interface PassportView {
+  readonly hydrated: boolean;
+  readonly summaries: readonly SpeciesSummary[];
+  readonly summaryOf: (speciesId: string) => SpeciesSummary | null;
+  readonly caughtSpeciesIds: ReadonlySet<string>;
+  readonly totals: PassportTotals;
+  readonly collections: readonly CollectionStanding[];
+  readonly badges: readonly BadgeStanding[];
+  /** The three nearest to done, furthest along first. Never includes finished ones. */
+  readonly nearestGoals: readonly Goal[];
+}
+
+export function usePassport(): PassportView {
+  const log = useLog();
+
+  return useMemo(() => {
+    const summaries = speciesSummaries(log.catches, KNOWN_SPECIES_IDS);
+    const byId = new Map(summaries.map((s) => [s.speciesId, s]));
+    const caughtSpeciesIds = new Set(byId.keys());
+
+    const collections = COLLECTIONS.map((definition) => ({
+      definition,
+      progress: collectionProgress(definition, caughtSpeciesIds, GROUP_SPECIES_IDS),
+    }));
+
+    const badges = evaluateBadges(BADGES, {
+      catches: log.catches,
+      trips: log.trips,
+      knownSpeciesIds: KNOWN_SPECIES_IDS,
+      waterClassOf,
+    });
+
+    const goals: Goal[] = [
+      ...collections
+        .filter((c) => !c.progress.complete && c.progress.required > 0)
+        .map((c) => ({
+          kind: "collection" as const,
+          id: c.definition.id,
+          name: c.definition.name,
+          current: c.progress.caught,
+          target: c.progress.required,
+          href: `/passport/collections/${c.definition.id}`,
+        })),
+      ...badges
+        .filter((b) => !b.earned)
+        .map((b) => ({
+          kind: "badge" as const,
+          id: b.badgeId,
+          name: BADGES.find((d) => d.id === b.badgeId)?.name ?? b.badgeId,
+          current: b.current,
+          target: b.threshold,
+          href: "/passport/badges",
+        })),
+    ];
+
+    // Nearest to done first. A goal not yet started sorts last rather than first — the
+    // point of the card is "you are close", not "here are nine things you have not done".
+    const nearestGoals = goals
+      .filter((g) => g.current > 0)
+      .sort((a, b) => b.current / b.target - a.current / a.target)
+      .slice(0, 3);
+
+    return {
+      hydrated: log.hydrated,
+      summaries,
+      summaryOf: (speciesId: string) => byId.get(speciesId) ?? null,
+      caughtSpeciesIds,
+      totals: passportTotals(summaries),
+      collections,
+      badges,
+      nearestGoals,
+    };
+  }, [log.catches, log.trips, log.hydrated]);
+}

--- a/src/features/passport/flag.ts
+++ b/src/features/passport/flag.ts
@@ -1,0 +1,10 @@
+/**
+ * `passport_v1` (passport spec §35).
+ *
+ * A build-time constant rather than a runtime lookup, so the routes stay static and a
+ * cold load on a boat still paints without the network (ADR 005 §5). The spec's
+ * requirement is that rules and data can ship before the UI is exposed; setting
+ * `NEXT_PUBLIC_PASSPORT_V1=off` does exactly that — the selectors, catalog and tests all
+ * still build, and only the screens disappear.
+ */
+export const PASSPORT_V1 = (process.env.NEXT_PUBLIC_PASSPORT_V1 ?? "on").toLowerCase() !== "off";

--- a/src/features/passport/ui-classes.ts
+++ b/src/features/passport/ui-classes.ts
@@ -1,0 +1,21 @@
+/**
+ * The passport's repeated controls.
+ *
+ * Copied value-for-value from `features/catches/ui-classes.ts` for the reason stated
+ * there: ADR 005 §3 forbids reaching into another feature's internals, and four class
+ * strings are a cheaper duplication than a cross-feature import. When a third caller
+ * appears these move to `src/components/`.
+ */
+
+export const FOCUS_RING =
+  "focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring";
+
+export const CHIP_CLASS = `min-h-touch-floor rounded-full border px-4 text-label transition-colors ${FOCUS_RING} active:scale-95 motion-reduce:transition-none`;
+export const CHIP_ON = "border-signal-orange bg-signal-orange text-ink-on-orange";
+export const CHIP_OFF = "border-border-interactive bg-surface text-text-link";
+
+export const SECONDARY_BUTTON = `inline-flex min-h-touch-floor items-center justify-center rounded-md border border-border-interactive px-4 text-label text-text-link transition-colors ${FOCUS_RING} active:scale-95 motion-reduce:transition-none`;
+
+export const CARD_CLASS = "rounded-lg border border-hairline bg-surface";
+
+export const SELECT_CLASS = `min-h-touch-floor rounded-md border border-border-interactive bg-background px-3 text-label text-text-primary ${FOCUS_RING}`;


### PR DESCRIPTION
Files the founder's Fishing Passport specification, resolves the decisions that were blocking it, and implements Phase 1 plus slams.

## What changed

**The spec** — `docs/specs/fishing-passport-wildlife-boat-games.md`, with a `docs/specs/README.md` index so the folder is reachable by path rather than by memory. Sections 1–43 are the founder's document verbatim in substance. Sections 44–48 are added: repo reality check, three blocked items, a sequencing recommendation, and the slam rules.

**Four decisions, recorded with reasoning:**

| Decision | Why |
|---|---|
| Geographic collections and New Waters I cut from Phase 1 | `reg_area.boundary_geojson` is effectively unpopulated and `RegionId` carries no geometry — deriving a region from a catch's GPS has nothing to derive from. Snapshotting the Settings preference was rejected on merit: it records where an angler *says* they fish. |
| Photos and the media table cut | Cost. This also removes verification levels 1–2 from Phase 2, since both are defined as "media attached". |
| ROADMAP C1 accepted into Phase 2 | Nothing in the 43 sections answers "should I go tomorrow", the only question that gets the app opened by someone not currently fishing. |
| `species.water_class` `both` resolves from `trip.water_class` | Already non-null on every trip. A striped bass caught in a river should not credit the saltwater collection. |

`ROADMAP.md` Part 3 lists badges and leaderboards as things deliberately not being built. That section is annotated rather than deleted — the newer founder document wins, but its gamification argument is good and §46 answers it point by point.

**Phase 1 implementation** (Tickets 1–5, in the order §47.7 sets):

- `src/core/rules/passport/` — species summaries, totals, collection progress. Pure, no React or DB (ADR 003).
- `src/core/rules/achievements/` — eight badges on five rule shapes, deterministic and idempotent.
- `src/core/rules/slams/` — same-day trifectas and grand slams.
- `src/features/passport/` + `src/app/(app)/passport/` — overview, My Species grid, species detail, badges, slams, collection detail.
- Vector files for all three rule sets, so a future Swift client is checkable against this one.

## Slams

Ten definitions covering both coasts, each carrying its source so a house rule cannot pass as IGFA's: the two founder-specified SoCal trifectas, the IGFA inshore and offshore grand slams and their super variants, the Texas Slam, and the Cape Cod slams.

A slam is a **pool plus a threshold**, not a checklist, because that is how the real ones are written — the IGFA Inshore Grand Slam is *any three* of bonefish, permit, snook and tarpon. A category can itself be a group, so two different tunas in a day fill the tuna slot once.

**This needed no region on a catch, so §45.1 does not block it: the species list is the geography.** Nobody catches a tarpon off Orange County. The Settings region only orders which slams show first, never what qualifies — so a SoCal angler who fishes the Keys is still credited with the Inshore Grand Slam.

"One day" is `catch.local_date`, already computed in the catch's own timezone, so a trip past midnight splits the way a tournament counts it. Released fish count, as IGFA also allows.

**Safeguard:** no protected species may appear on a slam (§4.5, §11, decision §40.8), enforced by `validateSlams` and failed by the suite. "Sea bass" in the Island Trifecta is **white seabass**; giant sea bass is protected and is not a target — there is a test named after that confusion.

## Why it's shaped this way

Everything is derived from catches already in the log. No new field, no new prompt, no backfill: an angler with three years of history opens it already full. Awards are recomputed rather than stored, so re-running cannot double-award, an edit cannot strand one, and a sync merge is just another evaluation.

Three rules were worth getting right: an unresolved quick mark is not yet a fish and resolving one later credits exactly once; deleting the only catch of a species removes it again; and logging "rockfish" when you can't tell which one keeps the individual slot open.

One badge is not from the founder's list. **Days on the Water** counts five finished trips, fish or no fish. ROADMAP Part 3 asks that any engagement mechanic reward confirming a trip honestly rather than catching more, and a blank day is the record most worth keeping.

Three of the founder's ten badges are absent, each for a stated reason: New Waters I (no region), Photo Journal I (photos cut), Night Bite (needs a sunrise library that isn't a dependency).

## How it was verified

- `npm run verify` — tokens, tripwires, lint (0 errors), `tsc --noEmit`, **534 tests pass**.
- `npm run build` — production build green; all six routes present.
- All screens opened in Chromium at **320px**. The filter layout was fixed after that pass, because three stacked selects pushed every fish below the fold.
- Screens were viewed against an **empty log**. The counting rules are covered by vectors and tests, not by clicking through real history — worth a look from someone with real catches before this is called done.

## Not in scope

No wildlife, no boat games, no verification, no photos. Behind `passport_v1`, reached from Settings — the nav bar stays at six destinations per §8.1 and `shell-nav.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173H7NUFw6hjnumRw4GLbi3