### PR TITLE
Remove the California default from the Terms, and add a pre-ship checklist

### DIFF
--- a/docs/team/BACKLOG.md
+++ b/docs/team/BACKLOG.md
@@ -16,8 +16,7 @@ the app cannot do its headline job for anyone who does not fish that one bay, wh
 outranks every feature idea we have.
 
 ## Now
-- Publish a contact address and confirm the governing jurisdiction, then flip `LEGAL_CONTACT.resolved` in `src/core/legal/documents.ts`. Until then the notices render as incomplete and the app is not ready for the public. Founder decision, one line of code — `ceo`
-- Attorney review of the three notices. They are drafted, specific and honest, but written by an engineer — `counsel`, then a real lawyer
+- Everything blocking public release now lives in `docs/team/PRE-SHIP-CHECKLIST.md`, with the legal questions tracked as issue #56. A legal team answers those before ship (founder, 2026-09-04) — `ceo`
 - Confirm the NOAA tide fetch against the live service. Written from the API docs and never exercised: this environment's proxy blocks `api.tidesandcurrents.noaa.gov`. One person with signal opening the tide chart settles it — `head-dev`
 
 ## Next

--- a/docs/team/PRE-SHIP-CHECKLIST.md
+++ b/docs/team/PRE-SHIP-CHECKLIST.md
@@ -1,0 +1,71 @@
+# Pre-ship checklist
+
+What must be true before Fish Log Book is offered to the public. Not a roadmap — this is
+only the list of things that are *blocking*, each with the evidence behind it, so that
+nobody has to re-derive the reasoning at launch.
+
+Founder direction, 2026-09-04: a legal team will be assembled to answer the legal
+questions before the product ships. This file is what they should be handed.
+
+---
+
+## Legal
+
+- [ ] **Contact address and governing law.** → **issue #56**
+      `LEGAL_CONTACT.resolved` in `src/core/legal/documents.ts` is `false`, and every legal
+      page says in amber that the documents are incomplete and the app is not ready for the
+      public. `jurisdiction` carries no default on purpose: a leftover working assumption
+      would otherwise become the governing law of a real contract the day somebody fills in
+      the email. `documents.test.ts` fails if the flag disagrees with either field.
+      Closing it is one edit — fill both, set `resolved: true`.
+
+- [ ] **Attorney review of the three notices.** `docs` are at `/legal/regulations`,
+      `/legal/terms`, `/legal/privacy`, sourced from `src/core/legal/documents.ts`.
+      They are specific and honest about what the code actually does, and they were written
+      by an engineer, not a lawyer. The regulations notice and the liability section are the
+      two that carry real exposure: the app tells people what they may legally keep.
+
+- [ ] **Species photo licensing.** `src/features/fish-legal/species-photos.ts` says it
+      plainly in its own header: several of the 51 images are "source-restricted —
+      attribution shown; Wikimedia/NOAA swap owed before release". Defensible for a dev
+      build, not for public distribution.
+
+## Correctness of things people act on
+
+- [ ] **Confirm the NOAA tide fetch against the live service.** `queries/noaa-tides.ts` was
+      written from the API documentation and has never touched the real endpoint — the
+      development environment's proxy blocks `api.tidesandcurrents.noaa.gov`. One person
+      with signal opening the tide chart settles it. Station ids in `stations.ts` are
+      unverified for the same reason.
+
+- [ ] **A regulation review pass on every pack shipped.** Rules are dated snapshots, and a
+      wrong bag limit is the most serious defect this app can have.
+
+## Infrastructure
+
+- [ ] **Confirm RLS is actually applied to the production database.** The policies are
+      right — `supabase/migrations/20260828120100_v1_rls.sql` enables row-level security on
+      every angler-owned table with `angler_id = (select auth.uid())` on all four verbs,
+      makes `trip_rig` insert-only, and revokes everything from `anon`. What is unverified
+      is that the migration has been *run* against production. Migrations existing is not
+      the same as migrations applied, and this is the check the privacy notice's "we do not
+      share your log" claim rests on.
+
+- [ ] **Account deletion actually deletes.** The privacy notice commits to removal from the
+      active database within 30 days on request. Confirm the auth cascade covers every
+      angler-owned table, and that there is a path for someone to ask.
+
+## Keep true
+
+Not tasks — properties the app currently has that are worth not losing, each enforced by a
+test in `src/core/legal/documents.test.ts` so they cannot be lost quietly:
+
+- No analytics, advertising, tracking, or crash-reporting dependency.
+- No runtime fetch to any host beyond Supabase and NOAA tides.
+- No basemap tile layer: the boundary map makes no outside calls, so looking at where you
+  are does not tell anyone where you are.
+- Species photos served from the app itself, never a remote host.
+
+The first time someone proposes adding product analytics, this is the paragraph to read
+first. It is a real asset — a privacy posture this clean is cheap to keep and expensive to
+recover.

--- a/src/core/legal/documents.test.ts
+++ b/src/core/legal/documents.test.ts
@@ -49,10 +49,13 @@ describe("legal documents", () => {
     expect(legalDocument("cookies")).toBeNull();
   });
 
