### PR TITLE
Washington v8: Marine Area Settings regions

### DIFF
--- a/src/core/ontology/regions.ts
+++ b/src/core/ontology/regions.ts
@@ -57,6 +57,18 @@ export type RegionId =
    *  regulations pack yet — the honest "no verified pack" state, not a hidden one. */
   | "oregon"
   | "washington"
+  | "wa_ma_1_4"
+  | "wa_ma_4_east"
+  | "wa_ma_5"
+  | "wa_ma_6"
+  | "wa_ma_7"
+  | "wa_ma_8_1"
+  | "wa_ma_8_2"
+  | "wa_ma_9"
+  | "wa_ma_10"
+  | "wa_ma_11"
+  | "wa_ma_12"
+  | "wa_ma_13"
   | "alaska"
   /** Angler-defined home water: nothing is pre-judged, Recent builds the picture. */
   | "custom";
@@ -102,7 +114,19 @@ export const REGIONS: readonly Region[] = [
   { id: "baja_california", label: "Baja California (MX)", hint: "Tijuana to Punta Eugenia: yellowtail, doggies." },
   { id: "baja_california_sur", label: "Baja California Sur (MX)", hint: "La Paz to Cabo: dorado, roosters, marlin." },
   { id: "oregon", label: "Oregon coast", hint: "Newport to Brookings: rockfish 4-fish marine bag, lingcod 3 @ 22\"+, halibut windows." },
-  { id: "washington", label: "Washington coast", hint: "Ilwaco to Neah Bay: bottomfish aggregate 9, rockfish sub-limits, halibut days." },
+  { id: "washington", label: "Washington coast", hint: "Ilwaco to Neah Bay (MA 1–4): bottomfish aggregate 9, rockfish sub-limits, halibut days." },
+  { id: "wa_ma_1_4", label: "WA · MA 1–4 coast", hint: "Ilwaco / Westport / La Push / Neah Bay west of Bonilla–Tatoosh." },
+  { id: "wa_ma_4_east", label: "WA · MA 4 east", hint: "Neah Bay east of Bonilla–Tatoosh: year-round bottomfish, four named rockfish only." },
+  { id: "wa_ma_5", label: "WA · MA 5 Sekiu", hint: "Sekiu / Pillar Point: first-3 black/blue west of Slip Point; barbless; halibut 1." },
+  { id: "wa_ma_6", label: "WA · MA 6 East Strait", hint: "East Juan de Fuca: rockfish closed; Pacific cod 2; halibut 1." },
+  { id: "wa_ma_7", label: "WA · MA 7 San Juans", hint: "San Juan Islands: rockfish closed; Pacific cod 2; halibut 1." },
+  { id: "wa_ma_8_1", label: "WA · MA 8-1 Skagit", hint: "Deception Pass / Skagit Bay: rockfish closed; lingcod May 1–Jun 15." },
+  { id: "wa_ma_8_2", label: "WA · MA 8-2 Everett", hint: "Port Susan / Port Gardner: rockfish closed; Tulalip salmon is a separate table." },
+  { id: "wa_ma_9", label: "WA · MA 9 Admiralty", hint: "Admiralty Inlet: 15 bottomfish, rockfish closed, lingcod slot May 1–Jun 15." },
+  { id: "wa_ma_10", label: "WA · MA 10 Seattle", hint: "Seattle / Bremerton: 15 bottomfish, rockfish closed; 2026 spot shrimp closed." },
+  { id: "wa_ma_11", label: "WA · MA 11 Tacoma", hint: "Tacoma / Vashon: rockfish closed; halibut closed; 2026 spot shrimp closed." },
+  { id: "wa_ma_12", label: "WA · MA 12 Hood Canal", hint: "Hood Canal: lingcod/cabezon/rockfish/halibut closed; flounder 15 north of Turner Creek." },
+  { id: "wa_ma_13", label: "WA · MA 13 South Sound", hint: "South of Tacoma Narrows: rockfish/halibut/crab closed 2026." },
   { id: "alaska", label: "Alaska", hint: "Salmon and halibut country. Regulations pack not yet shipped — check ADF&G." },
   { id: "custom", label: "Custom / anywhere else", hint: "No regional suggestions — search finds everything." },
 ];
