### PR TITLE
Passport follow-ups — slams, regional collections, and a nav overflow fix

### DIFF
--- a/docs/specs/fishing-passport-wildlife-boat-games.md
+++ b/docs/specs/fishing-passport-wildlife-boat-games.md
@@ -1427,6 +1427,18 @@ excluded from completion wherever it sits.
 New collections in the same pass: **Grouper and sea bass**, **Marlin** (blue, black, striped,
 white), and **Pelagic** (the tunas, billfish, dorado, wahoo and company).
 
-Still open, noted not fixed: red drum, black drum and the seatrout are also Sciaenidae and
-could join Croaker. They were not part of the request, and moving fish people think of as
-"redfish" into a croaker collection is a product call rather than a taxonomic one.
+### 49.3 Red drum and seatrout stay out of Croaker — resolved by the Texas rules
+
+Raised as open, then settled by deferring to the regulator, at the founder's direction.
+Red drum, black drum and the seatrout are Sciaenidae, so a taxonomist would file them with
+the croakers. **TPWD does not**, and our own Fish Legal pack already carries the proof:
+`texas-pack.ts` cites the Outdoor Annual at `.../drum-bag-length-limits` and
+`.../seatrout-bag-length-limits` — Texas manages **Drum** and **Seatrout** as separate
+categories, and there is no croaker umbrella over either.
+
+A second reason points the same way: every member of the Croaker collection is a Pacific
+fish (corbina, yellowfin and spotfin croaker, white croaker, queenfish). Dropping a Gulf
+redfish into it would make a coastal collection incoherent as well as unfamiliar.
+
+So Croaker keeps white seabass and nothing else moves. If a drum collection is ever wanted,
+TPWD's own grouping — red drum with black drum — is the shape to copy, not Sciaenidae.

--- a/docs/specs/fishing-passport-wildlife-boat-games.md
+++ b/docs/specs/fishing-passport-wildlife-boat-games.md
@@ -1320,3 +1320,66 @@ Same eight tickets from §36, resequenced by value and unblocked-ness:
 
 Blocked before code starts: the region ruling (§45.1) gates part of Ticket 2 and one badge;
 the media decision (§45.2) removes one badge from Ticket 5.
+
+## 48. Slams — several species, one day (founder request, 2026-09-03)
+
+Added after Phase 1 was built, at the founder's request, and shipped in the same slice.
+
+A slam is not a collection, and the distinction is the whole feature. A collection is a
+lifetime set filled in over years. A slam is a **day**: catch a yellowtail, a white seabass
+and a California halibut across three seasons and you have three good days; catch them
+between sunrise and sunset and you have the Island Trifecta.
+
+### 48.1 Why this does not need a region on a catch
+
+§45.1 cut geographic collections because no catch carries a region. Slams are
+region-flavoured and still ship, because **the species list is the geography**. Nobody
+catches a tarpon off Orange County or a white seabass off Montauk, so qualification is
+decided by the fish alone. The angler's Settings region only decides which slams surface
+first — the "picker of defaults, never a filter" stance of ADR 007 §4, used as intended.
+
+A SoCal angler who takes one week in the Keys is therefore still credited with the Inshore
+Grand Slam, which is correct and would not have been true of a region-gated design.
+
+### 48.2 The rule
+
+- **One day** is `catch.local_date`, already stored, already computed in the catch's own
+  timezone. A trip past midnight splits, which is what "in one day" means to a tournament.
+- **A slam is a pool, not a checklist.** The IGFA Inshore Grand Slam is *any three* of
+  bonefish, permit, snook and tarpon — so a definition is a set of categories plus how many
+  distinct ones a day must produce. That expresses "these exact three" and "any three of
+  four" without a second model.
+- **A category may be a group.** "Any tuna" and "any billfish" are single slots: two
+  different tunas in a day fill the tuna slot once.
+- **Released fish count.** IGFA does not require keeping one either.
+- Near misses are shown ("two of three on 14 June"). A fact about the log, not a nudge.
+
+### 48.3 The safeguard that matters
+
+A slam is the most competitive thing in the product — a list of fish to go and get today.
+So **no protected species may appear on one** (§4.5, §11, decision §40.8), enforced by
+`validateSlams` and failed by the test suite rather than remembered by hand.
+
+The specific trap: "sea bass" in the Island Trifecta means **white seabass**. Giant sea
+bass is protected and is not a target. There is a test named after that confusion.
+
+### 48.4 What shipped
+
+Ten slams, each carrying its source so a house rule cannot pass as IGFA's:
+
+| Slam | Rule | Coast |
+|---|---|---|
+| Island Trifecta | Yellowtail + white seabass + California halibut | West (founder-specified) |
+| Offshore Trifecta | Yellowtail + any tuna + any marlin | West (founder-specified) |
+| Salmon Slam | Any 3 Pacific salmon | West (house rule) |
+| Inshore Grand Slam | Any 3 of bonefish, permit, snook, tarpon | East / Gulf (IGFA) |
+| Inshore Super Grand Slam | All 4 of the above | East / Gulf (IGFA) |
+| Offshore Grand Slam | Any 3 of billfish, dorado, tuna, wahoo | Both (IGFA) |
+| Offshore Super Grand Slam | All 4 of the above | Both (IGFA) |
+| Texas Slam | Redfish + speckled trout + flounder | Gulf |
+| Cape Cod Slam | Striped bass + bluefish + false albacore | East |
+| Cape Cod Grand Slam | The above plus Atlantic bonito | East |
+
+Sources: IGFA slam rules (igfa.org), the published SoCal trifecta (BDOutdoors), the Texas
+Saltwater Slam, and the Martha's Vineyard derby tradition. The two founder-specified
+trifectas and the Salmon Slam are marked as house rules, not IGFA categories.

--- a/docs/specs/fishing-passport-wildlife-boat-games.md
+++ b/docs/specs/fishing-passport-wildlife-boat-games.md
@@ -1383,3 +1383,50 @@ Ten slams, each carrying its source so a house rule cannot pass as IGFA's:
 Sources: IGFA slam rules (igfa.org), the published SoCal trifecta (BDOutdoors), the Texas
 Saltwater Slam, and the Martha's Vineyard derby tradition. The two founder-specified
 trifectas and the Salmon Slam are marked as house rules, not IGFA categories.
+
+## 49. Regional collections and a taxonomy correction (founder, 2026-09-03)
+
+### 49.1 Regional collections are back on, and §45.1 still stands
+
+§45.1 cut geographic collections because no catch carries a region. They ship now, for the
+same reason slams do (§48.1): **the species list is the geography.** A Southern California
+collection is the fish an angler meets there; filling it is evidence enough, and no catch is
+ever asked where it happened.
+
+The distinction §45.1 was really protecting is intact — nothing here claims a *catch*
+occurred in a region. That claim still has no data behind it, and **New Waters I stays cut**,
+because counting distinct regions an angler has fished genuinely does require the field that
+does not exist.
+
+Membership comes from `popularSpeciesIds` — the researched starter lists the species picker
+already uses — so there is one region vocabulary rather than two. Forty-two collections
+ship: 30 regional, plus families and habitats. The regional lists run 8–12 species, which is
+a size an angler can finish; that is not luck, it is what those lists were curated to be.
+
+Two regions are excluded. `custom` leads with no species by design, and the five `ca_gma_*`
+entries are Fish Legal's groundfish management areas — regulatory splits of one coastline,
+not places with their own fish.
+
+Region orders the list; it never decides what counts. The overview shows the angler's own
+region and the families; the full list lives at `/passport/collections`.
+
+### 49.2 The sea basses are not bass
+
+Founder correction, and taxonomically right:
+
+| Species | Was | Now | Family |
+|---|---|---|---|
+| White seabass | Bass | **Croaker** | Sciaenidae — the largest croaker on the coast |
+| Black sea bass | Bass | **Grouper and sea bass** | Serranidae |
+| Giant sea bass | Bass | **Grouper and sea bass** | Moved with them; still protected, still informational-only |
+
+Giant sea bass was not named in the request. It moved anyway, because leaving it in a
+collection its own name argues against would contradict the correction being made. It stays
+excluded from completion wherever it sits.
+
+New collections in the same pass: **Grouper and sea bass**, **Marlin** (blue, black, striped,
+white), and **Pelagic** (the tunas, billfish, dorado, wahoo and company).
+
+Still open, noted not fixed: red drum, black drum and the seatrout are also Sciaenidae and
+could join Croaker. They were not part of the request, and moving fish people think of as
+"redfish" into a croaker collection is a product call rather than a taxonomic one.

--- a/docs/team/worklog/2026-09-03-12-head-dev.md
+++ b/docs/team/worklog/2026-09-03-12-head-dev.md
@@ -1,0 +1,27 @@
+### 2026-09-03 | head-dev | 1h
+
+- Added slams to the passport at the founder's request: several species caught in a single
+  day. A trifecta is three; a grand slam is three or four depending on whose rules.
+- Ten shipped, both coasts. The founder's two Southern California ones — yellowtail, white
+  seabass and halibut for the island day, and yellowtail, tuna and marlin offshore — plus
+  the real IGFA inshore and offshore slams, the Texas slam, and the Cape Cod ones. I looked
+  up the established rules rather than inventing them, and each carries a note saying where
+  it came from so a house rule cannot pass as IGFA's.
+- The neat part: this did not need the region work we cut. Nobody catches a tarpon off
+  Orange County, so which fish you caught already says where you were. The region setting
+  only decides which slams show first. Someone from California who spends a week in Florida
+  still gets credited.
+- The day is the hard part and the code treats it that way — it uses the date the catch was
+  logged in its own timezone, so a trip running past midnight splits into two days, the way
+  a tournament counts it.
+- One safety check worth recording: a slam is a list of fish to go and get today, so no
+  protected fish can ever appear on one. The build fails if one does. The specific trap is
+  "sea bass" — the trifecta means white seabass, and giant sea bass is protected. There is a
+  test named after that confusion.
+- Near misses are shown: "two of three on 14 June". That is the line most likely to get
+  someone back on the water, and it is only a fact about their own log.
+- Checks: tripwires clean, no lint errors, 534 tests pass, production build green, and I
+  looked at the new screen in a browser at phone width.
+- Files: src/core/rules/slams/, src/features/passport/components/slam-list.tsx,
+  src/app/(app)/passport/slams/, the passport overview, and spec §48.
+- Next: still nobody has opened any of this with a real log behind it.

