### PR TITLE
NY/CT/NJ v2 leftover pelagics and red drum

### DIFF
--- a/src/features/fish-legal/atlantic-wave2.test.ts
+++ b/src/features/fish-legal/atlantic-wave2.test.ts
@@ -57,4 +57,19 @@ describe("Atlantic wave 2 — RI / NY / NJ", () => {
     expect(regulationCard(NEW_JERSEY, "nj-marine", "black_sea_bass", TODAY, "boat")!.bagDaily).toBe(1);
     expect(regulationCard(NEW_JERSEY, "nj-marine", "tautog", TODAY, "boat")!.bagDaily).toBe(1);
   });
+  it("NY Spanish 14 @15; king 23 @3; red drum max 27", () => {
+    const sm = regulationCard(NEW_YORK, "ny-marine", "spanish_mackerel", TODAY, "boat");
+    expect(sm!.minSizeIn).toBe(14);
+    expect(sm!.bagDaily).toBe(15);
+    expect(regulationCard(NEW_YORK, "ny-marine", "king_mackerel", TODAY, "boat")!.minSizeIn).toBe(23);
+    expect(regulationCard(NEW_YORK, "ny-marine", "red_drum", TODAY, "boat")!.maxSizeIn).toBe(27);
+  });
+
+  it("NJ cobia 43 @1; Spanish 14 @10; king 23 @3", () => {
+    const cobia = regulationCard(NEW_JERSEY, "nj-marine", "cobia", TODAY, "boat");
+    expect(cobia!.minSizeIn).toBe(43);
+    expect(cobia!.bagDaily).toBe(1);
+    expect(regulationCard(NEW_JERSEY, "nj-marine", "spanish_mackerel", TODAY, "boat")!.bagDaily).toBe(10);
+    expect(regulationCard(NEW_JERSEY, "nj-marine", "king_mackerel", TODAY, "boat")!.minSizeIn).toBe(23);
+  });
 });

--- a/src/features/fish-legal/atlantic-wave3.test.ts
+++ b/src/features/fish-legal/atlantic-wave3.test.ts
@@ -66,4 +66,10 @@ describe("Atlantic wave 3 — CT / NH / ME", () => {
     expect(ken!.bagDaily).toBe(1);
     expect(regulationCard(MAINE, "me-coast", "atlantic_wolffish", TODAY, "boat")!.verdict).toBe("release");
   });
+  it("CT red drum 27 max @1; American shad prohibited on LIS", () => {
+    const rd = regulationCard(CONNECTICUT, "ct-lis", "red_drum", TODAY, "boat");
+    expect(rd!.maxSizeIn).toBe(27);
+    expect(rd!.bagDaily).toBe(1);
+    expect(regulationCard(CONNECTICUT, "ct-lis", "american_shad", TODAY, "boat")!.verdict).toBe("release");
+  });
 });