-  it("keeps the contact block honest — an address means resolved, and the reverse", () => {
-    // Guards the ship-with-a-blank case in both directions: a filled address that still
-    // claims to be unresolved would hide a real contact behind the pending notice.
-    expect(LEGAL_CONTACT.resolved).toBe(LEGAL_CONTACT.email.length > 0);
+  it("only counts as resolved once BOTH the address and the jurisdiction are filled in", () => {
+    // Guards it in both directions. Half-filled must not read as resolved: shipping a
+    // governing-law clause nobody chose is the failure this exists to prevent. And a
+    // fully-filled block that still claims to be unresolved would hide a real contact
+    // behind the pending notice.
+    const complete = LEGAL_CONTACT.email.length > 0 && LEGAL_CONTACT.jurisdiction.length > 0;
+    expect(LEGAL_CONTACT.resolved).toBe(complete);
   });
 });
 

--- a/src/core/legal/documents.ts
+++ b/src/core/legal/documents.ts
@@ -34,6 +34,7 @@ export const LEGAL_CONTACT = {
    * default would quietly become the governing law of a real contract without anyone
    * having chosen it. `documents.test.ts` fails if the flag and the fields disagree.
    */
+  // Tracked as issue #56 and docs/team/PRE-SHIP-CHECKLIST.md — a legal team answers both.
   resolved: false,
   /** Legal entity that publishes the app. A person's name is fine if there is no company. */
   entity: "the publisher of Fish Log Book",

--- a/src/core/legal/documents.ts
+++ b/src/core/legal/documents.ts
@@ -26,13 +26,21 @@ export const LEGAL_VERSION = "2026-09-04";
  * takes with "No verified data". Fill these in and flip the flag; nothing else changes.
  */
 export const LEGAL_CONTACT = {
+  /**
+   * Flip to `true` only when BOTH fields below are filled in. Founder, 2026-09-04:
+   * incorporation is undecided and a legal team will settle it before launch, so neither
+   * field carries a default. A pre-filled jurisdiction is the dangerous kind of
+   * placeholder — the day somebody adds the company email and flips this flag, that
+   * default would quietly become the governing law of a real contract without anyone
+   * having chosen it. `documents.test.ts` fails if the flag and the fields disagree.
+   */
   resolved: false,
   /** Legal entity that publishes the app. A person's name is fine if there is no company. */
   entity: "the publisher of Fish Log Book",
   /** Where a user sends a privacy or terms question. */
   email: "",
-  /** Whose law governs the Terms, and where disputes are heard. */
-  jurisdiction: "the State of California, United States",
+  /** Whose law governs the Terms, and where disputes are heard. Not yet decided. */
+  jurisdiction: "",
 } as const;
 
 export interface LegalSection {


### PR DESCRIPTION
Two commits that were pushed after PR #55 was opened and so were not included when it merged. #55 is finished; this carries the remainder.

**The first one matters.** `main` currently ships:

```ts
jurisdiction: "the State of California, United States",
```

## Why that is a problem

Founder direction, 2026-09-04: incorporation is undecided, and a legal team will settle it before launch. California was my working assumption while drafting, and a pre-filled jurisdiction is the dangerous kind of placeholder — the day somebody adds the company email and flips `LEGAL_CONTACT.resolved`, that default silently becomes the governing law of a real contract without anyone having chosen it.

Blanked. The test now requires **both** the address and the jurisdiction before the flag may read `true`, so a half-filled block cannot ship as complete.

Nothing rendered changes: while unresolved, the footer already showed the pending notice rather than a jurisdiction, so no user has ever been shown a governing-law claim.

## The pre-ship checklist

`docs/team/PRE-SHIP-CHECKLIST.md` — new, because no such document existed and a backlog line is not where a decision survives four months. It is the document the legal team gets handed. Only genuinely blocking items, each with its evidence:

- The two legal blanks (tracked as **issue #56**).
- Attorney review of the notice text. The drafts are accurate about what the code does; whether they are *sufficient* is a different question.
- Species photo licensing — 51 images, several described in `species-photos.ts` itself as "source-restricted — attribution shown; Wikimedia/NOAA swap owed before release".
- The NOAA tide fetch, still never exercised against the live service.
- Two infrastructure checks.

### One of those checks is worth naming here

Row-level security is **correct**. `20260828120100_v1_rls.sql` generates the same four policies for every angler-owned table keyed on `angler_id = (select auth.uid())`, makes `trip_rig` insert-only so rig history cannot be rewritten, and revokes everything from `anon`. (My first grep missed all of it because the policies are generated in a `do $$` loop — worth knowing before anyone else greps for `CREATE POLICY` and panics.)

What is *unverified* is that the migration has actually been **run** against production. Migrations existing is not migrations applied, and the privacy notice's "we do not share your log" rests entirely on it. Five-minute check, on the checklist.

The file also records four properties the app has today and should not lose quietly — no analytics, two outbound hosts, no map tiles, local photos — each already enforced by a test, with a note about what to read the first time somebody proposes adding product analytics.

## Verification

`npm run verify` — tokens clean, tripwires clean, **0 lint errors** (8 pre-existing warnings), `tsc --noEmit` clean, **649 tests pass** after rebasing onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173H7NUFw6hjnumRw4GLbi3

---
_Generated by [Claude Code](https://claude.ai/code/session_0173H7NUFw6hjnumRw4GLbi3)_