--- a/docs/team/worklog/2026-09-03-13-head-dev.md
+++ b/docs/team/worklog/2026-09-03-13-head-dev.md
@@ -1,0 +1,28 @@
+### 2026-09-03 | head-dev | 45m
+
+- Added collections for places, at the founder's request. Forty-two now: thirty regions
+  plus the families and water types.
+- These work for the same reason the slams did. We had cut region collections because a
+  catch does not record where it happened — but a Southern California collection is just
+  the fish you meet there, so catching them is proof enough. Nothing asks a catch where it
+  was. The lists come from the region species lists the app already uses for its species
+  picker, so there is one set of regional knowledge and not two.
+- Each regional list is eight to twelve fish, which is a size someone can actually finish.
+  Left out the five California groundfish management areas — those are legal boundaries,
+  not places with their own fish — and the "custom" region, which has no list by design.
+- The badge for fishing three different regions is still cut. That one genuinely does need
+  a catch to know where it happened, and it still does not.
+- Fixed the founder's taxonomy point: white seabass is a croaker, not a bass, and black sea
+  bass belongs with the groupers. Moved both. Also moved giant sea bass to the groupers —
+  it was not asked for, but leaving it in "Bass" right after making that correction would
+  have been silly. It stays protected and still cannot be required to finish anything.
+- New collections: grouper and sea bass, marlin, and pelagic.
+- The passport overview was going to list all forty-two, which is not a summary, so it now
+  shows your own region and the families with a link to the full list on its own page.
+- Checks: tripwires clean, no lint errors, 542 tests, production build green, and I looked
+  at the new pages in a browser and confirmed white seabass now sits in croaker and bass
+  holds only actual bass.
+- Files: src/core/rules/passport/collections.ts, collection-list.tsx,
+  src/app/(app)/passport/collections/page.tsx, the overview, and spec §49.
+- Next: red drum and the seatrout are croakers too, taxonomically. Left alone — calling a
+  redfish a croaker is a product decision, not a science one.

--- a/docs/team/worklog/2026-09-03-14-head-dev.md
+++ b/docs/team/worklog/2026-09-03-14-head-dev.md
@@ -1,0 +1,13 @@
+### 2026-09-03 | head-dev | 10m
+
+- Closed the open question about whether redfish and seatrout belong in the croaker
+  collection. The founder said to defer to how Texas categorizes them, and our own legal
+  data already had the answer: Texas Parks and Wildlife publishes separate rules for
+  "drum" and for "seatrout", with no croaker heading over either. So they stay where they
+  are.
+- A second reason worth recording: every fish currently in the croaker collection is a
+  Pacific species. Putting a Gulf redfish in it would have been odd geographically as well
+  as unfamiliar to anglers.
+- No code changed. This was a decision that needed writing down so it does not get raised
+  a third time.
+- Files: docs/specs/fishing-passport-wildlife-boat-games.md §49.3

--- a/docs/team/worklog/2026-09-03-15-head-dev.md
+++ b/docs/team/worklog/2026-09-03-15-head-dev.md
@@ -1,0 +1,29 @@
+### 2026-09-03 | head-dev | 40m
+
+- Fixed a real bug in the bottom navigation bar that nobody had noticed. On a small phone
+  the six buttons did not fit: they needed 366 pixels of room in a 320 pixel screen, so
+  "Settings" was cut off at the edge and read as "Set". It was still slightly too wide at
+  360 pixels. A comment in the code claimed the opposite; I measured it in a browser and
+  the comment was wrong, so I corrected that too.
+- The fix: below 384 pixels the bar wraps into two rows of three. Every label stays full
+  size and every button stays a full-size tap target. Above that nothing changes, so every
+  modern phone keeps the single row it has today.
+- I tried an equal-column grid first and it was worse — equal columns have to be as wide as
+  the longest word, so it would have put two rows on every phone made. Wrapping keeps the
+  short words short.
+- Shrinking the text was never an option. The 16-pixel minimum in the design foundations
+  has no escape hatch and it is the right rule for a screen people read on a boat.
+- Checked that the taller bar does not cover the bottom of a page. It does not — it sits in
+  the layout rather than floating over it, so content moves up to make room. Verified at
+  both widths.
+- Added the passport to the calendar home page as a small card: how many species, the
+  newest one, and the slam you came closest to. One line of substance and a link, sitting
+  below the calendar because the calendar is still the home surface.
+- That card is also the honest test of whether the passport deserves a permanent spot in
+  the navigation later, rather than us guessing now.
+- Checks: tokens regenerate cleanly, tripwires clean, no lint errors, 542 tests, production
+  build green, measured in a browser at 320, 360, 384, 390, 430 and 768 pixels.
+- Files: shell-nav.tsx, tokens.json, scripts/tokens.mjs, passport-home-card.tsx,
+  src/app/(app)/page.tsx
+- Next: the navigation question itself is still open, and should stay open until the card
+  has been in front of someone for a while.

--- a/scripts/tokens.mjs
+++ b/scripts/tokens.mjs
@@ -63,6 +63,18 @@ function buildFontSizeLines(fontSize) {
   return lines;
 }
 
+/**
+ * breakpoint: { "nav-single-row": "384px" } -> Tailwind v4's screen namespace is
+ * `--breakpoint-*`, so `--breakpoint-nav-single-row: 384px;` gives the variant
+ * `nav-single-row:`. Named rather than written inline because a raw `min-[384px]:`
+ * in a component is exactly the size literal the tripwire exists to catch.
+ */
+function buildBreakpointLines(breakpoint) {
+  return Object.entries(breakpoint).map(
+    ([name, value]) => `  --breakpoint-${name}: ${value};`,
+  );
+}
+
 /** fontFamily: { ui, mono } -> Tailwind's font-family namespace is `--font-*`. */
 function buildFontFamilyLines(fontFamily) {
   return Object.entries(fontFamily).map(
@@ -170,7 +182,7 @@ function buildOpacityLines(opacity) {
 
 function generate(tokens) {
   const { color, fontSize, fontFamily, spacing, radius, touchTarget, elevation, opacity,
-    tracking, container } = tokens;
+    tracking, container, breakpoint } = tokens;
 
   const { light: colorLight, dark: colorDark } = buildColorLines(color);
 
@@ -187,6 +199,7 @@ function generate(tokens) {
     ...buildRadiusLines(radius),
     ...(tracking ? ["", ...buildTrackingLines(tracking)] : []),
     ...(container ? ["", ...buildContainerLines(container)] : []),
+    ...(breakpoint ? ["", ...buildBreakpointLines(breakpoint)] : []),
     ...(opacity ? ["", ...buildOpacityLines(opacity)] : []),
   ];
 

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 import { MonthCalendar } from "@/features/calendar/components/month-calendar";
+import { PassportHomeCard } from "@/features/passport/components/passport-home-card";
+import { PASSPORT_V1 } from "@/features/passport/flag";
 
 export const metadata: Metadata = { title: "Calendar | Fish Log Book" };
 
@@ -25,6 +27,12 @@ export default function CalendarPage() {
       >
         Open tide chart
       </Link>
+      {/*
+        Below the calendar and the tide link on purpose: the calendar is the home surface
+        (D23) and the passport is the thing you read after the fishing, not before it.
+        This is also the honest test of whether it earns a nav slot later (spec §8.1).
+      */}
+      {PASSPORT_V1 ? <PassportHomeCard /> : null}
     </div>
   );
 }

--- a/src/app/(app)/passport/collections/page.tsx
+++ b/src/app/(app)/passport/collections/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { CollectionList } from "@/features/passport/components/collection-list";
+import { PASSPORT_V1 } from "@/features/passport/flag";
+
+export const metadata: Metadata = { title: "Collections | Fish Log Book" };
+
+export default function CollectionsPage() {
+  if (!PASSPORT_V1) notFound();
+  return <CollectionList />;
+}

--- a/src/app/(app)/passport/slams/page.tsx
+++ b/src/app/(app)/passport/slams/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { SlamList } from "@/features/passport/components/slam-list";
+import { PASSPORT_V1 } from "@/features/passport/flag";
+
+export const metadata: Metadata = { title: "Slams | Fish Log Book" };
+
+export default function SlamsPage() {
+  if (!PASSPORT_V1) notFound();
+  return <SlamList />;
+}

--- a/src/app/tokens.generated.css
+++ b/src/app/tokens.generated.css
@@ -84,6 +84,8 @@
 
   --container-reading: 820px;
 
+  --breakpoint-nav-single-row: 384px;
+
   --opacity-disabled: 0.45;
 }
 

--- a/src/core/design/tokens.json
+++ b/src/core/design/tokens.json
@@ -178,6 +178,9 @@
     "station": ".14em",
     "chart-pill": ".08em"
   },
+  "breakpoint": {
+    "nav-single-row": "384px"
+  },
   "container": {
     "reading": "820px"
   },

--- a/src/core/rules/passport/collections.test.ts
+++ b/src/core/rules/passport/collections.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import { speciesById } from "@/core/ontology/species";
 