@@ -185,6 +209,54 @@ const BY_REGION: Record<RegionId, readonly string[]> = {
   washington: [
     "rockfish", "black_rockfish", "lingcod", "cabezon", "chinook_salmon",
     "coho_salmon", "pacific_halibut", "surfperch", "sablefish", "kelp_greenling",
+  ],
+  wa_ma_1_4: [
+    "rockfish", "black_rockfish", "lingcod", "cabezon", "chinook_salmon",
+    "coho_salmon", "pacific_halibut", "surfperch", "sablefish", "kelp_greenling",
+  ],
+  wa_ma_4_east: [
+    "black_rockfish", "blue_rockfish", "lingcod", "cabezon", "pacific_halibut",
+    "chinook_salmon", "coho_salmon", "yellowtail_rockfish",
+  ],
+  wa_ma_5: [
+    "black_rockfish", "blue_rockfish", "lingcod", "pacific_halibut", "chinook_salmon",
+    "coho_salmon", "pacific_cod", "cabezon", "surfperch",
+  ],
+  wa_ma_6: [
+    "lingcod", "pacific_cod", "pacific_halibut", "chinook_salmon", "coho_salmon",
+    "cabezon", "surfperch", "flatfish",
+  ],
+  wa_ma_7: [
+    "lingcod", "pacific_cod", "pacific_halibut", "chinook_salmon", "coho_salmon",
+    "cabezon", "dungeness_crab", "flatfish",
+  ],
+  wa_ma_8_1: [
+    "lingcod", "chinook_salmon", "coho_salmon", "pacific_halibut", "cabezon",
+    "dungeness_crab", "surfperch", "flatfish",
+  ],
+  wa_ma_8_2: [
+    "lingcod", "chinook_salmon", "coho_salmon", "pacific_halibut", "cabezon",
+    "dungeness_crab", "surfperch", "flatfish",
+  ],
+  wa_ma_9: [
+    "lingcod", "chinook_salmon", "coho_salmon", "pacific_halibut", "cabezon",
+    "dungeness_crab", "surfperch", "flatfish",
+  ],
+  wa_ma_10: [
+    "lingcod", "chinook_salmon", "coho_salmon", "pacific_halibut", "cabezon",
+    "dungeness_crab", "surfperch", "flatfish",
+  ],
+  wa_ma_11: [
+    "lingcod", "chinook_salmon", "coho_salmon", "cabezon", "dungeness_crab",
+    "surfperch", "flatfish", "spot_shrimp",
+  ],
+  wa_ma_12: [
+    "flatfish", "chinook_salmon", "coho_salmon", "dungeness_crab", "spot_shrimp",
+    "surfperch", "lingcod", "cabezon",
+  ],
+  wa_ma_13: [
+    "chinook_salmon", "coho_salmon", "lingcod", "cabezon", "surfperch",
+    "flatfish", "spot_shrimp", "dungeness_crab",
   ],
   alaska: [
     "chinook_salmon", "coho_salmon", "sockeye_salmon", "pink_salmon", "pacific_halibut",

--- a/src/features/fish-legal/packs.ts
+++ b/src/features/fish-legal/packs.ts
@@ -197,6 +197,18 @@ export const PACKS: readonly BundledPack[] = [
     primaryAreaId: "wa-ma-1-4-coastal",
     data: WASHINGTON,
   },
+  { regionId: "wa_ma_1_4", jurisdictionLabel: "Washington MA 1–4 coast — WDFW (US)", shortCode: "WA·1–4", primaryAreaId: "wa-ma-1-4-coastal", data: WASHINGTON },
+  { regionId: "wa_ma_4_east", jurisdictionLabel: "Washington MA 4 east — WDFW (US)", shortCode: "WA·4E", primaryAreaId: "wa-ma4-east", data: WASHINGTON },
+  { regionId: "wa_ma_5", jurisdictionLabel: "Washington MA 5 Sekiu — WDFW (US)", shortCode: "WA·5", primaryAreaId: "wa-ma-5", data: WASHINGTON },
+  { regionId: "wa_ma_6", jurisdictionLabel: "Washington MA 6 East Strait — WDFW (US)", shortCode: "WA·6", primaryAreaId: "wa-ma-6", data: WASHINGTON },
+  { regionId: "wa_ma_7", jurisdictionLabel: "Washington MA 7 San Juans — WDFW (US)", shortCode: "WA·7", primaryAreaId: "wa-ma-7", data: WASHINGTON },
+  { regionId: "wa_ma_8_1", jurisdictionLabel: "Washington MA 8-1 Skagit — WDFW (US)", shortCode: "WA·8-1", primaryAreaId: "wa-ma-8-1", data: WASHINGTON },
+  { regionId: "wa_ma_8_2", jurisdictionLabel: "Washington MA 8-2 Everett — WDFW (US)", shortCode: "WA·8-2", primaryAreaId: "wa-ma-8-2", data: WASHINGTON },
+  { regionId: "wa_ma_9", jurisdictionLabel: "Washington MA 9 Admiralty — WDFW (US)", shortCode: "WA·9", primaryAreaId: "wa-ma-9", data: WASHINGTON },
+  { regionId: "wa_ma_10", jurisdictionLabel: "Washington MA 10 Seattle — WDFW (US)", shortCode: "WA·10", primaryAreaId: "wa-ma-10", data: WASHINGTON },
+  { regionId: "wa_ma_11", jurisdictionLabel: "Washington MA 11 Tacoma — WDFW (US)", shortCode: "WA·11", primaryAreaId: "wa-ma-11", data: WASHINGTON },
+  { regionId: "wa_ma_12", jurisdictionLabel: "Washington MA 12 Hood Canal — WDFW (US)", shortCode: "WA·12", primaryAreaId: "wa-ma-12", data: WASHINGTON },
+  { regionId: "wa_ma_13", jurisdictionLabel: "Washington MA 13 South Sound — WDFW (US)", shortCode: "WA·13", primaryAreaId: "wa-ma-13", data: WASHINGTON },
   // ——— Wave 4 (2026-09-02): Alaska Southeast (ADF&G Region 1 general saltwater) and
   // Hawaii's DLNR statewide table with the Maui HAR 13-95.1 split.
   {

--- a/src/features/fish-legal/wa-subareas.test.ts
+++ b/src/features/fish-legal/wa-subareas.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { speciesById } from "@/core/ontology/species";
+import { regionById } from "@/core/ontology/regions";
 
 import { packForRegion } from "./packs";
 import { regulationCard } from "./reg-engine";
@@ -8,21 +9,47 @@ import { WASHINGTON } from "./washington-pack";
 
 const TODAY = "2026-09-03";
 
-describe("Washington v7 — remaining Marine Area pamphlet tables", () => {
+describe("Washington v8 — Marine Area Settings regions", () => {
   it("every rule species exists in the vocabulary", () => {
     for (const r of WASHINGTON.rules) {
       if (r.speciesId) expect(speciesById(r.speciesId), r.id).not.toBeNull();
     }
   });
 
-  it("pack version 7 and washington still resolves", () => {
-    expect(WASHINGTON.pack.version).toBe(7);
-    expect(packForRegion("washington")?.data.pack.version).toBe(7);
+  it("pack version 8 and the coast region still resolves to MA 1–4", () => {
+    expect(WASHINGTON.pack.version).toBe(8);
+    expect(packForRegion("washington")?.primaryAreaId).toBe("wa-ma-1-4-coastal");
+    expect(packForRegion("washington")?.data.pack.version).toBe(8);
+  });
+
+  it("each Marine Area is a selectable Settings region with its own focus area", () => {
+    const MAS = [
+      ["wa_ma_1_4", "wa-ma-1-4-coastal"],
+      ["wa_ma_4_east", "wa-ma4-east"],
+      ["wa_ma_5", "wa-ma-5"],
+      ["wa_ma_6", "wa-ma-6"],
+      ["wa_ma_7", "wa-ma-7"],
+      ["wa_ma_8_1", "wa-ma-8-1"],
+      ["wa_ma_8_2", "wa-ma-8-2"],
+      ["wa_ma_9", "wa-ma-9"],
+      ["wa_ma_10", "wa-ma-10"],
+      ["wa_ma_11", "wa-ma-11"],
+      ["wa_ma_12", "wa-ma-12"],
+      ["wa_ma_13", "wa-ma-13"],
+    ] as const;
+    for (const [id, area] of MAS) {
+      expect(regionById(id), id).not.toBeNull();
+      const bundle = packForRegion(id);
+      expect(bundle, id).not.toBeNull();
+      expect(bundle!.primaryAreaId, id).toBe(area);
+      expect(bundle!.jurisdictionLabel, id).toContain("WDFW");
+    }
   });
 
   it("MA 5 allows the first 3 black/blue rockfish west of Slip Point in season", () => {
     const card = regulationCard(WASHINGTON, "wa-ma-5", "black_rockfish", TODAY, "boat");
     expect(card!.bagDaily).toBe(3);
+    expect(regulationCard(WASHINGTON, "wa-ma-5", "rockfish", TODAY, "boat")!.bagDaily).toBe(3);
   });
 
   it("MA 6 Pacific cod is 2/day; rockfish is release", () => {
@@ -39,5 +66,20 @@ describe("Washington v7 — remaining Marine Area pamphlet tables", () => {
   it("MA 12 flatfish 15/day; MA 8-1 lingcod 1 in the May–June window", () => {
     expect(regulationCard(WASHINGTON, "wa-ma-12", "flatfish", TODAY, "boat")!.bagDaily).toBe(15);
     expect(regulationCard(WASHINGTON, "wa-ma-8-1", "lingcod", "2026-05-20", "boat")!.bagDaily).toBe(1);
+  });
+
+  it("MA 9/10 Seattle-side halibut is 1/day on Sep 3 (fall window), not the coastal 9-fish bag", () => {
+    const seattle = packForRegion("wa_ma_10")!;
+    const card = regulationCard(seattle.data, seattle.primaryAreaId, "pacific_halibut", TODAY, "boat");
+    expect(card!.bagDaily).toBe(1);
+    expect(card!.verdict).not.toBe("release");
+    const coast = regulationCard(WASHINGTON, "wa-ma-1-4-coastal", "lingcod", TODAY, "boat");
+    expect(coast!.bagDaily).toBe(2);
+  });
+
+  it("does not apply the Sound 15-bottomfish / rockfish-closed template to MA 5 or MA 12", () => {
+    expect(regulationCard(WASHINGTON, "wa-ma-5", "rockfish", TODAY, "boat")!.verdict).not.toBe("release");
+    expect(regulationCard(WASHINGTON, "wa-ma-12", "cabezon", TODAY, "boat")!.verdict).toBe("release");
+    expect(regulationCard(WASHINGTON, "wa-ma-9", "rockfish", TODAY, "boat")!.verdict).toBe("release");
   });
 });

--- a/src/features/fish-legal/washington-pack.ts
+++ b/src/features/fish-legal/washington-pack.ts
@@ -18,7 +18,7 @@ import type { RegArea, RegGroup, RegPack, RegRule } from "./types";
 
 export const WASHINGTON_PACK: RegPack = {
   id: "washington-2026-09-02",
-  version: 7,
+  version: 8,
   publishedAt: "2026-09-03T20:00:00Z",
   notes:
     "Washington ocean Marine Areas 1-4 (WDFW news release March 5, 2026) — v2 deepens " +
@@ -30,7 +30,7 @@ export const WASHINGTON_PACK: RegPack = {
     "bottomfish daily, >120ft fishing prohibited, descending device required, lingcod " +
     "May 1-Jun 15 slot 26-36 in (spear May 21-Jun 15, hook-and-line from May 1), " +
     "cabezon May 1-Nov 30 @18 in @1, rockfish closed, cod/pollock/hake/wolf-eel closed, " +
-    "salmon headline windows as notes. v4 lands the Crab Rules page verbatim: Puget Sound (Dungeness 5 @ 6.25 in males hardshell / Red Rock 6 @ 5 in / Tanner 6 @ 4.5 in; CRC + endorsement; MA12 south of Ayock Point + MA13 closed to crab in 2026), Pacific Ocean (Dungeness 6 @ 6 in + Red Rock 6 @ 5 in; pot window Dec 1-Sep 15, year-round other gear; Willapa Bay pots Nov 15-Sep 15), Columbia River estuary (Dungeness 12 @ 5.75 in, year-round all gear), European green crab report-and-release. v5 lands the Shrimp Rules page verbatim: Puget Sound 80 spot shrimp/day cap inside a 10-lb all-species combined limit with 2026 spot closures (MA 8-1/8-2/9/10/11/13) as prohibited rows; Pacific Ocean 25-lb combined (max 200 spot, year-round); mesh/head-retention/pot-count gear doctrine. v7 lands remaining pamphlet Marine Areas 5, 6, 7, 8-1, 8-2, 11, 12 (2026-27 book, updated June 18 2026): MA5 rockfish first-3 west of Slip Point / first-1 east; MA6/7 Pacific cod 2/day (rockfish closed); MA12 Hood Canal lingcod/cabezon/rockfish closed, flounder 15 <120 ft north of Turner Creek.",
+    "salmon headline windows as notes. v4 lands the Crab Rules page verbatim: Puget Sound (Dungeness 5 @ 6.25 in males hardshell / Red Rock 6 @ 5 in / Tanner 6 @ 4.5 in; CRC + endorsement; MA12 south of Ayock Point + MA13 closed to crab in 2026), Pacific Ocean (Dungeness 6 @ 6 in + Red Rock 6 @ 5 in; pot window Dec 1-Sep 15, year-round other gear; Willapa Bay pots Nov 15-Sep 15), Columbia River estuary (Dungeness 12 @ 5.75 in, year-round all gear), European green crab report-and-release. v5 lands the Shrimp Rules page verbatim: Puget Sound 80 spot shrimp/day cap inside a 10-lb all-species combined limit with 2026 spot closures (MA 8-1/8-2/9/10/11/13) as prohibited rows; Pacific Ocean 25-lb combined (max 200 spot, year-round); mesh/head-retention/pot-count gear doctrine. v7 lands remaining pamphlet Marine Areas 5, 6, 7, 8-1, 8-2, 11, 12 (2026-27 book, updated June 18 2026): MA5 rockfish first-3 west of Slip Point / first-1 east; MA6/7 Pacific cod 2/day (rockfish closed); MA12 Hood Canal lingcod/cabezon/rockfish closed, flounder 15 <120 ft north of Turner Creek. v8: Settings regions per Marine Area so Puget Sound is not stuck on the coastal bag; MA 5–10 carry their own 1-halibut rows (Apr 2–Jun 30 and Aug 16–Sep 30).",
 };
 
 const A = {
@@ -59,7 +59,7 @@ const D1 = {
   updated: "2026-03-05",
 } as const;
 const VERIFIED = "2026-09-02";
-const pv = 7;
+const pv = 8;
 const C2 = {
   url: "https://www.eregulations.com/washington/fishing/crab-rules",
   title: "WDFW — 2026-2027 Washington Sport Fishing Rules (Crab Rules)",
@@ -457,6 +457,45 @@ function soundBottomfishRules(areaId: string, page?: string, pacificCodOpen = fa
   ];
 }
 
+
+/** 2026 Puget Sound / Strait halibut (MA 5–10). Copied onto each MA so Settings
+ *  primaryAreaId is not stuck looking at the shared wa-ma-5-10-halibut envelope. */
+function pugetHalibutRules(areaId: string): RegRule[] {
+  const pamphlet = {
+    url: "https://wdfw.wa.gov/fishing/regulations/halibut/puget-sound",
+    title: "WDFW — Puget Sound/Strait of Juan de Fuca halibut seasons and regulations",
+    updated: "2026-03-05",
+  } as const;
+  const tag = areaId.replace("wa-", "");
+  return [
+    rule({
+      id: `${tag}-halibut-bag`, speciesId: "pacific_halibut", regAreaId: areaId, kind: "bag_limit",
+      verbatim:
+        "In all marine areas open to halibut fishing, there is a one-fish daily catch limit and no minimum size restriction. There is a six fish annual bag limit. Anglers must record their catch on a WDFW catch record card.",
+      sourceUrl: pamphlet.url, sourceTitle: pamphlet.title, sourceUpdatedAt: pamphlet.updated, verifiedAt: VERIFIED,
+      seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: null, bagSharesWithGroup: false,
+      minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "Six fish annual bag limit; catch record card required.",
+      checkInseason: true, staleAfterDays: 7,
+    }),
+    rule({
+      id: `${tag}-halibut-spring`, speciesId: "pacific_halibut", regAreaId: areaId, kind: "season",
+      verbatim: "Marine Area 5-10. The 2026 season dates are as follows: April 2 through June 30, seven days per week.",
+      sourceUrl: pamphlet.url, sourceTitle: pamphlet.title, sourceUpdatedAt: pamphlet.updated, verifiedAt: VERIFIED,
+      seasonStart: "04-02", seasonEnd: "06-30", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+      minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+      checkInseason: true, staleAfterDays: 7,
+    }),
+    rule({
+      id: `${tag}-halibut-fall`, speciesId: "pacific_halibut", regAreaId: areaId, kind: "season",
+      verbatim: "Marine Area 5-10. August 16 through September 30, seven days per week. Fishing may close before September 30 if the quota is taken.",
+      sourceUrl: pamphlet.url, sourceTitle: pamphlet.title, sourceUpdatedAt: pamphlet.updated, verifiedAt: VERIFIED,
+      seasonStart: "08-16", seasonEnd: "09-30", bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+      minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+      checkInseason: true, staleAfterDays: 7,
+    }),
+  ];
+}
+
 export const WA_RULES: readonly RegRule[] = [
   rule({
     id: "wa-ma14-season", speciesId: null, regGroupId: "wa-bottomfish", regAreaId: "wa-ma-1-4-coastal", kind: "season",
@@ -738,6 +777,13 @@ export const WA_RULES: readonly RegRule[] = [
   ...soundBottomfishRules("wa-ma-8-1", "8-1"),
   ...soundBottomfishRules("wa-ma-8-2", "8-2"),
   ...soundBottomfishRules("wa-ma-11", "11"),
+  ...pugetHalibutRules("wa-ma-5"),
+  ...pugetHalibutRules("wa-ma-6"),
+  ...pugetHalibutRules("wa-ma-7"),
+  ...pugetHalibutRules("wa-ma-8-1"),
+  ...pugetHalibutRules("wa-ma-8-2"),
+  ...pugetHalibutRules("wa-ma-9"),
+  ...pugetHalibutRules("wa-ma-10"),
   rule({
     id: "wa-ma9-salmon-note", speciesId: null, regAreaId: "wa-ma-9", kind: "note",
     verbatim:
@@ -789,6 +835,14 @@ export const WA_RULES: readonly RegRule[] = [
     sourceUrl: "https://www.eregulations.com/washington/fishing/marine-area-5", sourceTitle: "WDFW — 2026-2027 Washington Sport Fishing Rules (Marine Area 5)", sourceUpdatedAt: "2026-06-18", verifiedAt: VERIFIED,
     seasonStart: "05-01", seasonEnd: "06-15", bagDaily: 1, possessionLimit: null, bagSharesWithGroup: false,
     minSizeIn: 26, maxSizeIn: 36, sizeMeasure: "total_length", platformScope: null, depthNote: "Spear window May 21–Jun 15.",
+    checkInseason: true, staleAfterDays: 30,
+  }),
+  rule({
+    id: "wa-ma5-rockfish-any", speciesId: "rockfish", regAreaId: "wa-ma-5", kind: "bag_limit",
+    verbatim: "Rockfish West of Slip Point: May 1-Sept. 30. No min. size. Daily limit is the first 3 black or blue/deacon rockfish caught. East of Slip Point: daily limit is the first black or blue/deacon rockfish caught. See Bottomfish Closure.",
+    sourceUrl: "https://www.eregulations.com/washington/fishing/marine-area-5", sourceTitle: "WDFW — 2026-2027 Washington Sport Fishing Rules (Marine Area 5)", sourceUpdatedAt: "2026-06-18", verifiedAt: VERIFIED,
+    seasonStart: "05-01", seasonEnd: "09-30", bagDaily: 3, possessionLimit: null, bagSharesWithGroup: true,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "West of Slip Point first 3; east of Slip Point first 1. Black or blue/deacon only.",
     checkInseason: true, staleAfterDays: 30,
   }),
   rule({


### PR DESCRIPTION
Washington was not missing tables — Settings treated the whole state as the coast (`wa-ma-1-4-coastal`). Puget Sound never got its own cards.

- Split WA into Marine Area regions (MA 1–4 through 13), same pattern as CA GMAs. Legacy `washington` still points at the coast.
- Copy 2026 Puget Sound/Strait **halibut 1/day** (Apr 2–Jun 30 and Aug 16–Sep 30) onto MA 5–10 so Seattle/Sekiu pickers are not empty.
- Do **not** re-apply the Sound 15-bottomfish / rockfish-closed template to MA 5 or MA 12.

Pack version 8.