--- a/src/features/fish-legal/connecticut-pack.ts
+++ b/src/features/fish-legal/connecticut-pack.ts
@@ -8,10 +8,10 @@ import type { RegArea, RegPack, RegRule } from "./types";
 
 export const CONNECTICUT_PACK: RegPack = {
   id: "connecticut-2026-09-03",
-  version: 1,
-  publishedAt: "2026-09-03T21:00:00Z",
+  version: 2,
+  publishedAt: "2026-09-04T22:00:00Z",
   notes:
-    "Connecticut DEEP marine recreational table (2026): stripers 28–<31\" @1 year-round + circle-hook bait; fluke 19\" May 4–Aug 1 then 19.5\" Aug 2–Oct 15 @3 (enhanced shore 17\"); tautog 16\" 2/2/3 windows; scup shore 9.5\" / boat 11\" @30 May 1–Dec 31; bluefish 5 (7 for-hire); BSB 15.5\" @4 May 16–Nov 25 (filament excluded).",
+    "Connecticut DEEP v2: v1 table plus red drum 27\" max @1; American shad closed in LIS (CT River only).",
 };
 
 const CT = {
@@ -20,7 +20,7 @@ const CT = {
   updated: "2026-01-01",
 } as const;
 const VERIFIED = "2026-09-03";
-const pv = 1;
+const pv = 2;
 
 export const CT_AREAS: readonly RegArea[] = [
   {
@@ -186,6 +186,22 @@ export const CT_RULES: readonly RegRule[] = [
     sourceUrl: CT.url, sourceTitle: CT.title, sourceUpdatedAt: CT.updated, verifiedAt: VERIFIED,
     seasonStart: null, seasonEnd: null, bagDaily: 0, possessionLimit: 0, bagSharesWithGroup: false,
     minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 90,
+  }),
+  rule({
+    id: "ct-red-drum", speciesId: "red_drum", regAreaId: "ct-lis", kind: "bag_limit",
+    verbatim: "Red Drum (Redfish): Maximum length: 27 inches. Daily creel limit: 1 fish per angler. Open Season: Open Year Round.",
+    sourceUrl: CT.url, sourceTitle: CT.title, sourceUpdatedAt: CT.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: 27, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ct-american-shad", speciesId: "american_shad", regAreaId: "ct-lis", kind: "prohibited",
+    verbatim: "American Shad: all state waters closed, except the Connecticut River System.",
+    sourceUrl: CT.url, sourceTitle: CT.title, sourceUpdatedAt: CT.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 0, possessionLimit: 0, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "Open only on the Connecticut River System.",
     checkInseason: false, staleAfterDays: 90,
   }),
 ];

--- a/src/features/fish-legal/new-jersey-pack.ts
+++ b/src/features/fish-legal/new-jersey-pack.ts
@@ -8,10 +8,10 @@ import type { RegArea, RegPack, RegRule } from "./types";
 
 export const NEW_JERSEY_PACK: RegPack = {
   id: "new-jersey-2026-09-03",
-  version: 1,
-  publishedAt: "2026-09-03T18:00:00Z",
+  version: 2,
+  publishedAt: "2026-09-04T22:00:00Z",
   notes:
-    "New Jersey (NJDEP Attention Anglers 2026): stripers 28–31\" @1 (ocean 0–3 mi year-round; other marine Mar 1–Dec 31; EEZ closed); fluke 18\" @3 May 4–Sep 25 (Delaware Bay 17\"; IBSP 16\" @2); BSB 12.5\" 10/1/10/15 windows; tautog 15\" 4/4/1/5 with March and May–July closed; bluefish 5 private/shore, 7 for-hire; weakfish 13\" @1.",
+    "New Jersey NJDEP v2: v1 table plus cobia 43\" @1 / 2 vessel; Spanish mackerel 14\" @10; king mackerel 23\" @3.",
 };
 
 const NJ = {
@@ -20,7 +20,7 @@ const NJ = {
   updated: "2026-03-01",
 } as const;
 const VERIFIED = "2026-09-03";
-const pv = 1;
+const pv = 2;
 
 export const NJ_AREAS: readonly RegArea[] = [
   {
@@ -247,6 +247,30 @@ export const NJ_RULES: readonly RegRule[] = [
     seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
     minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
     checkInseason: false, staleAfterDays: 90,
+  }),
+  rule({
+    id: "nj-cobia", speciesId: "cobia", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "Cobia: 1 per person, 2 per vessel. 43\".",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 43, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "2 per vessel.",
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "nj-spanish-mackerel", speciesId: "spanish_mackerel", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "Spanish Mackerel: 10. 14\".",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 10, possessionLimit: 10, bagSharesWithGroup: false,
+    minSizeIn: 14, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "nj-king-mackerel", speciesId: "king_mackerel", regAreaId: "nj-marine", kind: "bag_limit",
+    verbatim: "King Mackerel: 3. 23\".",
+    sourceUrl: NJ.url, sourceTitle: NJ.title, sourceUpdatedAt: NJ.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 3, possessionLimit: 3, bagSharesWithGroup: false,
+    minSizeIn: 23, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
   }),
 ];
 

--- a/src/features/fish-legal/new-york-pack.ts
+++ b/src/features/fish-legal/new-york-pack.ts
@@ -8,10 +8,10 @@ import type { RegArea, RegPack, RegRule } from "./types";
 
 export const NEW_YORK_PACK: RegPack = {
   id: "new-york-2026-09-03",
-  version: 1,
-  publishedAt: "2026-09-03T18:00:00Z",
+  version: 2,
+  publishedAt: "2026-09-04T22:00:00Z",
   notes:
-    "New York (DEC recreational saltwater table, last changed 2026-05-12): marine stripers 28–31\" @1 Apr 15–Dec 15 (Hudson north of GWB 23–28\" Apr 1–Nov 30); fluke 19\" May 4–Aug 1 then 19.5\" Aug 2–Oct 15 @3; BSB 16\" 3 then 6; scup shore 9.5\" / vessel 11\" @30; tautog LIS vs NY Bight split; bluefish 5/7; winter flounder Apr 1–May 30 @2.",
+    "New York DEC v2: v1 table plus Spanish mackerel 14\" @15; king mackerel 23\" @3; red drum no possession over 27\".",
 };
 
 const NY = {
@@ -20,7 +20,7 @@ const NY = {
   updated: "2026-05-12",
 } as const;
 const VERIFIED = "2026-09-03";
-const pv = 1;
+const pv = 2;
 
 export const NY_AREAS: readonly RegArea[] = [
   {
@@ -273,6 +273,30 @@ export const NY_RULES: readonly RegRule[] = [
     seasonStart: null, seasonEnd: null, bagDaily: 0, possessionLimit: 0, bagSharesWithGroup: false,
     minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
     checkInseason: false, staleAfterDays: 90,
+  }),
+  rule({
+    id: "ny-spanish-mackerel", speciesId: "spanish_mackerel", regAreaId: "ny-marine", kind: "bag_limit",
+    verbatim: "Spanish mackerel: 14\". Possession 15. All year.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 15, possessionLimit: 15, bagSharesWithGroup: false,
+    minSizeIn: 14, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ny-king-mackerel", speciesId: "king_mackerel", regAreaId: "ny-marine", kind: "bag_limit",
+    verbatim: "King mackerel: 23\". Possession 3. All year.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 3, possessionLimit: 3, bagSharesWithGroup: false,
+    minSizeIn: 23, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "ny-red-drum", speciesId: "red_drum", regAreaId: "ny-marine", kind: "bag_limit",
+    verbatim: "Red drum: No size limit. No limit for fish less than 27\" TL. Fish greater than 27\" TL shall not be possessed. All year.",
+    sourceUrl: NY.url, sourceTitle: NY.title, sourceUpdatedAt: NY.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: 27, sizeMeasure: "total_length", platformScope: null, depthNote: "No daily bag under 27\".",
+    checkInseason: true, staleAfterDays: 60,
   }),
 ];
 

--- a/supabase/migrations/20260904120000_v2_ny_ct_nj_digest.sql
+++ b/supabase/migrations/20260904120000_v2_ny_ct_nj_digest.sql
@@ -1,0 +1,28 @@
+-- NY / CT / NJ v2 leftover pelagics (2026-09-04). Insert-only + pack upsert.
+
+insert into public.reg_rule
+  (species_id, reg_group_id, reg_area_id, water_class, kind, verbatim, source_url, source_title, source_updated_at, verified_at, pack_version,
+   season_start, season_end, bag_daily, possession_limit, min_size_in, max_size_in, size_measure, platform_scope, depth_note, check_inseason, stale_after_days)
+values
+  ('spanish_mackerel', null, 'ny-marine', 'salt', 'bag_limit', 'Spanish mackerel: 14". Possession 15. All year.', 'https://dec.ny.gov/things-to-do/freshwater-fishing/regulations/saltwater-size-catch-limits', 'New York DEC — Recreational Saltwater Fishing Size, Catch, and Season Limits', '2026-05-12', '2026-09-04', 2,
+   null, null, 15, 15, 14, null, 'total_length', null, null, true, 60),
+  ('king_mackerel', null, 'ny-marine', 'salt', 'bag_limit', 'King mackerel: 23". Possession 3. All year.', 'https://dec.ny.gov/things-to-do/freshwater-fishing/regulations/saltwater-size-catch-limits', 'New York DEC — Recreational Saltwater Fishing Size, Catch, and Season Limits', '2026-05-12', '2026-09-04', 2,
+   null, null, 3, 3, 23, null, 'total_length', null, null, true, 60),
+  ('red_drum', null, 'ny-marine', 'salt', 'bag_limit', 'Red drum: No size limit. No limit for fish less than 27" TL. Fish greater than 27" TL shall not be possessed. All year.', 'https://dec.ny.gov/things-to-do/freshwater-fishing/regulations/saltwater-size-catch-limits', 'New York DEC — Recreational Saltwater Fishing Size, Catch, and Season Limits', '2026-05-12', '2026-09-04', 2,
+   null, null, null, null, null, 27, 'total_length', null, 'No daily bag under 27".', true, 60),
+  ('red_drum', null, 'ct-lis', 'salt', 'bag_limit', 'Red Drum (Redfish): Maximum length: 27 inches. Daily creel limit: 1 fish per angler. Open Season: Open Year Round.', 'https://portal.ct.gov/deep/fishing/saltwater-fishing-guide/species-regulations', 'Connecticut DEEP — Saltwater Fishing Guide: Species Regulations', '2026-04-01', '2026-09-04', 2,
+   null, null, 1, 1, null, 27, 'total_length', null, null, true, 60),
+  ('american_shad', null, 'ct-lis', 'salt', 'prohibited', 'American Shad: all state waters closed, except the Connecticut River System.', 'https://portal.ct.gov/deep/fishing/saltwater-fishing-guide/species-regulations', 'Connecticut DEEP — Saltwater Fishing Guide: Species Regulations', '2026-04-01', '2026-09-04', 2,
+   null, null, 0, 0, null, null, null, null, 'Open only on the Connecticut River System.', false, 90),
+  ('cobia', null, 'nj-marine', 'salt', 'bag_limit', 'Cobia: 1 per person, 2 per vessel. 43".', 'https://dep.nj.gov/njfw/fishing/marine/marine-regulations/', 'New Jersey DEP — Attention Anglers 2026 recreational marine table', '2026-01-01', '2026-09-04', 2,
+   null, null, 1, 1, 43, null, 'total_length', null, '2 per vessel.', true, 60),
+  ('spanish_mackerel', null, 'nj-marine', 'salt', 'bag_limit', 'Spanish Mackerel: 10. 14".', 'https://dep.nj.gov/njfw/fishing/marine/marine-regulations/', 'New Jersey DEP — Attention Anglers 2026 recreational marine table', '2026-01-01', '2026-09-04', 2,
+   null, null, 10, 10, 14, null, 'total_length', null, null, true, 60),
+  ('king_mackerel', null, 'nj-marine', 'salt', 'bag_limit', 'King Mackerel: 3. 23".', 'https://dep.nj.gov/njfw/fishing/marine/marine-regulations/', 'New Jersey DEP — Attention Anglers 2026 recreational marine table', '2026-01-01', '2026-09-04', 2,
+   null, null, 3, 3, 23, null, 'total_length', null, null, true, 60);
+
+insert into public.reg_pack (id, version, published_at, notes) values
+  ('new-york-2026-09-03', 2, '2026-09-04T22:00:00Z', 'New York DEC v2: v1 table plus Spanish mackerel 14" @15; king mackerel 23" @3; red drum no possession over 27".'),
+  ('connecticut-2026-09-03', 2, '2026-09-04T22:00:00Z', 'Connecticut DEEP v2: v1 table plus red drum 27" max @1; American shad closed in LIS (CT River only).'),
+  ('new-jersey-2026-09-03', 2, '2026-09-04T22:00:00Z', 'New Jersey NJDEP v2: v1 table plus cobia 43" @1 / 2 vessel; Spanish mackerel 14" @10; king mackerel 23" @3.')
+on conflict (id) do update set version = excluded.version, notes = excluded.notes, published_at = excluded.published_at;


### PR DESCRIPTION
## What
Bump New York, Connecticut, and New Jersey recreational packs to **v2** with leftover rows from official tables only.

- **NY DEC** (changed 2026-05-12): Spanish mackerel 14" @15; king mackerel 23" @3; red drum no possession over 27".
- **CT DEEP**: red drum 27" max @1; American shad prohibited on LIS (open CT River only).
- **NJ Attention Anglers 2026**: cobia 43" @1 / 2 vessel; Spanish 14" @10; king 23" @3 (not the older N.J.A.C. cobia).

RI DEM Rev 9/1/2026 has no cobia/Spanish/king rows — not invented. Hickory shad skipped (no species id).

Insert-only SQL: `20260904120000_v2_ny_ct_nj_digest.sql`. Tests in `atlantic-wave2.test.ts` / `atlantic-wave3.test.ts` (15 passing).

Field-test/auth still held.