-import { COLLECTIONS, GROUP_SPECIES_IDS, collectionById, validateCollections } from "./collections";
+import {
+  COLLECTIONS,
+  GROUP_SPECIES_IDS,
+  collectionById,
+  collectionsForRegion,
+  validateCollections,
+} from "./collections";
 import { collectionProgress } from "./selectors";
 
 describe("collection definitions", () => {
@@ -44,10 +50,36 @@ describe("collection definitions", () => {
     expect(informational.length).toBeGreaterThan(0);
   });
 
-  it("has no geographic collections — spec §45.1 cut them from Phase 1", () => {
-    for (const collection of COLLECTIONS) {
-      expect(["family", "habitat"]).toContain(collection.collectionType);
+  it("ships regional collections, built from the region ontology (founder, 2026-09-03)", () => {
+    const regional = COLLECTIONS.filter((c) => c.collectionType === "region");
+    expect(regional.length).toBeGreaterThan(5);
+    for (const collection of regional) {
+      expect(collection.regionId).not.toBeNull();
+      expect(collection.species.length).toBeGreaterThan(1);
     }
+  });
+
+  it("keeps region out of qualification — the species list is the geography (§48.1)", () => {
+    // collectionProgress takes caught species and group ids. It has no region parameter,
+    // and this test exists so nobody adds one: a catch carries no region (§45.1).
+    const socal = COLLECTIONS.find((c) => c.regionId === "southern_california");
+    expect(socal).toBeDefined();
+
+    const required = socal!.species.filter((s) => s.required).map((s) => s.speciesId);
+    const progress = collectionProgress(socal!, new Set(required), GROUP_SPECIES_IDS);
+    expect(progress.complete).toBe(true);
+  });
+
+  it("has no collection per groundfish management area — those are regulatory, not places", () => {
+    for (const collection of COLLECTIONS) {
+      expect(collection.id.startsWith("region-ca-gma")).toBe(false);
+    }
+  });
+
+  it("orders an angler's own region first without hiding the rest", () => {
+    const ordered = collectionsForRegion("florida");
+    expect(ordered).toHaveLength(COLLECTIONS.length);
+    expect(ordered[0].regionId).toBe("florida");
   });
 
   it("completes when every required species is caught, protected ones notwithstanding", () => {
@@ -64,5 +96,40 @@ describe("collection definitions", () => {
     for (const collection of COLLECTIONS) {
       expect(collection.version).toBeGreaterThanOrEqual(1);
     }
+  });
+});
+
+describe("the sea basses are not bass (founder correction, 2026-09-03)", () => {
+  const idsIn = (collectionId: string) =>
+    collectionById(collectionId)!.species.map((s) => s.speciesId);
+
+  it("moves white seabass out of Bass and into Croaker, where Sciaenidae belongs", () => {
+    expect(idsIn("bass")).not.toContain("white_seabass");
+    expect(idsIn("croaker")).toContain("white_seabass");
+  });
+
+  it("moves black sea bass out of Bass and into Grouper, where Serranidae belongs", () => {
+    expect(idsIn("bass")).not.toContain("black_sea_bass");
+    expect(idsIn("grouper")).toContain("black_sea_bass");
+  });
+
+  it("moves giant sea bass with them, still protected and still not required", () => {
+    expect(idsIn("bass")).not.toContain("giant_sea_bass");
+    const giant = collectionById("grouper")!.species.find((s) => s.speciesId === "giant_sea_bass");
+    expect(giant?.informationalOnly).toBe(true);
+    expect(giant?.required).toBe(false);
+  });
+
+  it("leaves Bass holding only actual bass", () => {
+    for (const id of idsIn("bass")) {
+      expect(id).toMatch(/bass$/);
+    }
+  });
+
+  it("ships the Marlin and Pelagic collections", () => {
+    expect(idsIn("marlin")).toEqual(
+      expect.arrayContaining(["blue_marlin", "black_marlin", "striped_marlin", "white_marlin"]),
+    );
+    expect(idsIn("pelagic")).toEqual(expect.arrayContaining(["bluefin_tuna", "dorado", "wahoo"]));
   });
 });

--- a/src/core/rules/passport/collections.ts
+++ b/src/core/rules/passport/collections.ts
@@ -16,10 +16,16 @@
  * appears in its family so an angler learns it exists, and it is excluded from the
  * denominator, so every collection here can be finished legally (spec §11, §4.5).
  *
- * Geographic collections are absent on purpose. Spec §45.1 cut them from Phase 1: there is
- * no region on a catch and no region geometry to derive one from.
+ * **Geographic collections work after all** (founder request 2026-09-03), and for the reason
+ * slams do (§48.1): the species list is the geography. A catch still carries no region, and
+ * none is inferred — a Southern California collection is simply the species an angler meets
+ * there, and filling it is evidence enough. The region-shaped hole §45.1 left was never
+ * about collections; it was about claiming a *catch* happened in a region, which nothing
+ * here does. Membership comes from `popularSpeciesIds`, the researched starter list the
+ * species picker already uses, so there is one region vocabulary and not two.
  */
 
+import { REGIONS, popularSpeciesIds, type RegionId } from "@/core/ontology/regions";
 import { SPECIES, speciesById, type Species } from "@/core/ontology/species";
 
 import type { CollectionDefinition, CollectionSpecies } from "./types";
@@ -63,15 +69,37 @@ interface Definition {
   id: string;
   name: string;
   description: string;
-  type: "family" | "habitat";
+  type: "family" | "habitat" | "region";
   members: readonly Species[];
   /** Ids asserted by hand, kept for validation. Empty for derived families. */
   asserted?: readonly string[];
+  /** Regional collections only — used to order them, never to qualify a catch. */
+  regionId?: RegionId;
 }
 
+/*
+ * Founder correction, 2026-09-03: the "sea basses" are not bass.
+ *
+ * White seabass is a croaker — *Atractoscion nobilis*, family Sciaenidae, and the biggest
+ * one on this coast. Black sea bass is *Centropristis striata*, family Serranidae, which is
+ * the grouper family. Giant sea bass moves with them for the same reason rather than being
+ * left behind in a collection its own name argues against; it stays informational-only
+ * wherever it sits, because it is protected.
+ */
 const BASS = [
-  "kelp_bass", "barred_sand_bass", "spotted_sand_bass", "largemouth_bass",
-  "smallmouth_bass", "striped_bass", "black_sea_bass", "white_seabass", "giant_sea_bass",
+  "kelp_bass", "barred_sand_bass", "spotted_sand_bass",
+  "largemouth_bass", "smallmouth_bass", "striped_bass",
+];
+const GROUPER = [
+  "black_sea_bass", "giant_sea_bass", "red_grouper", "black_grouper", "gag_grouper",
+  "scamp", "warsaw_grouper", "speckled_hind", "goliath_grouper", "hapuu",
+];
+const MARLIN = ["blue_marlin", "black_marlin", "striped_marlin", "white_marlin"];
+const PELAGIC = [
+  "bluefin_tuna", "yellowfin_tuna", "bigeye_tuna", "skipjack_tuna", "false_albacore",
+  "atlantic_bonito", "pacific_bonito", "dorado", "wahoo", "cobia",
+  "blue_marlin", "black_marlin", "striped_marlin", "white_marlin", "sailfish", "swordfish",
+  "king_mackerel", "spanish_mackerel", "sierra_mackerel", "yellowtail",
 ];
 const TUNA = ["bluefin_tuna", "yellowfin_tuna", "bigeye_tuna", "skipjack_tuna"];
 const SALMON_TROUT = [
@@ -139,9 +167,35 @@ const DEFINITIONS: readonly Definition[] = [
   {
     id: "croaker",
     name: "Croaker",
-    description: "The croaker family, corbina included.",
+    description: "The croaker family — corbina, the drums, and the biggest of them all.",
     type: "family",
-    members: rollUpFamily("croaker"),
+    // Derived members plus white seabass, which is a croaker however it is marketed.
+    members: [...rollUpFamily("croaker"), ...namedFamily(["white_seabass"])],
+    asserted: ["white_seabass"],
+  },
+  {
+    id: "grouper",
+    name: "Grouper and sea bass",
+    description: "The Serranidae — groupers proper, and the sea basses that belong with them.",
+    type: "family",
+    members: namedFamily(GROUPER),
+    asserted: GROUPER,
+  },
+  {
+    id: "marlin",
+    name: "Marlin",
+    description: "Blue, black, striped and white. A day's run for one bite.",
+    type: "family",
+    members: namedFamily(MARLIN),
+    asserted: MARLIN,
+  },
+  {
+    id: "pelagic",
+    name: "Pelagic",
+    description: "Blue water: the tunas, billfish, dorado and wahoo that live away from the bottom.",
+    type: "habitat",
+    members: namedFamily(PELAGIC),
+    asserted: PELAGIC,
   },
   {
     id: "surfperch",
@@ -159,7 +213,33 @@ const DEFINITIONS: readonly Definition[] = [
   },
 ];
 
-export const COLLECTIONS: readonly CollectionDefinition[] = DEFINITIONS.filter(
+/**
+ * Regional collections (founder request 2026-09-03), generated from the region ontology.
+ *
+ * Two regions are deliberately excluded. `custom` leads with no species by design, and the
+ * five `ca_gma_*` entries are Fish Legal's groundfish management areas — regulatory splits
+ * of one coastline, not places with their own fish. A collection per management area would
+ * be five near-identical lists and a wrong idea about what a region is.
+ *
+ * The lists run 8-12 species, which is the right size for something an angler can actually
+ * finish. That is not a coincidence: they are the picker's "common here" chips, chosen to
+ * be a welcome mat rather than a taxonomy.
+ */
+const REGIONAL_EXCLUDED = new Set<string>(["custom"]);
+
+const REGIONAL: readonly Definition[] = REGIONS.filter(
+  (region) => !REGIONAL_EXCLUDED.has(region.id) && !region.id.startsWith("ca_gma_"),
+).map((region) => ({
+  id: `region-${region.id.replace(/_/g, "-")}`,
+  name: region.label,
+  description: `The fish you meet around ${region.label}. ${region.hint}`,
+  type: "region" as const,
+  members: namedFamily(popularSpeciesIds(region.id as RegionId)),
+  asserted: popularSpeciesIds(region.id as RegionId),
+  regionId: region.id as RegionId,
+}));
+
+export const COLLECTIONS: readonly CollectionDefinition[] = [...DEFINITIONS, ...REGIONAL].filter(
   // A one-species collection is not a collection.
   (d) => d.members.length > 1,
 ).map(
@@ -171,9 +251,21 @@ export const COLLECTIONS: readonly CollectionDefinition[] = DEFINITIONS.filter(
     collectionType: d.type,
     version: COLLECTION_RULE_VERSION,
     active: true,
+    regionId: d.regionId ?? null,
     species: toEntries(d.members),
   }),
 );
+
+/**
+ * An angler's own region first, then everything else — the same stance as slams. Region
+ * orders the list; it never decides what counts.
+ */
+export function collectionsForRegion(regionId: string): readonly CollectionDefinition[] {
+  const mine = COLLECTIONS.filter((c) => c.regionId === regionId);
+  const families = COLLECTIONS.filter((c) => c.regionId === null);
+  const otherRegions = COLLECTIONS.filter((c) => c.regionId !== null && c.regionId !== regionId);
+  return [...mine, ...families, ...otherRegions];
+}
 
 export function collectionById(id: string): CollectionDefinition | null {
   return COLLECTIONS.find((c) => c.id === id) ?? null;

--- a/src/core/rules/passport/selectors.test.ts
+++ b/src/core/rules/passport/selectors.test.ts
@@ -156,6 +156,7 @@ describe("collectionProgress", () => {
         name: vector.definition.id,
         description: "",
         collectionType: "family",
+        regionId: null,
         version: 1,
         active: true,
         species: [
@@ -189,6 +190,7 @@ describe("collectionProgress", () => {
       name: "Empty",
       description: "",
       collectionType: "family",
+      regionId: null,
       version: 1,
       active: true,
       species: [],

--- a/src/core/rules/passport/types.ts
+++ b/src/core/rules/passport/types.ts
@@ -56,7 +56,7 @@ export interface PassportTotals {
   readonly latestNewSpecies: { readonly speciesId: string; readonly caughtAt: string } | null;
 }
 
-export type CollectionType = "family" | "habitat";
+export type CollectionType = "family" | "habitat" | "region";
 
 /**
  * One species' place in a collection (spec §29.2).
@@ -85,6 +85,12 @@ export interface CollectionDefinition {
   readonly name: string;
   readonly description: string;
   readonly collectionType: CollectionType;
+  /**
+   * Set for regional collections, and used only to order them for an angler who has told
+   * Settings where they fish. Never consulted when deciding whether a catch counts — a
+   * catch carries no region (spec §45.1), and the species list is the geography (§48.1).
+   */
+  readonly regionId: string | null;
   readonly version: number;
   readonly active: boolean;
   readonly species: readonly CollectionSpecies[];

--- a/src/core/rules/slams/catalog.ts
+++ b/src/core/rules/slams/catalog.ts
@@ -1,0 +1,278 @@
+/**
+ * The slam catalog (founder request 2026-09-03).
+ *
+ * Sourced, not invented. This repo's Fish Legal work established a citation-or-nothing
+ * rule for anything presented as an outside fact, and a slam is exactly that — an angler
+ * telling their mates they got the IGFA Inshore Grand Slam means the real one, with the
+ * real rules. Every entry therefore carries where its rule comes from, and the two the
+ * founder specified are marked as the house's own rather than dressed up as IGFA's.
+ *
+ * Two safeguards are load-bearing:
+ *
+ * 1. **No protected species is ever a slam target** (spec §4.5, §11, decision §40.8). A
+ *    slam is the most competitive thing in the product — it is a list of fish to go and
+ *    get today — so a protected fish must never appear on one. `validateSlams` enforces
+ *    it and the test fails the build. Note "sea bass" in the Island Trifecta is white
+ *    seabass; giant sea bass is protected and is not a target.
+ * 2. **Region is display, never qualification** (see `types.ts`). The species list is the
+ *    geography, so spec §45.1's missing region column does not block this.
+ */
+
+import type { SlamDefinition } from "./types";
+
+export const SLAM_RULE_VERSION = 1;
+
+const TUNA = ["bluefin_tuna", "yellowfin_tuna", "bigeye_tuna", "skipjack_tuna"];
+const BILLFISH = ["blue_marlin", "black_marlin", "striped_marlin", "white_marlin", "sailfish", "swordfish"];
+const MARLIN = ["blue_marlin", "black_marlin", "striped_marlin", "white_marlin"];
+
+export const SLAMS: readonly SlamDefinition[] = [
+  /* ---- West Coast ---- */
+  {
+    id: "socal-island-trifecta",
+    name: "Island Trifecta",
+    description:
+      "Yellowtail, white seabass and a California halibut, all in one day. The classic Channel Islands day — the three share the same ground and almost never share a mood.",
+    tier: "trifecta",
+    categories: [
+      { id: "yellowtail", label: "Yellowtail", speciesIds: ["yellowtail"] },
+      { id: "white-seabass", label: "White seabass", speciesIds: ["white_seabass"] },
+      { id: "halibut", label: "California halibut", speciesIds: ["california_halibut"] },
+    ],
+    requiredCategories: 3,
+    regions: ["southern_california", "ca_gma_southern", "ca_gma_central"],
+    source: "Widely recognised SoCal trifecta; described as yellowtail + white seabass + halibut in one day (BDOutdoors). Founder-specified.",
+    version: SLAM_RULE_VERSION,
+  },
+  {
+    id: "socal-offshore-trifecta",
+    name: "Offshore Trifecta",
+    description:
+      "Yellowtail, any tuna and any marlin in one day. The blue-water version — a long run and a lot of luck.",
+    tier: "trifecta",
+    categories: [
+      { id: "yellowtail", label: "Yellowtail", speciesIds: ["yellowtail"] },
+      { id: "tuna", label: "Any tuna", speciesIds: TUNA },
+      { id: "marlin", label: "Any marlin", speciesIds: MARLIN },
+    ],
+    requiredCategories: 3,
+    regions: ["southern_california", "ca_gma_southern", "cabo_baja", "baja_california", "baja_california_sur"],
+    source: "Founder-specified (2026-09-03). House rule, not an IGFA category.",
+    version: SLAM_RULE_VERSION,
+  },
+  {
+    id: "pacific-salmon-slam",
+    name: "Salmon Slam",
+    description: "Any three Pacific salmon species in one day.",
+    tier: "grand-slam",
+    categories: [
+      { id: "chinook", label: "Chinook", speciesIds: ["chinook_salmon"] },
+      { id: "coho", label: "Coho", speciesIds: ["coho_salmon"] },
+      { id: "sockeye", label: "Sockeye", speciesIds: ["sockeye_salmon"] },
+      { id: "pink", label: "Pink", speciesIds: ["pink_salmon"] },
+      { id: "chum", label: "Chum", speciesIds: ["chum_salmon"] },
+    ],
+    requiredCategories: 3,
+    regions: ["washington", "oregon", "alaska", "northern_california"],
+    source: "House rule, built on the common Pacific Northwest multi-salmon day. Not an IGFA category.",
+    version: SLAM_RULE_VERSION,
+  },
+
+  /* ---- East Coast and Gulf ---- */
+  {
+    id: "igfa-inshore-grand-slam",
+    name: "Inshore Grand Slam",
+    description:
+      "Any three of bonefish, permit, snook and tarpon in a single day. The flats classic.",
+    tier: "grand-slam",
+    categories: [
+      { id: "bonefish", label: "Bonefish", speciesIds: ["atlantic_bonefish", "oio_bonefish"] },
+      { id: "permit", label: "Permit", speciesIds: ["permit"] },
+      { id: "snook", label: "Snook", speciesIds: ["common_snook"] },
+      { id: "tarpon", label: "Tarpon", speciesIds: ["atlantic_tarpon"] },
+    ],
+    requiredCategories: 3,
+    regions: ["florida", "gulf_coast", "texas", "louisiana"],
+    source: "IGFA Inshore Grand Slam — any three of bonefish, permit, snook, tarpon in one day (igfa.org).",
+    version: SLAM_RULE_VERSION,
+  },
+  {
+    id: "igfa-inshore-super-grand-slam",
+    name: "Inshore Super Grand Slam",
+    description: "All four: bonefish, permit, snook and tarpon, in a single day.",
+    tier: "super-grand-slam",
+    categories: [
+      { id: "bonefish", label: "Bonefish", speciesIds: ["atlantic_bonefish", "oio_bonefish"] },
+      { id: "permit", label: "Permit", speciesIds: ["permit"] },
+      { id: "snook", label: "Snook", speciesIds: ["common_snook"] },
+      { id: "tarpon", label: "Tarpon", speciesIds: ["atlantic_tarpon"] },
+    ],
+    requiredCategories: 4,
+    regions: ["florida", "gulf_coast"],
+    source: "IGFA Inshore Super Grand Slam — all four inshore species in one day (igfa.org).",
+    version: SLAM_RULE_VERSION,
+  },
+  {
+    id: "igfa-offshore-grand-slam",
+    name: "Offshore Grand Slam",
+    description:
+      "Any three of a billfish, a dorado, a tuna and a wahoo in a single day.",
+    tier: "grand-slam",
+    categories: [
+      { id: "billfish", label: "Any billfish", speciesIds: BILLFISH },
+      { id: "dorado", label: "Dorado (mahi)", speciesIds: ["dorado"] },
+      { id: "tuna", label: "Any tuna", speciesIds: TUNA },
+      { id: "wahoo", label: "Wahoo", speciesIds: ["wahoo"] },
+    ],
+    requiredCategories: 3,
+    regions: ["florida", "gulf_coast", "southern_california", "cabo_baja", "hawaii", "north_carolina"],
+    source: "IGFA Offshore Grand Slam — any three of billfish, dolphinfish, tuna, wahoo in one day (igfa.org).",
+    version: SLAM_RULE_VERSION,
+  },
+  {
+    id: "igfa-offshore-super-grand-slam",
+    name: "Offshore Super Grand Slam",
+    description: "All four: a billfish, a dorado, a tuna and a wahoo, in a single day.",
+    tier: "super-grand-slam",
+    categories: [
+      { id: "billfish", label: "Any billfish", speciesIds: BILLFISH },
+      { id: "dorado", label: "Dorado (mahi)", speciesIds: ["dorado"] },
+      { id: "tuna", label: "Any tuna", speciesIds: TUNA },
+      { id: "wahoo", label: "Wahoo", speciesIds: ["wahoo"] },
+    ],
+    requiredCategories: 4,
+    regions: ["florida", "gulf_coast", "hawaii", "cabo_baja"],
+    source: "IGFA Offshore Super Grand Slam — all four offshore species in one day (igfa.org).",
+    version: SLAM_RULE_VERSION,
+  },
+  {
+    id: "texas-slam",
+    name: "Texas Slam",
+    description: "Redfish, speckled trout and a flounder in the same day.",
+    tier: "trifecta",
+    categories: [
+      { id: "redfish", label: "Redfish (red drum)", speciesIds: ["red_drum"] },
+      { id: "trout", label: "Speckled trout", speciesIds: ["spotted_seatrout", "sand_seatrout"] },
+      { id: "flounder", label: "Flounder", speciesIds: ["southern_flounder", "summer_flounder"] },
+    ],
+    requiredCategories: 3,
+    regions: ["texas", "louisiana", "gulf_coast", "mississippi", "alabama"],
+    source: "Texas Saltwater Slam — red drum, spotted seatrout and flounder in one calendar day (widely published Gulf-coast rule).",
+    version: SLAM_RULE_VERSION,
+  },
+  {
+    id: "cape-cod-slam",
+    name: "Cape Cod Slam",
+    description: "A striped bass, a bluefish and a false albacore in one day.",
+    tier: "trifecta",
+    categories: [
+      { id: "striper", label: "Striped bass", speciesIds: ["striped_bass"] },
+      { id: "bluefish", label: "Bluefish", speciesIds: ["bluefish"] },
+      { id: "albie", label: "False albacore", speciesIds: ["false_albacore"] },
+    ],
+    requiredCategories: 3,
+    regions: ["northeast", "rhode_island", "connecticut", "new_york", "new_jersey", "maine", "new_hampshire"],
+    source: "New England autumn slam — striper, bluefish, false albacore in one day (widely published; Martha's Vineyard derby tradition).",
+    version: SLAM_RULE_VERSION,
+  },
+  {
+    id: "cape-cod-grand-slam",
+    name: "Cape Cod Grand Slam",
+    description:
+      "Striped bass, bluefish, false albacore and an Atlantic bonito — all four, one day. The derby fish.",
+    tier: "grand-slam",
+    categories: [
+      { id: "striper", label: "Striped bass", speciesIds: ["striped_bass"] },
+      { id: "bluefish", label: "Bluefish", speciesIds: ["bluefish"] },
+      { id: "albie", label: "False albacore", speciesIds: ["false_albacore"] },
+      { id: "bonito", label: "Atlantic bonito", speciesIds: ["atlantic_bonito"] },
+    ],
+    requiredCategories: 4,
+    regions: ["northeast", "rhode_island", "connecticut", "new_york"],
+    source: "Martha's Vineyard Striped Bass & Bluefish Derby tradition — false albacore, bonito, striper, bluefish.",
+    version: SLAM_RULE_VERSION,
+  },
+];
+
+export function slamById(id: string): SlamDefinition | null {
+  return SLAMS.find((s) => s.id === id) ?? null;
+}
+
+/**
+ * Slams for an angler's region first, then the rest. Never a filter — someone who fishes
+ * SoCal and takes one trip to the Keys should still be credited and should still see it.
+ */
+export function slamsForRegion(regionId: string): readonly SlamDefinition[] {
+  const mine = SLAMS.filter((s) => (s.regions as readonly string[]).includes(regionId));
+  const rest = SLAMS.filter((s) => !(s.regions as readonly string[]).includes(regionId));
+  return [...mine, ...rest];
+}
+
+/**
+ * Ticket-2-style validation, run by the test rather than at import: a bad definition
+ * should fail a build with a readable list, not blank a screen on a boat.
+ *
+ * The protected-species rule is the one that matters. A slam is a list of fish to go and
+ * catch today, so a protected fish appearing on one would be the product telling anglers
+ * to target something they must release — the exact thing spec §40.8 forbids.
+ */
+export function validateSlams(
+  speciesLookup: (id: string) => { isGroup: boolean; takeStatus: string } | null,
+): readonly string[] {
+  const problems: string[] = [];
+
+  for (const slam of SLAMS) {
+    const seenSpecies = new Set<string>();
+    const seenCategories = new Set<string>();
+
+    for (const category of slam.categories) {
+      if (seenCategories.has(category.id)) {
+        problems.push(`${slam.id}: category "${category.id}" appears twice`);
+      }
+      seenCategories.add(category.id);
+
+      if (category.speciesIds.length === 0) {
+        problems.push(`${slam.id}/${category.id}: no species, so it can never be filled`);
+      }
+
+      for (const speciesId of category.speciesIds) {
+        const species = speciesLookup(speciesId);
+        if (species === null) {
+          problems.push(`${slam.id}/${category.id}: "${speciesId}" is not in the ontology`);
+          continue;
+        }
+        if (species.takeStatus === "protected") {
+          problems.push(
+            `${slam.id}/${category.id}: "${speciesId}" is protected and must never be a slam target`,
+          );
+        }
+        if (species.isGroup) {
+          problems.push(
+            `${slam.id}/${category.id}: "${speciesId}" is a group entry — name the species instead`,
+          );
+        }
+        if (seenSpecies.has(speciesId)) {
+          problems.push(`${slam.id}: "${speciesId}" fills two categories, which is ambiguous`);
+        }
+        seenSpecies.add(speciesId);
+      }
+    }
+
+    if (slam.requiredCategories > slam.categories.length) {
+      problems.push(`${slam.id}: needs ${slam.requiredCategories} of ${slam.categories.length}`);
+    }
+    if (slam.requiredCategories < 2) {
+      problems.push(`${slam.id}: a slam of one fish is not a slam`);
+    }
+    if (slam.source.trim() === "") {
+      problems.push(`${slam.id}: no source. A slam presented as real needs a citation.`);
+    }
+  }
+
+  const ids = SLAMS.map((s) => s.id);
+  for (const id of ids) {
+    if (ids.indexOf(id) !== ids.lastIndexOf(id)) problems.push(`duplicate slam id "${id}"`);
+  }
+
+  return problems;
+}

--- a/src/core/rules/slams/evaluate.test.ts
+++ b/src/core/rules/slams/evaluate.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import { speciesById } from "@/core/ontology/species";
+
+import vectors from "../vectors/slams.json";
+import type { CatchRecord, Disposition, Outcome, ResolutionState } from "../catch/types";
+import { SLAMS, slamById, slamsForRegion, validateSlams } from "./catalog";
+import { evaluateSlam } from "./evaluate";
+
+interface VectorCatch {
+  id: string;
+  species: string;
+  day: string;
+  disposition?: string | null;
+  state?: string;
+  deleted?: boolean;
+}
+
+function expand(v: VectorCatch): CatchRecord {
+  const at = `${v.day}T18:00:00.000Z`;
+  return {
+    id: v.id,
+    angler_id: "angler",
+    trip_id: "trip",
+    caught_at: at,
+    caught_tz: "America/Los_Angeles",
+    local_date: v.day,
+    lat: null,
+    lng: null,
+    gps_accuracy_m: null,
+    resolution_state: (v.state ?? "confirmed") as ResolutionState,
+    dismissed_reason: null,
+    resolved_at: null,
+    species_id: v.species,
+    species_other: null,
+    outcome: "landed" as Outcome,
+    disposition: (v.disposition ?? null) as Disposition | null,
+    quantity: 1,
+    length_mm: null,
+    weight_g: null,
+    size_estimated: false,
+    spot_id: null,
+    platform: null,
+    depth_fished_m: null,
+    rig_id: null,
+    rig_revision: null,
+    rig_slot: null,
+    inherited_fields: [],
+    location_condition_id: null,
+    location_name: null,
+    current_term: null,
+    current_strength: null,
+    structure_type_ids: [],
+    bottom_depth_m: null,
+    water_color_id: null,
+    water_clarity_id: null,
+    presentation: null,
+    notes: null,
+    tags: [],
+    favorite: false,
+    regulation_snapshot: null,
+    capture_mode: "live",
+    client_created_at: at,
+    created_at: at,
+    client_updated_at: at,
+    deleted_at: v.deleted === true ? at : null,
+  };
+}
+
+describe("slam evaluation", () => {
+  for (const vector of vectors.cases) {
+    it(vector.name, () => {
+      const definition = slamById(vector.slam);
+      expect(definition).not.toBeNull();
+
+      const standing = evaluateSlam(definition!, vector.catches.map(expand));
+      expect(standing.achieved).toBe(vector.expect.achieved);
+      expect(standing.days.map((d) => d.localDate)).toEqual(vector.expect.days);
+      expect(standing.closest?.have ?? null).toBe(vector.expect.closestHave);
+    });
+  }
+
+  it("does not care what order the catches arrive in", () => {
+    const vector = vectors.cases[0];
+    const definition = slamById(vector.slam)!;
+    const forwards = evaluateSlam(definition, vector.catches.map(expand));
+    const backwards = evaluateSlam(definition, [...vector.catches].reverse().map(expand));
+    expect(backwards).toEqual(forwards);
+  });
+
+  it("re-running changes nothing", () => {
+    const vector = vectors.cases[0];
+    const definition = slamById(vector.slam)!;
+    const catches = vector.catches.map(expand);
+    expect(evaluateSlam(definition, catches)).toEqual(evaluateSlam(definition, catches));
+  });
+});
+
+describe("the slam catalog", () => {
+  it("names no species the ontology lacks, and no protected fish anywhere", () => {
+    expect(
+      validateSlams((id) => {
+        const species = speciesById(id);
+        return species === null
+          ? null
+          : { isGroup: species.isGroup, takeStatus: species.takeStatus };
+      }),
+    ).toEqual([]);
+  });
+
+  it("never targets giant sea bass — 'sea bass' in the trifecta is white seabass", () => {
+    // The one confusion most likely to put a protected fish on a target list.
+    const island = slamById("socal-island-trifecta")!;
+    const allSpecies = island.categories.flatMap((c) => c.speciesIds);
+    expect(allSpecies).toContain("white_seabass");
+    expect(allSpecies).not.toContain("giant_sea_bass");
+  });
+
+  it("carries a source for every slam, so a house rule cannot pass as IGFA's", () => {
+    for (const slam of SLAMS) {
+      expect(slam.source.length).toBeGreaterThan(10);
+    }
+  });
+
+  it("covers both coasts", () => {
+    const regions = new Set(SLAMS.flatMap((s) => s.regions as readonly string[]));
+    expect(regions.has("southern_california")).toBe(true);
+    expect(regions.has("florida")).toBe(true);
+    expect(regions.has("northeast")).toBe(true);
+    expect(regions.has("texas")).toBe(true);
+  });
+
+  it("orders an angler's own region first without hiding the rest", () => {
+    const ordered = slamsForRegion("northeast");
+    expect(ordered).toHaveLength(SLAMS.length);
+    expect((ordered[0].regions as readonly string[])).toContain("northeast");
+  });
+
+  it("qualifies on fish alone, so it needs no region on a catch (spec §45.1)", () => {
+    // A Floridian slam completed by a catch record that knows nothing about Florida.
+    const standing = evaluateSlam(
+      slamById("igfa-inshore-grand-slam")!,
+      [
+        { id: "a", species: "atlantic_tarpon", day: "2026-06-10" },
+        { id: "b", species: "permit", day: "2026-06-10" },
+        { id: "c", species: "common_snook", day: "2026-06-10" },
+      ].map(expand),
+    );
+    expect(standing.achieved).toBe(true);
+  });
+});

--- a/src/core/rules/slams/evaluate.ts
+++ b/src/core/rules/slams/evaluate.ts
@@ -1,0 +1,85 @@
+/**
+ * Slam evaluation: group the log by day, ask what each day produced.
+ *
+ * Pure, like every other rule here — a function of the catches handed in, so an edit or a
+ * delete recalculates and re-running cannot award twice.
+ *
+ * "One day" is `catch.local_date`, which the catch already stores, computed in the
+ * catch's own timezone at log time. That is the right clock: a trip that runs past
+ * midnight splits, which is what "in one day" means to a tournament and to an angler, and
+ * flying between timezones cannot retroactively merge two days into a slam.
+ */
+
+import { isCountable } from "../catch/rules";
+import type { CatchRecord } from "../catch/types";
+import type { SlamDefinition, SlamDay, SlamStanding } from "./types";
+
+/** speciesId → the categories it can fill, for one definition. */
+function categoryIndex(definition: SlamDefinition): ReadonlyMap<string, string> {
+  const index = new Map<string, string>();
+  for (const category of definition.categories) {
+    for (const speciesId of category.speciesIds) {
+      // First category wins if a species is listed twice; `validateSlams` rejects that
+      // case outright so it cannot happen in shipped data.
+      if (!index.has(speciesId)) index.set(speciesId, category.id);
+    }
+  }
+  return index;
+}
+
+export function evaluateSlam(
+  definition: SlamDefinition,
+  catches: readonly CatchRecord[],
+): SlamStanding {
+  const index = categoryIndex(definition);
+
+  // day → category → the catch that filled it first
+  const byDay = new Map<string, Map<string, string>>();
+
+  for (const record of catches) {
+    if (!isCountable(record)) continue;
+    if (record.species_id === null) continue;
+
+    const categoryId = index.get(record.species_id);
+    if (categoryId === undefined) continue;
+
+    const day = byDay.get(record.local_date) ?? new Map<string, string>();
+    if (!day.has(categoryId)) day.set(categoryId, record.id);
+    byDay.set(record.local_date, day);
+  }
+
+  const days: SlamDay[] = [];
+  let closest: SlamStanding["closest"] = null;
+
+  for (const [localDate, filled] of byDay) {
+    if (filled.size >= definition.requiredCategories) {
+      days.push({
+        localDate,
+        // Sorted so the same day always reads the same way, here and in a second client.
+        categoryIds: [...filled.keys()].sort(),
+        catchIds: [...filled.values()].sort(),
+      });
+      continue;
+    }
+    if (closest === null || filled.size > closest.have) {
+      closest = { localDate, have: filled.size };
+    }
+  }
+
+  days.sort((a, b) => (a.localDate < b.localDate ? 1 : a.localDate > b.localDate ? -1 : 0));
+
+  return {
+    slamId: definition.id,
+    achieved: days.length > 0,
+    days,
+    closest: days.length > 0 ? null : closest,
+    required: definition.requiredCategories,
+  };
+}
+
+export function evaluateSlams(
+  definitions: readonly SlamDefinition[],
+  catches: readonly CatchRecord[],
+): readonly SlamStanding[] {
+  return definitions.map((definition) => evaluateSlam(definition, catches));
+}

--- a/src/core/rules/slams/types.ts
+++ b/src/core/rules/slams/types.ts
@@ -1,0 +1,72 @@
+/**
+ * Slams — several species, one day (founder request 2026-09-03).
+ *
+ * A slam is not a collection. A collection is a lifetime set an angler fills in over
+ * years; a slam is a *day*. Catch a yellowtail, a white seabass and a halibut across three
+ * seasons and you have three good days. Catch them between sunrise and sunset and you have
+ * the Island Trifecta. The whole feature is that one constraint.
+ *
+ * The shape is a pool, not a checklist, because that is how the real ones are written. The
+ * IGFA Inshore Grand Slam is *any three* of bonefish, permit, snook and tarpon — not four
+ * fixed slots. So a slam is a set of categories plus how many distinct ones a day must
+ * produce, which expresses both "these exact three fish" (three categories, need three)
+ * and "any three of these four" (four categories, need three) without a second model.
+ */
+
+import type { RegionId } from "@/core/ontology/regions";
+
+/**
+ * One qualifying slot. A category can be a single species (white seabass) or a whole
+ * group ("any tuna", "any billfish") — the offshore slams are written in groups, and an
+ * angler who lands two different tunas has filled the tuna slot once, not twice.
+ */
+export interface SlamCategory {
+  readonly id: string;
+  readonly label: string;
+  readonly speciesIds: readonly string[];
+}
+
+export type SlamTier = "trifecta" | "grand-slam" | "super-grand-slam";
+
+export interface SlamDefinition {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly tier: SlamTier;
+  readonly categories: readonly SlamCategory[];
+  /** Distinct categories a single local day must produce. */
+  readonly requiredCategories: number;
+  /**
+   * Where this slam is *shown*, never where it counts.
+   *
+   * Qualification is decided by the fish alone, which is what lets slams exist while
+   * spec §45.1 keeps region off the catch record: nobody catches a tarpon in Orange County
+   * or a white seabass off Montauk, so the species list is the geography. Region only
+   * decides which slams surface first for an angler who has told Settings where they fish
+   * — the "picker of defaults, never a filter" stance of ADR 007 §4.
+   */
+  readonly regions: readonly RegionId[];
+  /** Where the rule comes from. Invented slams and real ones must be tellable apart. */
+  readonly source: string;
+  readonly version: number;
+}
+
+/** A day on which a slam was completed. */
+export interface SlamDay {
+  readonly localDate: string;
+  readonly categoryIds: readonly string[];
+  readonly catchIds: readonly string[];
+}
+
+export interface SlamStanding {
+  readonly slamId: string;
+  readonly achieved: boolean;
+  /** Every day it was done, most recent first. Doing it twice is worth seeing. */
+  readonly days: readonly SlamDay[];
+  /**
+   * The closest an angler has come without finishing, for the day that got furthest.
+   * Null once achieved — at that point the near misses are no longer the story.
+   */
+  readonly closest: { readonly localDate: string; readonly have: number } | null;
+  readonly required: number;
+}

--- a/src/core/rules/vectors/slams.json
+++ b/src/core/rules/vectors/slams.json
@@ -1,0 +1,135 @@
+{
+  "$comment": "Vectors for src/core/rules/slams/ (ADR 003 §4). Catches use the compact shape from slams.test.ts. 'day' is the catch's local_date — the one-day rule is a local calendar day, so a trip past midnight splits.",
+  "cases": [
+    {
+      "name": "three qualifying fish on one day is the Island Trifecta",
+      "slam": "socal-island-trifecta",
+      "catches": [
+        { "id": "a", "species": "yellowtail", "day": "2026-05-02" },
+        { "id": "b", "species": "white_seabass", "day": "2026-05-02" },
+        { "id": "c", "species": "california_halibut", "day": "2026-05-02" }
+      ],
+      "expect": { "achieved": true, "days": ["2026-05-02"], "closestHave": null }
+    },
+    {
+      "name": "the same three fish across three days is three good days, not a trifecta",
+      "slam": "socal-island-trifecta",
+      "catches": [
+        { "id": "a", "species": "yellowtail", "day": "2026-05-02" },
+        { "id": "b", "species": "white_seabass", "day": "2026-05-03" },
+        { "id": "c", "species": "california_halibut", "day": "2026-05-04" }
+      ],
+      "expect": { "achieved": false, "days": [], "closestHave": 1 }
+    },
+    {
+      "name": "two of three reports how close the best day got",
+      "slam": "socal-island-trifecta",
+      "catches": [
+        { "id": "a", "species": "yellowtail", "day": "2026-05-02" },
+        { "id": "b", "species": "white_seabass", "day": "2026-05-02" },
+        { "id": "c", "species": "california_halibut", "day": "2026-06-01" }
+      ],
+      "expect": { "achieved": false, "days": [], "closestHave": 2 }
+    },
+    {
+      "name": "a released fish counts — IGFA does not require keeping one either",
+      "slam": "socal-island-trifecta",
+      "catches": [
+        { "id": "a", "species": "yellowtail", "day": "2026-05-02", "disposition": "released" },
+        { "id": "b", "species": "white_seabass", "day": "2026-05-02", "disposition": "released" },
+        { "id": "c", "species": "california_halibut", "day": "2026-05-02", "disposition": "released" }
+      ],
+      "expect": { "achieved": true, "days": ["2026-05-02"], "closestHave": null }
+    },
+    {
+      "name": "two tunas fill the tuna slot once, not twice",
+      "slam": "socal-offshore-trifecta",
+      "catches": [
+        { "id": "a", "species": "bluefin_tuna", "day": "2026-07-04" },
+        { "id": "b", "species": "yellowfin_tuna", "day": "2026-07-04" },
+        { "id": "c", "species": "yellowtail", "day": "2026-07-04" }
+      ],
+      "expect": { "achieved": false, "days": [], "closestHave": 2 }
+    },
+    {
+      "name": "any marlin closes the marlin slot",
+      "slam": "socal-offshore-trifecta",
+      "catches": [
+        { "id": "a", "species": "bluefin_tuna", "day": "2026-07-04" },
+        { "id": "b", "species": "yellowtail", "day": "2026-07-04" },
+        { "id": "c", "species": "striped_marlin", "day": "2026-07-04" }
+      ],
+      "expect": { "achieved": true, "days": ["2026-07-04"], "closestHave": null }
+    },
+    {
+      "name": "any three of the four inshore fish is the grand slam",
+      "slam": "igfa-inshore-grand-slam",
+      "catches": [
+        { "id": "a", "species": "atlantic_tarpon", "day": "2026-06-10" },
+        { "id": "b", "species": "permit", "day": "2026-06-10" },
+        { "id": "c", "species": "common_snook", "day": "2026-06-10" }
+      ],
+      "expect": { "achieved": true, "days": ["2026-06-10"], "closestHave": null }
+    },
+    {
+      "name": "three of four is not the super grand slam",
+      "slam": "igfa-inshore-super-grand-slam",
+      "catches": [
+        { "id": "a", "species": "atlantic_tarpon", "day": "2026-06-10" },
+        { "id": "b", "species": "permit", "day": "2026-06-10" },
+        { "id": "c", "species": "common_snook", "day": "2026-06-10" }
+      ],
+      "expect": { "achieved": false, "days": [], "closestHave": 3 }
+    },
+    {
+      "name": "all four is",
+      "slam": "igfa-inshore-super-grand-slam",
+      "catches": [
+        { "id": "a", "species": "atlantic_tarpon", "day": "2026-06-10" },
+        { "id": "b", "species": "permit", "day": "2026-06-10" },
+        { "id": "c", "species": "common_snook", "day": "2026-06-10" },
+        { "id": "d", "species": "atlantic_bonefish", "day": "2026-06-10" }
+      ],
+      "expect": { "achieved": true, "days": ["2026-06-10"], "closestHave": null }
+    },
+    {
+      "name": "doing it twice records both days, most recent first",
+      "slam": "texas-slam",
+      "catches": [
+        { "id": "a", "species": "red_drum", "day": "2026-04-01" },
+        { "id": "b", "species": "spotted_seatrout", "day": "2026-04-01" },
+        { "id": "c", "species": "southern_flounder", "day": "2026-04-01" },
+        { "id": "d", "species": "red_drum", "day": "2026-09-15" },
+        { "id": "e", "species": "spotted_seatrout", "day": "2026-09-15" },
+        { "id": "f", "species": "southern_flounder", "day": "2026-09-15" }
+      ],
+      "expect": { "achieved": true, "days": ["2026-09-15", "2026-04-01"], "closestHave": null }
+    },
+    {
+      "name": "an unresolved quick mark cannot complete a slam",
+      "slam": "cape-cod-slam",
+      "catches": [
+        { "id": "a", "species": "striped_bass", "day": "2026-09-20" },
+        { "id": "b", "species": "bluefish", "day": "2026-09-20" },
+        { "id": "c", "species": "false_albacore", "day": "2026-09-20", "state": "unresolved" }
+      ],
+      "expect": { "achieved": false, "days": [], "closestHave": 2 }
+    },
+    {
+      "name": "deleting one fish takes the slam back",
+      "slam": "cape-cod-slam",
+      "catches": [
+        { "id": "a", "species": "striped_bass", "day": "2026-09-20" },
+        { "id": "b", "species": "bluefish", "day": "2026-09-20" },
+        { "id": "c", "species": "false_albacore", "day": "2026-09-20", "deleted": true }
+      ],
+      "expect": { "achieved": false, "days": [], "closestHave": 2 }
+    },
+    {
+      "name": "an empty log has no slams and no near misses",
+      "slam": "socal-island-trifecta",
+      "catches": [],
+      "expect": { "achieved": false, "days": [], "closestHave": null }
+    }
+  ]
+}

--- a/src/features/passport/components/collection-list.tsx
+++ b/src/features/passport/components/collection-list.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Link from "next/link";
+
+import type { CollectionDefinition, CollectionProgress } from "@/core/rules/passport/types";
+
+import { usePassport } from "../data";
+import { CARD_CLASS } from "../ui-classes";
+
+/**
+ * Every collection (founder request 2026-09-03).
+ *
+ * Grouped by kind so a long list stays readable, and regional collections keep the
+ * region-first ordering the data layer applies — the angler's own water at the top, the
+ * rest still visible because a Californian who fishes Baja in July should find it.
+ */
+export function CollectionList() {
+  const { hydrated, collections } = usePassport();
+
+  const groups = [
+    { key: "region", title: "Where you fish", blurb: "The fish a place is known for." },
+    { key: "family", title: "Families", blurb: "Related fish, wherever you catch them." },
+    { key: "habitat", title: "Water", blurb: "Grouped by the kind of water they live in." },
+  ] as const;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <nav>
+        <Link
+          href="/passport"
+          className="inline-flex min-h-touch-floor items-center text-label text-text-link focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+        >
+          ← Passport
+        </Link>
+      </nav>
+
+      <section className={`${CARD_CLASS} p-4`}>
+        <h1 className="text-h1">Collections</h1>
+        <p className="mt-1 text-body text-text-muted" aria-live="polite">
+          {hydrated
+            ? `${collections.filter((c) => c.progress.complete).length} of ${collections.length} complete.`
+            : "Reading your log…"}
+        </p>
+      </section>
+
+      {groups.map((group) => {
+        const rows = collections.filter((c) => c.definition.collectionType === group.key);
+        if (rows.length === 0) return null;
+
+        return (
+          <section key={group.key} className={`${CARD_CLASS} p-4`}>
+            <h2 className="text-h3">{group.title}</h2>
+            <p className="mt-1 text-caption text-text-muted">{group.blurb}</p>
+            <ul className="mt-3 flex flex-col gap-2">
+              {rows.map((row) => (
+                <li key={row.definition.id}>
+                  <CollectionRow definition={row.definition} progress={row.progress} />
+                </li>
+              ))}
+            </ul>
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+function CollectionRow({
+  definition,
+  progress,
+}: {
+  definition: CollectionDefinition;
+  progress: CollectionProgress;
+}) {
+  return (
+    <Link
+      href={`/passport/collections/${definition.id}`}
+      className="flex min-h-touch-floor items-center justify-between gap-3 rounded-md border border-hairline px-3 text-body transition-colors hover:bg-surface-raised focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+    >
+      <span>{definition.name}</span>
+      <span className="text-caption text-text-muted">
+        {progress.caught} of {progress.required}
+        {progress.complete ? " · complete" : ""}
+      </span>
+    </Link>
+  );
+}

--- a/src/features/passport/components/passport-home-card.tsx
+++ b/src/features/passport/components/passport-home-card.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import Link from "next/link";
+
+import { speciesById } from "@/core/ontology/species";
+
+import { usePassport } from "../data";
+import { CARD_CLASS, SECONDARY_BUTTON } from "../ui-classes";
+
+/**
+ * The passport's card on the Calendar home page.
+ *
+ * Deliberately one line of substance and a link. The calendar is the home surface (D23)
+ * and this must not compete with it — the card exists so an angler *sees* their collection
+ * exists without hunting for it in Settings, which is the cheap test of whether the
+ * passport deserves a permanent place in the navigation later (spec §8.1).
+ *
+ * It says something real or it says nothing worth reading, so the empty state is a plain
+ * invitation rather than a row of zeroes.
+ */
+export function PassportHomeCard() {
+  const { hydrated, totals, slams } = usePassport();
+
+  if (!hydrated) return null;
+
+  const newest = totals.latestNewSpecies;
+  const newestName =
+    newest !== null ? (speciesById(newest.speciesId)?.commonName ?? null) : null;
+
+  // The nearest unfinished slam, and only when someone has actually started one.
+  const nearest = slams
+    .filter((s) => !s.standing.achieved && s.standing.closest !== null)
+    .sort((a, b) => (b.standing.closest?.have ?? 0) - (a.standing.closest?.have ?? 0))[0];
+
+  return (
+    <section className={`${CARD_CLASS} p-4`}>
+      <h2 className="text-h3">Passport</h2>
+
+      {totals.uniqueSpecies === 0 ? (
+        <p className="mt-2 text-body text-text-muted">
+          Your species collection builds itself from your log. Nothing to fill in.
+        </p>
+      ) : (
+        <>
+          <p className="mt-2 text-body">
+            <span className="text-text-primary">
+              {totals.uniqueSpecies} {totals.uniqueSpecies === 1 ? "species" : "species"}
+            </span>{" "}
+            <span className="text-text-muted">
+              from {totals.totalCatches} {totals.totalCatches === 1 ? "catch" : "catches"}
+            </span>
+          </p>
+          {newestName !== null ? (
+            <p className="mt-1 text-caption text-text-muted">
+              Newest: {newestName} · {newest?.caughtAt.slice(0, 10)}
+            </p>
+          ) : null}
+          {nearest !== undefined ? (
+            <p className="mt-1 text-caption text-text-muted">
+              {nearest.definition.name}: {nearest.standing.closest?.have} of{" "}
+              {nearest.standing.required} on {nearest.standing.closest?.localDate}
+            </p>
+          ) : null}
+        </>
+      )}
+
+      <Link href="/passport" className={`${SECONDARY_BUTTON} mt-3`}>
+        Open Passport
+      </Link>
+    </section>
+  );
+}

--- a/src/features/passport/components/passport-overview.tsx
+++ b/src/features/passport/components/passport-overview.tsx
@@ -15,9 +15,14 @@ import { CARD_CLASS, SECONDARY_BUTTON } from "../ui-classes";
  * activity list and no "you're on a roll" copy.
  */
 export function PassportOverview() {
-  const { hydrated, totals, collections, badges, nearestGoals } = usePassport();
+  const { hydrated, totals, collections, badges, slams, nearestGoals } = usePassport();
   const earned = badges.filter((b) => b.earned);
   const newest = totals.latestNewSpecies;
+  const slamsDone = slams.filter((s) => s.standing.achieved).length;
+  // The single closest near miss, and only if someone has actually started one.
+  const nearestSlam = slams
+    .filter((s) => !s.standing.achieved && s.standing.closest !== null)
+    .sort((a, b) => (b.standing.closest?.have ?? 0) - (a.standing.closest?.have ?? 0))[0];
   const newestName =
     newest !== null ? (speciesById(newest.speciesId)?.commonName ?? newest.speciesId) : null;
 
@@ -108,6 +113,27 @@ export function PassportOverview() {
             </li>
           ))}
         </ul>
+      </section>
+
+      {/*
+        Slams sit above badges deliberately: a trifecta is the thing an angler actually
+        talks about in the parking lot, and the near-miss line is the strongest reason on
+        this page to go out again.
+      */}
+      <section className={`${CARD_CLASS} p-4`}>
+        <h2 className="text-h3">Slams</h2>
+        <p className="mt-2 text-body text-text-muted">
+          Several species, one day. {slamsDone} of {slams.length} done.
+        </p>
+        {nearestSlam !== undefined ? (
+          <p className="mt-2 text-caption text-text-muted">
+            Closest: {nearestSlam.definition.name} — {nearestSlam.standing.closest?.have} of{" "}
+            {nearestSlam.standing.required} on {nearestSlam.standing.closest?.localDate}.
+          </p>
+        ) : null}
+        <Link href="/passport/slams" className={`${SECONDARY_BUTTON} mt-3`}>
+          See slams
+        </Link>
       </section>
 
       <section className={`${CARD_CLASS} p-4`}>

--- a/src/features/passport/components/passport-overview.tsx
+++ b/src/features/passport/components/passport-overview.tsx
@@ -18,6 +18,16 @@ export function PassportOverview() {
   const { hydrated, totals, collections, badges, slams, nearestGoals } = usePassport();
   const earned = badges.filter((b) => b.earned);
   const newest = totals.latestNewSpecies;
+  /*
+    `collections` arrives ordered region-first, so its head is the angler's own water and
+    then the families. The other regions are real but they are not this page's job — a
+    Californian does not need Maine's progress on their overview, and forty rows is not a
+    summary. The full list has its own page.
+  */
+  const homeRegionId = collections.find((c) => c.definition.regionId !== null)?.definition.regionId;
+  const shownCollections = collections.filter(
+    (c) => c.definition.regionId === null || c.definition.regionId === homeRegionId,
+  );
   const slamsDone = slams.filter((s) => s.standing.achieved).length;
   // The single closest near miss, and only if someone has actually started one.
   const nearestSlam = slams
@@ -98,7 +108,7 @@ export function PassportOverview() {
       <section className={`${CARD_CLASS} p-4`}>
         <h2 className="text-h3">Collections</h2>
         <ul className="mt-3 flex flex-col gap-2">
-          {collections.map(({ definition, progress }) => (
+          {shownCollections.map(({ definition, progress }) => (
             <li key={definition.id}>
               <Link
                 href={`/passport/collections/${definition.id}`}
@@ -113,6 +123,11 @@ export function PassportOverview() {
             </li>
           ))}
         </ul>
+        {collections.length > shownCollections.length ? (
+          <Link href="/passport/collections" className={`${SECONDARY_BUTTON} mt-3`}>
+            All {collections.length} collections
+          </Link>
+        ) : null}
       </section>
 
       {/*

--- a/src/features/passport/components/slam-list.tsx
+++ b/src/features/passport/components/slam-list.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import Link from "next/link";
+
+import { speciesById } from "@/core/ontology/species";
+import type { SlamCategory } from "@/core/rules/slams/types";
+
+import { usePassport, type SlamView } from "../data";
+import { CARD_CLASS } from "../ui-classes";
+
+/**
+ * Slams — several species, one day (founder request 2026-09-03).
+ *
+ * Ordered by the angler's region so a Californian sees the Island Trifecta first, but
+ * nothing is hidden: a SoCal angler who takes one week in the Keys should still be told
+ * they got the Inshore Grand Slam. Region decides the order, the fish decide the credit.
+ *
+ * A near miss is shown deliberately. "Two of three on 14 June" is the line that makes
+ * someone go back out, and it is honest — it is a fact about their log, not a nudge.
+ */
+export function SlamList() {
+  const { hydrated, slams } = usePassport();
+  const achieved = slams.filter((s) => s.standing.achieved).length;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <nav>
+        <Link
+          href="/passport"
+          className="inline-flex min-h-touch-floor items-center text-label text-text-link focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+        >
+          ← Passport
+        </Link>
+      </nav>
+
+      <section className={`${CARD_CLASS} p-4`}>
+        <h1 className="text-h1">Slams</h1>
+        <p className="mt-1 text-body text-text-muted">
+          Several species, one day. The day is what makes it hard — the same three fish across
+          three trips is three good days, not a trifecta.
+        </p>
+        <p className="mt-3 text-body-strong" aria-live="polite">
+          {hydrated ? `${achieved} of ${slams.length} done` : "Reading your log…"}
+        </p>
+      </section>
+
+      <ul className="flex flex-col gap-3">
+        {slams.map((slam) => (
+          <li key={slam.definition.id}>
+            <SlamCard slam={slam} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function SlamCard({ slam }: { slam: SlamView }) {
+  const { definition, standing } = slam;
+  const { categories, requiredCategories } = definition;
+  const partial = categories.length > requiredCategories;
+
+  return (
+    <article
+      className={`rounded-lg border p-4 ${
+        standing.achieved
+          ? "border-signal-orange bg-surface"
+          : "border-dashed border-border-interactive bg-background"
+      }`}
+    >
+      <div className="flex items-baseline justify-between gap-3">
+        <h2 className="text-body-strong text-text-primary">{definition.name}</h2>
+        <span className="text-caption text-text-muted">
+          {standing.achieved
+            ? standing.days.length === 1
+              ? "Done"
+              : `Done ×${standing.days.length}`
+            : `0 of ${requiredCategories}`}
+        </span>
+      </div>
+
+      <p className="mt-1 text-body text-text-muted">{definition.description}</p>
+
+      <p className="mt-2 text-caption text-text-muted">
+        {partial ? `Any ${requiredCategories} of:` : "All of:"}{" "}
+        {categories.map((c) => categoryLabel(c)).join(" · ")}
+      </p>
+
+      {standing.achieved ? (
+        <p className="mt-2 text-caption text-text-primary">
+          {standing.days.length === 1
+            ? `Caught it on ${standing.days[0].localDate}.`
+            : `Most recently ${standing.days[0].localDate}.`}
+        </p>
+      ) : standing.closest !== null ? (
+        <p className="mt-2 text-caption text-text-muted">
+          Closest: {standing.closest.have} of {requiredCategories} on {standing.closest.localDate}.
+        </p>
+      ) : null}
+
+      <p className="mt-2 text-caption text-text-muted">{definition.source}</p>
+    </article>
+  );
+}
+
+/** Prefer the ontology's own name for a single-species slot, so the two never disagree. */
+function categoryLabel(category: SlamCategory): string {
+  if (category.speciesIds.length === 1) {
+    return speciesById(category.speciesIds[0])?.commonName ?? category.label;
+  }
+  return category.label;
+}

--- a/src/features/passport/data.ts
+++ b/src/features/passport/data.ts
@@ -8,7 +8,7 @@ import { evaluateSlams } from "@/core/rules/slams/evaluate";
 import type { SlamDefinition, SlamStanding } from "@/core/rules/slams/types";
 import { evaluateBadges } from "@/core/rules/achievements/evaluate";
 import type { BadgeStanding } from "@/core/rules/achievements/types";
-import { COLLECTIONS, GROUP_SPECIES_IDS } from "@/core/rules/passport/collections";
+import { collectionsForRegion, GROUP_SPECIES_IDS } from "@/core/rules/passport/collections";
 import {
   collectionProgress,
   passportTotals,
@@ -83,7 +83,7 @@ export function usePassport(): PassportView {
     const byId = new Map(summaries.map((s) => [s.speciesId, s]));
     const caughtSpeciesIds = new Set(byId.keys());
 
-    const collections = COLLECTIONS.map((definition) => ({
+    const collections = collectionsForRegion(regionId).map((definition) => ({
       definition,
       progress: collectionProgress(definition, caughtSpeciesIds, GROUP_SPECIES_IDS),
     }));

--- a/src/features/passport/data.ts
+++ b/src/features/passport/data.ts
@@ -3,6 +3,9 @@
 import { useMemo } from "react";
 
 import { BADGES } from "@/core/rules/achievements/catalog";
+import { slamsForRegion } from "@/core/rules/slams/catalog";
+import { evaluateSlams } from "@/core/rules/slams/evaluate";
+import type { SlamDefinition, SlamStanding } from "@/core/rules/slams/types";
 import { evaluateBadges } from "@/core/rules/achievements/evaluate";
 import type { BadgeStanding } from "@/core/rules/achievements/types";
 import { COLLECTIONS, GROUP_SPECIES_IDS } from "@/core/rules/passport/collections";
@@ -19,6 +22,7 @@ import type {
 } from "@/core/rules/passport/types";
 import { SPECIES, speciesById } from "@/core/ontology/species";
 import { useLog } from "@/features/catches/store";
+import { useRegionPreference } from "@/features/settings/region";
 
 /**
  * The passport's application layer: the one place the pure rules meet the local log.
@@ -35,6 +39,11 @@ const KNOWN_SPECIES_IDS: ReadonlySet<string> = new Set(SPECIES.map((s) => s.id))
 
 const waterClassOf = (speciesId: string): "salt" | "fresh" | null =>
   speciesById(speciesId)?.waterClass ?? null;
+
+export interface SlamView {
+  readonly definition: SlamDefinition;
+  readonly standing: SlamStanding;
+}
 
 export interface CollectionStanding {
   readonly definition: CollectionDefinition;
@@ -59,12 +68,15 @@ export interface PassportView {
   readonly totals: PassportTotals;
   readonly collections: readonly CollectionStanding[];
   readonly badges: readonly BadgeStanding[];
+  /** Ordered by the angler's region first — never filtered by it (see slams/types.ts). */
+  readonly slams: readonly SlamView[];
   /** The three nearest to done, furthest along first. Never includes finished ones. */
   readonly nearestGoals: readonly Goal[];
 }
 
 export function usePassport(): PassportView {
   const log = useLog();
+  const [regionId] = useRegionPreference();
 
   return useMemo(() => {
     const summaries = speciesSummaries(log.catches, KNOWN_SPECIES_IDS);
@@ -82,6 +94,12 @@ export function usePassport(): PassportView {
       knownSpeciesIds: KNOWN_SPECIES_IDS,
       waterClassOf,
     });
+
+    const slamDefinitions = slamsForRegion(regionId);
+    const slams = evaluateSlams(slamDefinitions, log.catches).map((standing, i) => ({
+      definition: slamDefinitions[i],
+      standing,
+    }));
 
     const goals: Goal[] = [
       ...collections
@@ -121,7 +139,8 @@ export function usePassport(): PassportView {
       totals: passportTotals(summaries),
       collections,
       badges,
+      slams,
       nearestGoals,
     };
-  }, [log.catches, log.trips, log.hydrated]);
+  }, [log.catches, log.trips, log.hydrated, regionId]);
 }

--- a/src/features/shell/components/shell-nav.tsx
+++ b/src/features/shell/components/shell-nav.tsx
@@ -22,8 +22,16 @@ import { usePathname } from "next/navigation";
  * lived in this comment block and in shell-nav.test.ts; both were updated together —
  * the guard below is a decision record, not a patch over.
  *
- * "Rules" is deliberately the shortest label: six one-word labels still clear 320px
- * with min-h-touch-floor taps, which keeps the spec's "must not crowd the bar" clause.
+ * "Rules" is deliberately the shortest label. Six labels do NOT clear 320px in one row,
+ * despite what this comment claimed until 2026-09-03: measured, the bar wants 366px and
+ * overflowed the viewport by 46px at 320 and by 6px at 360, which is why "Settings" read
+ * as "Set" on a small phone. Below `nav-single-row` (384px) the bar wraps to two rows of
+ * three instead — all six labels at full size, every tap still min-h-touch-floor, nothing
+ * off-screen. Wrapping flex rather than a six-column grid on purpose: equal columns would
+ * need six times the *widest* label (432px) where flex needs only their sum (366px), so a
+ * grid would have pushed two rows onto every phone made.
+ * Shrinking the type was not an option: the 16px floor in docs/design/01-foundations.md
+ * has no escape hatch, and it is the right rule.
  * Ordered by how the day runs: plan on the Calendar, rig on Setup, log what you catch,
  * check the Tide, check the Rules, visit Settings rarely.
  */
@@ -44,12 +52,12 @@ export function ShellNav() {
       aria-label="Primary"
       className="border-t border-hairline bg-surface"
     >
-      <ul className="mx-auto flex max-w-3xl">
+      <ul className="mx-auto flex max-w-3xl flex-wrap">
         {SHELL_ROUTES.map((route) => {
           const active =
             route.href === "/" ? pathname === "/" : pathname.startsWith(route.href);
           return (
-            <li key={route.href} className="flex-1">
+            <li key={route.href} className="basis-1/3 nav-single-row:flex-1 nav-single-row:basis-auto">
               <Link
                 href={route.href}
                 aria-current={active ? "page" : undefined}


### PR DESCRIPTION
Four commits that were built after PR #51 was merged. #51 landed Phase 1 only, so this carries everything since, rebased onto current `main`.

## Slams — several species in one day

Ten definitions covering both coasts, each carrying its source so a house rule cannot pass as IGFA's: the two founder-specified SoCal trifectas, the IGFA inshore and offshore grand slams and their super variants, the Texas Slam, and the Cape Cod slams.

A slam is a **pool plus a threshold**, not a checklist, because that is how the real ones are written — the IGFA Inshore Grand Slam is *any three* of bonefish, permit, snook and tarpon. A category can itself be a group, so two different tunas in a day fill the tuna slot once.

"One day" is `catch.local_date`, already computed in the catch's own timezone, so a trip past midnight splits the way a tournament counts it. Released fish count, as IGFA also allows.

**Safeguard:** no protected species may appear on a slam (§4.5, §11, decision §40.8), enforced by `validateSlams` and failed by the suite. "Sea bass" in the Island Trifecta is **white seabass**; giant sea bass is protected and is not a target — there is a test named after that confusion.

## Regional collections

Forty-two collections now: thirty regional, plus families and habitats.

**This needed no region on a catch, so §45.1 still stands: the species list is the geography.** Membership comes from `popularSpeciesIds`, the researched lists the species picker already uses, so there is one region vocabulary rather than two. The `ca_gma_*` entries are excluded — regulatory splits of one coastline, not places with their own fish. **New Waters I stays cut**, because counting distinct regions an angler has fished genuinely does need the field that does not exist.

## Taxonomy correction

- White seabass moves from Bass to **Croaker** (Sciaenidae — the largest croaker on the coast).
- Black sea bass moves from Bass to the new **Grouper** collection (Serranidae).
- Giant sea bass moves with them. Not named in the request, but leaving it in Bass would contradict the correction being made. Still protected, still excluded from completion.

New collections: Grouper and sea bass, Marlin, Pelagic.

Red drum and the seatrout stay out of Croaker, resolved by deferring to TPWD: our own `texas-pack.ts` cites the Outdoor Annual at `drum-bag-length-limits` and `seatrout-bag-length-limits`, so Texas manages Drum and Seatrout as separate categories with no croaker umbrella.

## Nav overflow fix

Measured, not assumed: the bottom bar wanted **366px of content in a 320px viewport** — 46px off the edge at 320 and 6px at 360, which is why "Settings" rendered as "Set". The comment in `shell-nav.tsx` claimed six labels cleared 320px; it was wrong and is corrected.

Below a new `nav-single-row` breakpoint (384px) the bar wraps to two rows of three, all labels full size with `min-h-touch-floor` taps. At 384px and up nothing changes, so every modern phone keeps its single row. Wrapping flex rather than a six-column grid on purpose: equal columns need six times the *widest* label (432px) where flex needs only their sum (366px), so a grid would have pushed two rows onto every phone made.

The breakpoint is a **named token** (`tokens.json` plus a `--breakpoint-*` namespace in the generator) rather than an inline `min-[384px]:`, which is exactly the size literal the tripwire exists to catch.

Also adds a passport card to the calendar home page — species count, newest species, nearest slam — below the calendar, as the honest test of whether the passport earns a nav slot later (§8.1) rather than guessing now.

## How it was verified

- `npm run verify` — tokens regenerate clean, tripwires clean, lint 0 errors, `tsc --noEmit`, **546 tests pass**.
- `npm run build` — production build green.
- Measured in Chromium at 320/360/384/390/430/768px: no overflow or clipping at any width, and the taller bar does not cover page content (it sits in the layout, not over it).
- Passport screens were viewed against an **empty log**. The counting rules are covered by vectors and tests, not by clicking through real history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173H7NUFw6hjnumRw4GLbi3

---
_Generated by [Claude Code](https://claude.ai/code/session_0173H7NUFw6hjnumRw4GLbi3)_