### PR TITLE
Guided setup, the Quiver, reel sizes, and region honesty

### DIFF
--- a/docs/architecture/decisions/008-quiver-identity-and-type-scoped-gear-options.md
+++ b/docs/architecture/decisions/008-quiver-identity-and-type-scoped-gear-options.md
@@ -1,0 +1,315 @@
+# 008 — Quiver setup identity, and type-scoped gear options
+
+**Date:** 2026-09-04 · **Status:** accepted
+**Answers:** `docs/specs/setup-flow-and-quiver.md` §7.1 and §7.2 — the two rulings the
+founder's §6 information architecture left open.
+**Depends on:** `003-web-prototype-boundary.md` (pure core, vectors, folder law),
+`004-offline-store-and-sync.md` (IndexedDB is the read path, ids are minted on device),
+`005-front-end-architecture.md` §2 (tokens), `001-canonical-ontology-shape.md`.
+**Supersedes:** nothing. **Amends:** nothing. Both calls are additive.
+
+## Context
+
+The founder settled the information architecture in the spec's §6: the Quiver is a
+section inside Setup, the nav stays at six, the Tackle Box is reached from Setup. Two
+questions were left to the architect because neither is a product call.
+
+**1. What is a Quiver entry?** `Put away` calls `retireRodSetup`, which writes revision
+*n+1* with `retired_at` set rather than mutating (`src/features/catches/store.ts`,
+`src/core/rules/catch/rules.ts`). That is correct and stays. But it means a rod put away
+and brought back three times is four rows, and `RigRecord` has no field that says those
+four rows are the same rod. `slot` is not it: `slot` is unique within a **trip**
+(`nextRodSlot` maxes over `rigs` filtered by `trip_id`), and the Quiver's entire purpose
+is to survive *between* trips. Saturday's Rod 1 and Tuesday's Rod 1 are two different
+sticks, and Tuesday's Rod 3 may well be Saturday's Rod 1.
+
+**2. Reel sizes.** `src/features/tackle/types.ts` offers spinning sizes (500–8000) and
+conventional classes (12–30) in one flat `size` list regardless of the `type` chosen.
+
+The log is on-device only (IndexedDB, `src/lib/offline/db.ts`, `DB_VERSION = 2`). There
+is no server for this data yet — note that `supabase/migrations/…v1_core_schema.sql`'s
+`trip_rig` does not even carry `slot`, `name`, `setup_type`, `gear` or `retired_at` yet,
+so the local record is already ahead of the table. Whatever is decided here has to work
+against rows sitting on the founder's phone right now, with no server to re-derive them
+from and no second chance.
+
+---
+
+## The call
+
+### 1. A Quiver entry is a lineage, identified by a new `quiver_id` on the rig record
+
+**The Quiver groups by `quiver_id`: a UUIDv7 minted once, when a rod setup is first
+created, and carried unchanged through every later revision — re-rig, retire, bring
+back — and across every trip.**
+
+The identity cannot be derived. Each candidate derivation fails on a case that will
+happen in the first week of use:
+
+| derived from | fails because |
+|---|---|
+| `(trip_id, slot)` | Trip-scoped by construction. Every new trip would start an empty Quiver. |
+| `slot` alone | "Rod 1" on Saturday and "Rod 1" on Tuesday are different rods, and the same rod moves slots. |
+| `name` | Nullable, defaults to `Rod {slot}`, and renaming a rod would silently fork it into two Quiver entries while two unnamed rods would merge into one. |
+| gear fingerprint | Re-rigging is the normal case. Changing a leader must not create a second rod. |
+
+So this is a new stable id on the record, not a derivation. Three fields, three
+different questions, none of which substitute for another:
+
+- `id` — this revision. What a catch points at. Never reused.
+- `slot` — where this rod stands **in one trip**. Rod 1, Rod 2. `nextRodSlot` is
+  unchanged and still never reuses a slot, including retired ones.
+- `quiver_id` — **which rod this is**, for all time. The Quiver's grouping key.
+
+```ts
+// src/core/rules/catch/types.ts — RigRecord
+/**
+ * The rod's identity across trips and revisions: "my 40-lb yo-yo stick". Minted once
+ * when the setup is first created, then copied forward by every revision, including
+ * retire and bring-back. `slot` says where a rod stands in one trip; this says which
+ * rod it is. The Quiver groups by this and nothing else.
+ */
+readonly quiver_id: string;
+```
+
+**`revision` becomes lineage-scoped, not slot-scoped.** Revisions increase monotonically
+within a `quiver_id`, across trips. `activeRodSetups` stays correct unchanged — within
+one trip a lineage occupies one slot at a time and its revisions still increase in time
+order, so "highest revision in the slot" is still the standing rod — and the Quiver gains
+a total order that makes "the latest state of this rod" well defined without comparing
+timestamps.
+
+**Bring-back is a new revision, not an un-retire.** `retired_at` is never cleared on an
+existing row; nothing in `trip_rig` is ever mutated. Bringing a rod back writes revision
+*n+1* with the same `quiver_id`, the **new** `trip_id`, a fresh slot from `nextRodSlot`,
+`retired_at: null`, and the gear copied from the revision being restored. A rod put away
+and brought back three times is one Quiver entry with six revisions, which is exactly
+what "the log never lies about what a fish was caught on" costs.
+
+**Guard:** bring-back is legal only when the lineage's latest revision is retired. Two
+live revisions of one lineage in one trip would render the same rod twice in Today's
+Setup, so the guard is a pure function, not a disabled button.
+
+**Labelling:** the Quiver never falls back to `Rod {slot}`. A slot number from a trip
+three weeks ago is meaningless in a saved collection. An unnamed lineage is labelled from
+its `setup_type` and its rod/reel gear. `rodSetupLabel` keeps its current slot fallback
+for Today's Setup, where the slot is the thing the angler is looking at.
+
+#### Where the code goes (ADR 003 §2, §3)
+
+Pure, in a new `src/core/rules/catch/quiver.ts`. No React, no DOM, no db, no id or clock
+generation inside — the caller supplies `id` and `nowIso`, exactly as `repeatSeedFrom`
+already refuses to mint them:
+
+```ts
+export interface QuiverEntry {
+  readonly quiver_id: string;
+  readonly latest: RigRecord;      // highest revision in the lineage
+  readonly in_todays_setup: boolean;
+  readonly last_used_at: string;   // latest.effective_from
+  readonly label: string;
+}
+
+export function quiverKeyOf(rig: RigRecord): string;
+export function quiverEntries(rigs: readonly RigRecord[], tripId: string): readonly QuiverEntry[];
+export function canBringBack(entry: QuiverEntry): boolean;
+export function broughtBackRevision(
+  latest: RigRecord,
+  input: { id: string; tripId: string; slot: number; nowIso: string },
+): RigRecord;
+```
+
+`quiverKeyOf` returns `rig.quiver_id` and falls back to `` `${rig.trip_id}:${rig.slot}` ``
+if it is ever absent. Belt and braces: after the migration below no persisted row lacks
+it, but core must stay total when a row arrives from a sync path whose column does not
+exist yet.
+
+The impure half is three lines in `src/features/catches/store.ts`, next to
+`saveRodSetup`/`retireRodSetup` and using the same `persist(row, mutation)` path:
+`bringBackRodSetup(quiverId, tripId)` reads the snapshot, calls `broughtBackRevision`
+with `uuidv7()`, `new Date().toISOString()` and `nextRodSlot(...)`, and persists.
+`saveRodSetup` gains an optional `quiverId` — omitted mints a new lineage, supplied
+continues one. `retireRodSetup` already spreads `...rig`, so it carries the id for free.
+
+The Quiver component calls `quiverEntries(state.rigs, tripId)` and
+`logActions.bringBackRodSetup`. **No grouping, no revision arithmetic and no
+retired-filtering in a component** — that is the rule ADR 003 exists for, and it is the
+rule this feature is most likely to break, because grouping in a `useMemo` looks harmless.
+
+Vectors, per ADR 003 §4: a `quiver` block in `src/core/rules/vectors/catch-rules.json`.
+It must contain at minimum — put away and brought back three times appears **once**;
+a lineage across two trips appears once; two unnamed rods in different trips do not
+merge; a legacy row with no `quiver_id` groups by trip and slot; `canBringBack` is false
+for a live lineage. (`scripts/check-tripwires.mjs` only enforces vectors for *top-level*
+`src/core/rules/*.ts`, so a file in `catch/` is on the honour system. Write them anyway.)
+
+#### The migration — required, and it must not be skipped
+
+Rigs already exist on the founder's device. There is no server to re-derive them from.
+
+**`src/lib/offline/db.ts`: `DB_VERSION` 2 → 3.** Inside the version-change transaction
+(so it is atomic with the upgrade, and a killed tab leaves either v2 or a fully
+backfilled v3):
+
+1. Read every `trip_rig` row. Group by `(trip_id, slot)`.
+2. Mint one UUIDv7 per group. Write it as `quiver_id` onto every row in that group.
+3. In the same transaction, for every `outbox` mutation with `entity === "trip_rig"` and
+   `state !== "done"`, merge the same `quiver_id` into its payload, so the queued insert
+   and the stored row do not disagree.
+
+Adding an absent identity field to a local row is not a violation of append-only. Nothing
+about what was fished changes, no `id` changes, and every `catch.rig_id` pointer still
+resolves. Append-only protects the angler's history from being rewritten; it does not
+require us to leave rows unlabelled forever.
+
+**What the angler sees afterwards:** every rod they have ever saved is in the Quiver and
+still works. Rods from *different trips* that were "the same rod" in the angler's head
+appear as separate entries, because the data linking them never existed and inventing the
+link — by name, or by gear similarity — would merge two rods that were never the same
+one. This is honest, it is one-time, it decays as new setups are created with real
+lineages, and a future "these are the same rod" merge action can be added if the founder
+actually finds the duplicates annoying. **Nothing is orphaned and nothing disappears.**
+
+**Trap, and this one is load-bearing.** The current `upgrade` callback does
+`if (oldVersion >= 1) { …create location_condition…; return; }`. That early `return`
+means a device on v1 or v2 would run the v2 step and **skip the v3 backfill entirely**,
+leaving rods with no `quiver_id` and an empty-looking Quiver — silently, with no error.
+The upgrade must be restructured into cumulative, non-returning steps
+(`if (oldVersion < 2) { … }` then `if (oldVersion < 3) { … }`) as part of this change.
+Verify by opening the app with an existing v2 database, not only with a fresh one.
+
+**Server, later.** When `trip_rig` is brought up to the local shape, the same migration
+adds `quiver_id uuid not null`, an index on `(angler_id, quiver_id, revision desc)`, and
+replaces `unique (trip_id, revision)` with `unique (quiver_id, revision)` — revision is
+lineage-scoped now. That migration is out of scope here; it is named so it is not
+rediscovered.
+
+Add **Quiver** and **rod setup lineage** to `docs/architecture/ontology.md`. A term the
+schema carries is a term the glossary defines.
+
+### 2. Reel sizes are type-scoped, on the field schema. `head-dev` is right
+
+Options that depend on another field belong in **type-scoped option sets on the field
+that has them**, not in the shared gear vocabulary. The vocabulary is a flat list of
+values; "4000 is meaningless on a lever drag" is a *relation between two fields*, and a
+flat list has nowhere to put it. A shared list can only be right for one reel type at a
+time, and it is currently right for none.
+
+`AttributeField` in `src/features/tackle/types.ts` gains three optional keys. Every
+existing field is untouched and keeps working:
+
+```ts
+export type AttributeField = {
+  key: string;
+  label: string;
+  /** Options when the field has no controller, or when the controller's value has no
+   *  set of its own. Never a union of two numbering systems. */
+  options: readonly string[];
+  placeholder: string;
+  maxChips?: number;
+  /** Key of the field in the SAME category whose value selects this field's options. */
+  dependsOn?: string;
+  /** Controlling value -> options. Exact match on the controlling field's value. */
+  optionsBy?: Readonly<Record<string, readonly string[]>>;
+  /** Shown in place of the chip row while the controller is unset. Copy is ux-ui's. */
+  emptyHint?: string;
+};
+```
+
+Resolution is one pure function in the same file, and it is the **only** place options
+are chosen:
+
+```ts
+export function fieldOptions(
+  field: AttributeField,
+  attributes: Record<string, string>,
+): readonly string[] {
+  if (!field.optionsBy) return field.options;
+  const controller = field.dependsOn ? attributes[field.dependsOn] ?? "" : "";
+  return field.optionsBy[controller] ?? field.options;
+}
+```
+
+The `reels` `size` field becomes `dependsOn: "type"`, `options: []`, an `emptyHint`, and
+an `optionsBy` keyed on the five existing type values — spinning in thousands
+(500–20000), conventional and star drag in line classes (10–80), lever drag in classes
+(12–130), baitcasting in hundreds (100–400). The exact ladders are `head-dev`'s to write
+from the founder's brief; the shape above is the contract. Brand-specific ladders (Avet
+SX/JX/MX, Shimano 200/300/400) go through Other… until someone asks for a second field.
+
+Three invariants, enforced by a unit test in `src/features/tackle/`, not by care:
+
+1. A field with `optionsBy` has `dependsOn`, and that key exists in the same category.
+2. A dependent field appears **after** its controller in `fields`, so the controller is
+   answered first. `reels` already satisfies this.
+3. No category's `options` array mixes two numbering systems. This is the bug; a test is
+   how it stops coming back.
+
+`ChoiceField` stays dumb: `tackle-editor-sheet.tsx` calls `fieldOptions(field,
+draft.attributes)` and passes the resolved list in as an `options` prop. Resolution does
+not move into the component (ADR 003 §3, ADR 005 §3). No colour or size literals are
+involved either way (ADR 005 §2, tripwire 2).
+
+#### Gear already saved with a size that is not valid for its type
+
+**Nothing happens to it, and that is the design, not an oversight. No migration.**
+
+`attributes` is `Record<string, string>` and was never constrained to the option list.
+`ChoiceField` already computes `valueIsCustom` for a value outside the chip row and opens
+the free-text input pre-filled with it. So a spinning reel saved as "20" keeps its value,
+keeps rendering, keeps matching search (`itemMatchesSearch` scans attribute values), and
+keeps its auto-name. It simply shows as a custom value instead of a highlighted chip —
+which is also true today for anyone who typed their own size.
+
+**Changing `type` does not clear `size`.** The dependent value stays and becomes a custom
+value. Silently deleting something the angler typed because they corrected an unrelated
+field is the worse failure by a wide margin, and a Penn 30 relabelled from Conventional
+to Lever drag is still a 30. This matches `retainedAttributes`, which already keeps values
+whose key survives a category switch.
+
+The gear vocabulary stays in `src/features/tackle/types.ts` for now. When the Setup gear
+picker becomes a second consumer, the registry moves to `src/core/ontology/tackle.ts`
+**unchanged in shape** — that is a scoped move, not a redesign, and it is not part of
+this work.
+
+---
+
+## What it costs us
+
+- **A new field on the rig record and a real IndexedDB migration**, on the one store
+  whose data cannot be re-fetched from anywhere. The `upgrade` restructure is the risky
+  part and has to be tested against an existing v2 database.
+- **Rods saved before today split by trip in the Quiver.** One-time, honest, and the
+  alternative is guessing which rods were the same one.
+- **A typo in a rod's name still costs a revision**, and now those revisions also
+  accumulate in the lineage. Unchanged from D21a; the Quiver just makes it visible.
+- **`revision` changes meaning** from slot-scoped to lineage-scoped. Nothing reads it
+  arithmetically today except `saveRodSetup`, but the future server migration has to
+  change its unique constraint, and that is now a thing someone must not forget.
+- **Three more optional keys on `AttributeField`.** A field schema that can express a
+  dependency is a field schema someone will eventually build a three-level dependency
+  with. Invariant 1 and the review bar are the only things stopping that.
+
+## Rejected
+
+- **A separate saved-setup / template store that a trip rig is instantiated from.** The
+  tidy-looking option. It duplicates the gear shape into a second entity, needs a second
+  write path and a second migration, and gives two answers to "what was I fishing with" —
+  precisely the drift ADR 003 §3 exists to prevent. One append-only table with a lineage
+  id says everything the template table would, and cannot disagree with itself.
+- **Grouping the Quiver by `name`.** No new field, no migration, and wrong within a week:
+  renaming forks a rod in two, and two rods left unnamed merge into one.
+- **Grouping by a gear fingerprint.** Makes re-rigging — the normal act — destroy the
+  rod's identity.
+- **Clearing `retired_at` on the existing row to bring a rod back.** One row instead of
+  two, and it mutates a record the server explicitly revokes UPDATE on. Retirement was a
+  fact that was true; unmaking it silently rewrites what the trip looked like.
+- **Deriving `quiver_id` lazily in the view instead of persisting it.** The derivation
+  would have to be recomputed identically by the Swift client from the same ambiguous
+  inputs, forever. An identity that two clients each guess at is not an identity.
+- **Reel size as a shared vocabulary with a `system` tag on each value** (`{value:
+  "4000", system: "spinning"}`). More general, and it pushes the filtering decision into
+  every consumer instead of answering it once in the registry. Type-scoped sets answer it
+  in the data, where it can be read.
+- **Clearing the size when the reel type changes.** Loses the angler's own input to fix
+  a display concern.

--- a/docs/design/12-guided-setup-and-quiver.md
+++ b/docs/design/12-guided-setup-and-quiver.md
@@ -1,0 +1,438 @@
+# 12 — Guided setup checklist, Setup reorganised, and the Quiver
+
+**Status:** Proposed — design only, no `.tsx` touched
+**Date:** 2026-09-04
+**Governs:** the Calendar home checklist, `/setup`, the new Quiver section
+**Reads first:** `docs/specs/setup-flow-and-quiver.md` §6 (settled IA), `docs/design/10-setup.md`,
+`docs/design/README.md` ("the test")
+**Author:** `ux-ui`
+
+Section §6 of the spec is not re-litigated here: the Quiver lives inside Setup, the nav
+bar stays at six, the checklist lives on Calendar above the calendar, and the Tackle Box
+is reached from Setup, not the nav. This document designs inside those rulings.
+
+Two facts from the code drove decisions below and are stated up front so head-dev does
+not have to re-derive them:
+
+1. **Steps 1 and 4 of the founder's five-step list are one screen, not two.**
+   `LocationConditionRecord` (`src/core/rules/catch/types.ts`) holds the place's name
+   *and* its observed current, structure, water and depth in a single record, and
+   `LocationSheet` is a single form where only `name` is required — everything else is
+   optional. "Set a location" and "add conditions" are the same sheet, distinguished only
+   by which fields got filled in. The checklist treats them as two rows because the
+   founder's brief numbers them that way and each teaches a different idea, but both rows
+   point at the same destination.
+2. **A trip has no "end" in the UI yet** (`docs/design/09-fish-log.md`, "deliberately not
+   built"). An open trip can span days. That makes "is there a location on the *current
+   trip*" an unstable, code-churn-sensitive thing to hang a one-time checklist on — see
+   §1.2 below for why the checklist does not use it.
+
+---
+
+## Part 1 — the five-step guided checklist
+
+### 1.1 The five steps, their destination, and what "done" means
+
+This is the most important table in the document. Read the two right-hand columns
+before building anything.
+
+| # | Step (founder's words) | Destination | "Done" test | Lifetime or per-trip? |
+|---|---|---|---|---|
+| 1 | Set or select a fishing location | `/setup` — Location & Conditions section | The angler has **ever** saved a location (any `location_condition` row, any trip, `deleted_at IS NULL`) | **Lifetime** |
+| 2 | Add gear to the Tackle Box | `/tackle` | The Tackle Box has **ever** held at least one item | **Lifetime** |
+| 3 | Build or select a fishing rod setup | `/setup` — Today's Setup / Quiver section | The angler has **ever** saved a rod setup (any `trip_rig` row, any trip, any revision — active or retired) | **Lifetime** |
+| 4 | Add current fishing-location conditions | `/setup` — Location & Conditions section (same sheet as step 1) | At least one saved location has **ever** had one or more of `current_term`, `current_strength`, `structure_type_ids`, `bottom_depth_m`, `water_color_id`, `water_clarity_id` set — i.e. something beyond just a name | **Lifetime** |
+| 5 | Log a fish | `/log` | The angler has **ever** logged at least one catch | **Lifetime** |
+
+**Every step is lifetime, not "today," and this is deliberate — it is the actual design
+decision, not a simplification.**
+
+The data underneath steps 1 and 4 is genuinely per-trip: a location describes right now,
+and a fresh trip starts with no locations of its own (spec §6, `docs/design/10-setup.md`
+"Location conditions are mutable"). If the checklist re-asked "is there a location on
+*this* trip" every time a new trip opened, it would flip back to incomplete every single
+outing for an angler who has fished for a decade — which is exactly the nagging failure
+mode the founder named in §6.2 ("a checklist that keeps nagging an experienced user is a
+checklist they learn to ignore"). A stepper that re-opens itself is worse than one that
+never existed.
+
+So the checklist is not a live readout of today's trip. It is a **one-time orientation
+flag**, checked once per step and then remembered forever, independent of what happens to
+any later trip. Concretely: each of the five booleans above is computed once, and the
+moment it is true, it is written to durable local state (e.g. a `checklist_progress`
+record, one boolean per step, no `trip_id`) and never re-derived from live data again —
+so if an angler later deletes every location they ever saved, step 1 stays checked. The
+checklist is not audited state; it is a memory of "you have done this before, so you know
+how." That is also why deleting all your gear does not resurrect step 2 — the flag, once
+set, cannot go back to false.
+
+Steps 2 and 3 read the same way whether "lifetime" is stated for them or not, since
+tackle and rod setups already persist independent of any single trip (that is the entire
+point of the Tackle Box and the Quiver). Writing "lifetime" next to all five, including
+the two that are naturally per-trip data, is the one line in this document worth
+re-reading if anything about the checklist behaves unexpectedly later: **the checklist
+step is not the data. It is a memory that the data was produced once.**
+
+### 1.2 What each step's row says
+
+Order matches the founder's numbered list exactly (spec §1).
+
+Incomplete row — number, label, one-line explainer in `text-caption`/`text-text-muted`,
+whole row is a `min-h-touch-floor` tap target that links to its destination:
+
+| # | Label (`text-body`, `text-text-primary`) | Explainer (`text-caption`, `text-text-muted`) |
+|---|---|---|
+| 1 | Set a fishing location | Where are you fishing? |
+| 2 | Add gear to your Tackle Box | Rods, reels, line, hooks — whatever's in your box. |
+| 3 | Build a rod setup | Pair your gear into a rod you can fish with. |
+| 4 | Add today's conditions | Current, structure, water — what you see out there. |
+| 5 | Log your first fish | One tap, from here or the Log tab. |
+
+Completed row — same label, explainer replaced by a status word, not removed (color is
+never the only signal — 06-accessibility-baseline.md):
+
+> **Set a fishing location** — *Done*
+
+`Done` renders in `success-green` (the token's own documented use is "system-confidence
+indicators... a completed... checkmark" — `02-semantic-colors.md` §"Success /
+confirmation" — this is exactly that case, not a catch-quality signal, so it does not
+reopen D23). No checkmark glyph without the word next to it, per the house rule on icons.
+
+A completed row **stays tappable** and still goes to its destination — someone who
+finished step 2 in January may want to add more gear in September, and the row is the
+obvious place to do that. Completion changes the caption, not the tap behavior.
+
+### 1.3 Layout at 320px
+
+```
+┌───────────────────────────────────┐  Card: CARD_CLASS, p-4, gap-3
+│ Get set up                        │  h2, text-h3
+│                                    │
+│ [1] Set a fishing location      › │  min-h-touch-floor row, full width
+│     Where are you fishing?        │  text-caption below label, wraps
+│                                    │  12px+ gap before next row
+│ [2] Add gear to your Tackle Box › │
+│     Rods, reels, line, hooks —    │
+│     whatever's in your box.       │
+│                                    │
+│ [3] Build a rod setup           › │
+│     Pair your gear into a rod     │
+│     you can fish with.            │
+│                                    │
+│ [4] Add today's conditions      › │
+│     Current, structure, water —   │
+│     what you see out there.       │
+│                                    │
+│ [5] Log your first fish         › │
+│     One tap, from here or the     │
+│     Log tab.                      │
+└───────────────────────────────────┘
+```
+
+Numbers are plain circled digits (`1`–`5`) in a fixed-width leading column, not icons —
+no image asset, no icon package (V1 ships none, per ADR 005 / README). Each row is a
+single `<Link>` with `flex items-start gap-3 min-h-touch-floor` — the number and text
+sit in one flex row so the two-line explainer wraps under the label without breaking the
+tap target into two pieces. At 320px width the explainer text wraps to 2 lines for rows
+2–4; that is accounted for above and does not overflow, because nothing in the row is
+fixed-width except the leading number column.
+
+Card sits **above** `MonthCalendar` in `src/app/(app)/page.tsx`, same page, above the
+existing "Open tide chart" link and the passport card — matching spec §6.2 exactly
+("the first screen on launch, so a new angler meets the order of operations without
+having to find anything first").
+
+### 1.4 The collapsed state — exact copy
+
+The moment all five lifetime flags are true, the five-row card is replaced by one row:
+
+```
+┌───────────────────────────────────┐
+│ Setup complete            Review › │
+└───────────────────────────────────┘
+```
+
+- Left text: **"Setup complete"** — `text-body`, `text-text-muted`. Plain past-tense
+  statement, not praise ("Nice work!" is the wrong register for this audience and this
+  product — the log itself never celebrates, per D23, and this card should not either).
+- Right side: **"Review"** — a `SECONDARY_BUTTON`-style link to `/setup`. Not "Open
+  Setup" or "Setup" alone — "Review" says correctly that there is nothing left to
+  configure for the first time, only things to look at or change.
+- Whole thing is one row, `min-h-touch-floor`, fits on one line at 320px (the string
+  "Setup complete" + "Review" is well under the ~30-character budget at 288px of usable
+  width in `text-body`/`text-label`).
+
+**Can it be re-expanded? No — not automatically, and there is no manual toggle.** Once
+collapsed, it stays collapsed for the life of the account (or until app data is reset).
+There is no accordion affordance to bring the five rows back, on purpose: a toggle that
+re-shows five rows on a misplaced tap is itself a small annoyance, and the entire feature
+that the five rows point at — rods, gear, locations, conditions — already lives
+permanently at `/setup`, which is exactly where "Review" sends you. The checklist's job
+was to teach the order once; `/setup` is the durable home for doing any of it again.
+Nothing is lost by never re-expanding, because nothing the checklist could show you is
+unavailable elsewhere.
+
+If, hypothetically, an angler wipes their local data (`docs/architecture/decisions/004`)
+and starts over, the checklist naturally reappears, because the lifetime flags themselves
+were part of that wiped state — no special-case code needed.
+
+---
+
+## Part 2 — the Setup page, reorganised
+
+### 2.1 Section order, and why
+
+1. **Setup intro card** — unchanged. One `h1` ("Setup") and the existing one-line job
+   statement. It orients; it is not a step.
+2. **Today's Setup → Rods.** The founder's own phrase in spec §2, kept as the exact
+   section label. This is the highest-frequency action on the page for a returning
+   angler — most trips start with "is my usual rod still rigged, or do I need to bring
+   one back" — so it sits first, immediately under the intro.
+3. **Quiver.** Placed directly beneath Today's Setup's rods, not lower on the page and
+   not behind a nav item, because spec §6.1 states the reasoning plainly: "saved rods sit
+   next to the place you pull them into, which is also where the mental model wants
+   them." Bring a rod back from the Quiver and the section you land in — Today's Setup —
+   is one scroll away, not a page away.
+4. **Today's Setup → Location & Conditions.** Second half of "what am I fishing with, and
+   where" (the page's own job statement in `10-setup.md`). It follows rods for the same
+   frequency reason: most returning anglers check their rod before they check the spot,
+   since the spot is often the same water they fished last time and the rod is the thing
+   more likely to have changed hands or gotten re-rigged.
+5. **Tackle Box** — a single link-out card at the bottom, not a full section. Restocking
+   gear is an at-home, off-trip errand, not a per-trip decision, and it is already reached
+   from Setup per spec §6.3 ("the Tackle Box is reached from Setup, not promoted to the
+   nav"). Bottom placement matches its lower frequency: you touch it when your gear
+   changes, not every time you go fishing.
+
+This keeps the two sections that repeat every trip (Rods, Location & Conditions) at the
+top in the order most anglers actually use them, puts the Quiver where the founder said
+the mental model wants it, and demotes the one section that is genuinely occasional
+(Tackle Box) to a single card at the end rather than competing for attention with the
+things done today.
+
+### 2.2 Section headers — exact copy
+
+| Order | Header (`h2`/`text-h3`) | Subheading / count line (unchanged pattern from current code) |
+|---|---|---|
+| 1 | Setup | *(unchanged intro paragraph)* |
+| 2 | Today's Setup | *(no separate label — "Rods" is implicit as the first subsection; see 2.3)* |
+| — | Rods | "None yet" / "N rigged" (existing copy, unchanged) |
+| 3 | Quiver | "Nothing saved yet" / "N saved" |
+| — | Location & Conditions | "None yet" / "N set up" *(renamed from "Today's locations" — see 2.4)* |
+| 4 | Tackle Box | *(link card, see 2.5)* |
+
+### 2.3 "Today's Setup" as a page-level grouping, not a redundant heading
+
+Rather than inserting a literal `<h2>Today's Setup</h2>` above `<h3>Rods</h3>`, which
+would put two headings back to back with nothing between them, "Today's Setup" is the
+name of the region of the page containing Rods and Location & Conditions — realized as a
+short intro line under the page's `h1`, not a second heading:
+
+> Setup
+> What you are fishing with and where, so logging a fish stays a couple of taps.
+
+This sentence already exists in the current `SetupPage` component (`setup-page.tsx`) and
+does not need to change — it already says "Today's Setup" in substance. Rods and
+Location & Conditions keep their own `h3`s exactly as today.
+
+### 2.4 One rename: "Today's locations" → "Location & Conditions"
+
+The current heading "Today's locations" undersells what the section stores (spec §11–§13:
+current, structure, water colour and clarity, bottom depth — not just a name), and it is
+also the destination for checklist step 4, which is explicitly about conditions, not
+location alone. Renaming it to **"Location & Conditions"** makes the checklist step 4
+destination self-evident when an angler lands on the page after tapping it. The "+ Add
+location" button keeps its existing label unchanged — adding a location is still the
+single action that opens the sheet where conditions also live.
+
+### 2.5 The Tackle Box link card — exact copy
+
+A small card at the bottom of Setup, not a full section with a list, since Setup does not
+own the Tackle Box's content:
+
+```
+┌───────────────────────────────────┐
+│ Tackle Box                        │
+│ Everything in your kit — rods,    │
+│ reels, line, hooks, and more.     │
+│                                    │
+│ [ Open Tackle Box ]               │
+└───────────────────────────────────┘
+```
+
+- Header: **"Tackle Box"** (`text-h3`)
+- Body: **"Everything in your kit — rods, reels, line, hooks, and more."** (`text-body`,
+  `text-text-muted`)
+- Button: **"Open Tackle Box"** (`SECONDARY_BUTTON`, links to `/tackle`) — secondary, not
+  primary, because Setup's one primary action is building today's rig, not shopping your
+  inventory.
+
+---
+
+## Part 3 — the Quiver
+
+`docs/architecture/decisions/008-quiver-identity-and-type-scoped-gear-options.md` landed
+while this document was being written and settles the identity question §7.1 of the spec
+left open: a Quiver entry is a **lineage**, grouped by a persistent `quiver_id` carried
+across every re-rig, retire, and bring-back. This section designs against that ruling,
+not around it. Two things from ADR 008 shape the screen directly:
+
+- `quiverEntries()` returns **every lineage the angler has ever created**, not only the
+  retired ones — each entry carries `in_todays_setup: boolean`.
+- `canBringBack(entry)` is false whenever the lineage's latest revision is still active.
+  A lineage currently rigged cannot be brought back a second time (that would put the
+  same rod in Today's Setup twice), so the Quiver must show *something* for it other than
+  the bring-back button, rather than hiding it and leaving an angler wondering where it
+  went.
+
+### 3.1 What a Quiver card shows
+
+One card per lineage (`QuiverEntry`), sorted most-recently-used first
+(`last_used_at`). Per spec §2, saved information includes rod, reel, line,
+leader, hooks, and bait configuration. Rather than reusing the terse, unlabelled
+`rodSummary()` string ("40 lb Fluoro · 6/0 Circle · Live bait") used on the active
+Today's Setup card — appropriate there because the angler already knows which rod they
+are looking at mid-trip — the Quiver shows **labelled rows**, because here the angler is
+scanning several saved setups to pick the right one, sometimes weeks after they built it:
+
+```
+┌───────────────────────────────────┐
+│ 40 lb Yo-Yo Stick                 │  title: the angler's own name, or
+│                                    │  see 3.2 if none was given
+│ Rod      Conventional             │  each row only appears if that
+│ Reel     Star drag, 30            │  gear role was set — omit blanks,
+│ Line     40 lb mono               │  never print "—" or "Not set"
+│ Leader   60 lb fluorocarbon       │
+│ Hooks    6/0 circle               │
+│ Bait     Live bait                │
+│                                    │
+│ [ Bring back to Today's Setup ]   │  one primary action, full width
+└───────────────────────────────────┘
+```
+
+- Row labels are exactly: **Rod, Reel, Line, Leader, Hooks, Bait** — plain words matching
+  the founder's own list in spec §2, not the internal `GearRole` keys (`main_line`,
+  `lure`/`jig`, `terminal`, `weight` collapse into or are omitted from this list; if a
+  setup also has a weight or terminal-tackle entry recorded, add it as a seventh row
+  labelled **Weight** or **Terminal tackle** only when present — never a blank row).
+- Rows with no value are omitted entirely, not shown as "—" or greyed out (a blank row a
+  70-year-old has to parse and dismiss is wasted attention).
+- **One primary action:** `PRIMARY_BUTTON`, full width of the card, reads **"Bring back
+  to Today's Setup"** — the exact destination named, matching spec §2's own phrase
+  ("From the Quiver, the user can add that rod back to Today's Setup"). No secondary
+  actions on this card (no rename, no delete) — the Quiver is a save point, not an
+  inventory manager, and adding a second button here would break the one-primary-action
+  rule for no benefit an angler on a boat needs.
+- Tapping the button is instant, no confirmation screen — it is purely additive (a new
+  active rod appears in Today's Setup; nothing is removed or overwritten), so there is
+  nothing to protect against. A toast confirms where it went and offers the one
+  correction an angler might want:
+
+  > **Back in Today's Setup.** `Undo`
+
+  Tapping `Undo` puts it straight back in the Quiver — symmetric with 3.3 below, and
+  cheaper than a confirmation dialog nobody reads.
+
+**When `in_todays_setup` is true** (`canBringBack(entry)` is false), the card shows the
+same rod/reel/line/leader/hooks/bait rows, but the primary-button slot is replaced with a
+plain status line instead of a disabled-looking button — a greyed-out button an angler
+pokes at twice in the sun is worse than no button:
+
+```
+┌───────────────────────────────────┐
+│ 40 lb Yo-Yo Stick                 │
+│ Rod      Conventional             │
+│ Reel     Star drag, 30            │
+│ Line     40 lb mono               │
+│ Leader   60 lb fluorocarbon       │
+│ Hooks    6/0 circle               │
+│ Bait     Live bait                │
+│                                    │
+│ Already in Today's Setup          │  text-body, text-text-muted, no button
+└───────────────────────────────────┘
+```
+
+Text: **"Already in Today's Setup."** No action needed here — put it away from Today's
+Setup first (2.1) if it needs to come back later for a different slot.
+
+### 3.2 The title
+
+ADR 008 rules that the Quiver never falls back to `Rod {slot}` — a slot number from a
+trip three weeks ago is meaningless in a saved collection, and `rodSetupLabel()`'s
+existing `Rod {slot}` fallback stays exactly as-is, but only for Today's Setup, where the
+slot is the thing on screen. `QuiverEntry.label` is the ADR's own field, already resolved
+by core before it reaches the component, so this design does not need to compute a
+fallback — only specify what it should read when a lineage has no angler-given name:
+
+**Named lineage:** the angler's own name, unchanged, e.g. "40 lb Yo-Yo Stick".
+
+**Unnamed lineage:** built from `setup_type` and the rod/reel gear rows, short and
+joined, e.g. **"Conventional · Star drag, 30"** — enough to tell two unnamed rods apart
+in a scanning list, without inventing an identity `quiver_id` doesn't already give it.
+
+### 3.3 Put Away — corrected copy
+
+Spec §2 is explicit: putting a rod away must not imply deletion, because it never
+deletes. Today's `setup-page.tsx` already does the right *thing* (`retireRodSetup` writes
+a new revision, nothing is destroyed) but says nothing to the angler about it — a plain
+"Put away" button with no follow-up reads as final, even though it is not.
+
+**No confirmation dialog is added.** Per the house rule (undo over "are you sure"), and
+because this action is reversible in one tap, a blocking dialog would tax every angler to
+guard against a mistake that costs nothing to reverse. Instead:
+
+- **Button copy stays "Put away"** on the Today's Setup rod card (`SECONDARY_BUTTON`) —
+  it is already short, plain, and accurate; the fix is not the button, it is the
+  follow-up.
+- **A toast appears immediately after the tap:**
+
+  > **Put away — saved in your Quiver.** `Undo`
+
+  This is the corrected copy the spec asks for: it names where the rod went (answering
+  "did I just lose this?") in the same breath as confirming the action happened, and
+  `Undo` reverses it in one tap (re-activates the same rod in Today's Setup) for the rare
+  case of a mis-tap — cheaper and faster than a dialog that would have appeared on every
+  single put-away, including the 99% that were intentional.
+- The existing caption on a re-rigged rod — "Version 2 — earlier fish keep the setup they
+  were caught on" — is unrelated to Put Away and is correct as-is; it is not changed by
+  this document.
+
+### 3.4 Quiver empty state — exact copy
+
+Before any rod has ever been put away:
+
+```
+┌───────────────────────────────────┐
+│ Quiver                            │
+│                                    │
+│ Nothing saved yet. Put a rod away │
+│ from Today's Setup and it lands   │
+│ here, ready to bring back next    │
+│ trip — nothing you build today    │
+│ has to be rebuilt tomorrow.       │
+└───────────────────────────────────┘
+```
+
+- Header: **"Quiver"**, count line reads **"Nothing saved yet"** (matches the existing
+  "None yet" pattern's tone for Rods/Locations, adapted to the Quiver's own verb).
+- Body copy: **"Nothing saved yet. Put a rod away from Today's Setup and it lands here,
+  ready to bring back next trip — nothing you build today has to be rebuilt tomorrow."**
+  This both explains what the Quiver is for and tells the angler exactly which button on
+  the page above fills it, matching the house rule that an empty state teaches rather
+  than just states absence.
+- No button on the empty card itself — the action that would fill it ("Put away") lives
+  on the Rods cards above, and duplicating it here would be a second way to do the same
+  thing on the same page, which is not needed.
+
+---
+
+## Open items this document raises but does not close
+
+1. **Deep-linking a checklist row to a specific field inside `/setup`.** This document
+   specifies destinations at the page/section level (e.g. "the Location & Conditions
+   section"), not a query-param or anchor scheme that auto-opens the `LocationSheet` on
+   arrival. An anchor (`/setup#location`) that scrolls to the section header is a
+   reasonable, low-risk enhancement head-dev can add without a client-side sheet-opening
+   hook on page load, but it is not required to satisfy spec §1 ("tapping a step should
+   take the user directly to the corresponding page") — landing on the right section with
+   its existing "+ Add" button one tap away already does that.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -12,6 +12,7 @@ files rather than silently resolved.
 | Spec | Status | What it covers |
 |---|---|---|
 | [fishing-passport-wildlife-boat-games.md](fishing-passport-wildlife-boat-games.md) | **Proposed** — planning only, nothing built | Fishing Passport / My Species, badges and verification levels, marine wildlife sightings, reusable Fin ID, private Boat Games. Phase 1 = Passport + starter badges. **Read §44–§47 first** — repo reality check, three blocked items, and the sequencing recommendation. |
+| [setup-flow-and-quiver.md](setup-flow-and-quiver.md) | **Proposed** — awaiting architect + UX rulings | Guided five-step setup workflow, the Quiver (saved rod setups), reel sizes by reel type, Fish Legal region emphasis. **Read §5 first** — the repository reality check, including that the boundaries page shows a *Florida* map to every non-California region. |
 | [tackle-box.md](tackle-box.md) | MVP / ready for implementation | Personal tackle inventory: two-level item model, search, and gear snapshots on a catch. |
 | [fish-legal-expansion.md](fish-legal-expansion.md) | Shipped (Phases 1–3, PR #24) | Region-aware rules and regulations surface: packs, verdicts, citation-or-nothing. |
 | [regulations-architecture.md](regulations-architecture.md) | Proposed architecture | How regulation data is packaged, versioned, and served offline. |

--- a/docs/specs/setup-flow-and-quiver.md
+++ b/docs/specs/setup-flow-and-quiver.md
@@ -1,0 +1,217 @@
+# Guided setup, the Quiver, reel sizes, and region honesty
+
+**Status:** Proposed — founder-supplied, awaiting architect and UX rulings
+**Date:** 2026-09-04
+**Governs:** `/setup`, `/tackle`, navigation and information architecture, reel vocabulary,
+Fish Legal home and the boundaries page
+**Document:** `docs/specs/setup-flow-and-quiver.md`
+
+> Founder-supplied, 2026-09-04, after using the application enough to know where it does
+> not read the way it works. Sections 1–4 and the completion checks are the founder's
+> words, kept intact. Section 5 is what the code actually does today, written by
+> `head-dev` before any work started, because two of the four asks rest on assumptions
+> the repository does not support.
+
+The founder also directed, same day: **the log stays on-device for now.** Database sync
+comes later, once the offline path has been proven in real use. Nothing in this spec
+should introduce a server round trip.
+
+---
+
+## Founder brief
+
+> Now that I'm more familiar with the application, I've identified several small changes
+> that would make the setup and catch-logging experience easier to understand. So ask the
+> architect and the UI/UX designers, if we have to re-organize the pages and how the
+> navigation is set up, let's do so — everything just makes sense and everything's on the
+> right page in the right order and everything flows so that any user could pick this up.
+
+### 1. Guided setup workflow
+
+The ideal workflow appears to be:
+
+1. Set or select a fishing location.
+2. Add gear to the Tackle Box.
+3. Build or select a fishing rod setup.
+4. Add the current fishing-location conditions.
+5. Log a fish.
+
+Please organize the Settings or Setup area around this sequence. Display it as a clearly
+ordered checklist or stepper so users understand what they should complete next. On
+mobile, it should remain readable without horizontal overflow.
+
+Each completed step should display a simple completed state, and tapping a step should
+take the user directly to the corresponding page.
+
+### 2. Add a Rod Quiver page
+
+Create a page called **Quiver**, using the surfing term for a saved collection of
+surfboards. In this application, the Quiver will contain the user's saved fishing rods and
+complete rod setups.
+
+Update the current **Put Away** behavior:
+
+- Putting away a rod must remove it from Today's Setup.
+- It must not delete the rod or make it disappear permanently.
+- The complete setup should remain saved in the user's Quiver.
+- From the Quiver, the user can add that rod back to Today's Setup for another trip.
+- Saved information should include the rod, reel, line, leader, hooks, bait configuration,
+  and other existing setup details.
+
+The goal is to let anglers reuse their normal rod setups without rebuilding them before
+every trip.
+
+### 3. Correct reel-size options
+
+The current reel-size values appear too large or too broad because spinning reels and
+conventional reels use different numbering systems.
+
+Please make the available reel sizes depend on the selected reel type:
+
+- Spinning reels should use the appropriate larger numbering format.
+- Conventional reels should use their appropriate size format.
+- Other reel types should receive relevant options where applicable.
+- Include a custom value when the user's reel does not match a preset.
+
+The architect should confirm whether these values belong in the shared gear vocabulary or
+in reel-type-specific option sets.
+
+### 4. Fish Legal region emphasis
+
+On the Fish Legal home page:
+
+- Highlight the selected region and the Change action using the application's orange
+  accent color.
+- Make it immediately obvious which jurisdiction's regulations the user is viewing.
+- Rename **Depth & Boundaries** to **California Depth & Boundaries** if that information
+  currently applies only to California.
+- When a non-California region is selected, do not imply that California-specific depth
+  and boundary information applies there. Hide the option or replace it with an honest
+  unavailable state until that region has equivalent data.
+
+### Completion checks
+
+- The five-step workflow is clear on a phone.
+- Every workflow step links to the correct destination.
+- Put Away preserves the rod in the Quiver.
+- A saved Quiver rod can be returned to Today's Setup without being rebuilt.
+- Reel sizes change appropriately based on reel type.
+- Fish Legal clearly displays the active jurisdiction.
+- California-only boundary information is never presented as universal.
+- Existing saved rods, catches, settings, and Fish Legal data continue to work.
+
+---
+
+## 5. Repository reality check
+
+Written before implementation so the architect and UX rule on facts rather than
+assumptions. Four findings, two of which change what the founder asked for.
+
+### 5.1 The Quiver is mostly a view, not a migration — §2 is cheaper than it looks
+
+`Put away` already calls `retireRodSetup`, which writes a new revision with `retired_at`
+set. **The setup is not deleted today.** `core/rules/catch/rules.ts` is explicit about
+why: retiring writes revision *n+1* rather than mutating, so a fish caught on revision 1
+keeps the rod it was actually caught on.
+
+So the Quiver needs no schema change and no data migration. It needs:
+
+- a view over retired rigs (grouped so the *setup* appears once, not once per revision),
+- a "bring back to Today's Setup" action, which is a new revision with `retired_at: null`
+  and a fresh slot (`nextRodSlot` never reuses a slot, including retired ones),
+- and copy that stops implying `Put away` is destructive.
+
+**Ruling needed:** a rod put away and brought back three times accumulates revisions. The
+Quiver must group by setup identity, and the architect should say what that identity is —
+`rules.ts` currently treats a slot as the identity of a rod within a trip, which is not
+the same thing as "my 40-lb yo-yo stick".
+
+### 5.2 The reel size list is exactly the bug described — one flat list of two systems
+
+`src/features/tackle/types.ts`, the `reels` category:
+
+```ts
+{ key: "type",  options: ["Conventional", "Spinning", "Baitcasting", "Lever drag", "Star drag"] },
+{ key: "size",  options: ["500","1000","2500","3000","4000","5000","6000","8000","12","16","20","30"] },
+```
+
+Spinning sizes and conventional sizes are offered in the same chip row regardless of the
+type chosen, which is why the values read as "too large or too broad". The founder's
+diagnosis is correct and the fix is a dependent option set keyed on `type`.
+
+**Ruling needed** (the founder asked for it explicitly): shared vocabulary or type-scoped
+option sets. `head-dev`'s recommendation is type-scoped — the field schema already exists
+per category, so this is a `optionsBy` variant on one field rather than a new vocabulary
+concept, and a shared list cannot express "4000 is meaningless on a lever drag".
+
+### 5.3 Depth & boundaries is NOT California-only — it is worse than that
+
+The founder's §4 assumed the page is California-specific. It is not. Reading
+`boundary-map.tsx`:
+
+- Southern California and the five `ca_gma_*` regions render the SoCal bundle with the
+  50-fathom RCA ribbon.
+- Northern California and its GMA regions render the NorCal bundle.
+- **Every other region falls back to a Florida overview.**
+
+So a Washington or Texas angler opening "Depth & boundary rules" today is shown a
+**Florida** map, centred on the Indian River Lagoon. That is not a California-specific
+page leaking into other states — it is a Florida page leaking into every state that is
+not California.
+
+Renaming the card to "California Depth & Boundaries" would therefore be *inaccurate*, and
+would also hide the real defect. The honest fixes are:
+
+- name the card for the region actually being rendered, and
+- for a region with no verified boundary data, do what §4's second half asks — hide it, or
+  state plainly that there is no verified boundary data for that region — rather than
+  silently substituting another state's coastline.
+
+This is a correctness issue in the same family as the two contradictory bag limits fixed
+on 2026-09-04, and it should be treated with the same priority.
+
+### 5.4 The navigation bar is full, and a seventh destination is a founder decision
+
+`shell-nav.tsx` carries six destinations — Calendar, Setup, Log, Tide, Legal, Settings —
+and `shell-nav.test.ts` pins the count with a comment saying a seventh "still needs a
+decision, not a patch". Below 384px the bar already wraps to two rows of three.
+
+The founder has now opened that decision by asking for the pages and navigation to be
+reorganised. It cannot be resolved inside a component: it is an information-architecture
+ruling, and it interacts with §1 (where the guided checklist lives) and §2 (where the
+Quiver lives).
+
+**This is the ruling the architect and `ux-ui` owe before implementation starts.**
+
+---
+
+## 6. Information architecture — decided
+
+Founder, 2026-09-04, answering the three questions §5 raised. These are settled; the
+architect and `ux-ui` design *within* them, not around them.
+
+1. **The Quiver lives inside Setup, as a section.** Setup becomes "Today's Setup" plus
+   "Quiver". **The nav bar stays at six** — `shell-nav.test.ts` keeps its pin, and the
+   seventh-destination decision stays unspent. Saved rods sit next to the place you pull
+   them into, which is also where the mental model wants them.
+2. **The guided checklist lives on the Calendar home page**, above the calendar. It is the
+   first screen on launch, so a new angler meets the order of operations without having to
+   find anything first. It must collapse to a single line once all five steps are done —
+   a checklist that keeps nagging an experienced user is a checklist they learn to ignore.
+3. **The Tackle Box is reached from Setup**, not promoted to the nav. Setup becomes the hub
+   for everything you do before fishing — location, tackle, rods, conditions — and Settings
+   goes back to being only settings.
+
+The through-line: **Setup is trip preparation, home is what to do next, Settings is
+preferences.** Anything that does not fit one of those three sentences is in the wrong
+place.
+
+## 7. Still owed by the architect
+
+Both were raised in §5 and neither is a founder call.
+
+1. **Quiver setup identity** (§5.1). A rod put away and brought back accumulates revisions.
+   What identity does the Quiver group by, given that `rules.ts` treats a slot as a rod's
+   identity *within a trip*, which is not "my 40-lb yo-yo stick"?
+2. **Reel size option shape** (§5.2). Shared gear vocabulary, or type-scoped option sets?
+   `head-dev` recommends type-scoped.

--- a/docs/team/worklog/2026-09-04-09-head-dev.md
+++ b/docs/team/worklog/2026-09-04-09-head-dev.md
@@ -1,0 +1,51 @@
+### 2026-09-04 | head-dev | 4h
+
+- Finished the founder's UX brief: the five-step guided checklist (§1) and the Quiver (§2).
+  §3 reel sizes and §4 Fish Legal landed earlier the same day.
+- The Quiver needed no schema change and no new concept. `Put away` already wrote a
+  retired revision rather than deleting, so the setups were all still there — what was
+  missing was anywhere to see them, a way to fish one again, and a word to the angler
+  saying where the rod had gone. That last one is why it read as destructive.
+- `quiver_id` (ADR 008) is what makes two revisions the same rod. Slot could not do it —
+  `nextRodSlot` scopes slots to a trip, so Rod 1 in June and Rod 1 in July are unrelated
+  — and neither could name or gear, which change every time you re-rig.
+- Grouping, "which revision is latest", "is this rod already out" and "what does the next
+  revision look like" are all in `core/rules/catch/quiver.ts`. None of it is in a
+  component. Grouping inside a `useMemo` looks harmless and is exactly what ADR 003
+  exists to stop, because the Swift client cannot see a `useMemo`.
+- Re-rigging passes the existing lineage through, or every leader change would have
+  created a second Quiver entry for the same rod.
+- The checklist is the interesting design problem, and the UX doc got it right: **a step
+  is a memory that something was done once, not a readout of today.** Steps 1 and 4 are
+  per-trip data. If the card asked "is there a location on THIS trip" it would reset every
+  outing for somebody who has fished for a decade, which is the nagging failure the
+  founder named.
+- **I was wrong in what I told the founder about this.** I said deriving from live data
+  would be self-correcting where a stored flag could drift. Deriving gives you "do you
+  have tackle now", not "have you ever added tackle", and those differ in exactly the case
+  that matters: an angler who clears out their box should not be marched back through the
+  tutorial. So it latches — derive, then union with what the device remembers, one-way.
+  Corrected to the founder in the same message as the result.
+- Vectors for `setup-progress.ts` (the tripwire caught the missing file immediately),
+  including the two latch cases, which are the ones a second client would get wrong.
+- **A defect in my own feature, caught by driving it rather than by a test.** The Tackle
+  Box ships pre-seeded with twelve sample items so the category form and low-stock states
+  are visible on first load. So step 2 rendered as *Done* for somebody who had never
+  opened it. A checklist that ticks a box you did not tick teaches you not to trust the
+  other four. Sample items are now excluded by `isFixtureItem`, and a fresh profile
+  correctly starts with nothing done.
+- Setup is now the trip-preparation hub in the order the design gave: Today's rods →
+  Quiver → Location & Conditions → Tackle Box. "Today's locations" became "Location &
+  Conditions" because steps 1 and 4 are the same sheet, and the old name only named half
+  of what it does.
+- Put away keeps its name — the button was never the problem — and now says "Put away —
+  saved in your Quiver." No confirmation dialog: the house rule prefers undo, and taxing
+  every angler to guard against a one-tap mistake is the wrong trade.
+- Checks: tripwires clean, 0 lint errors (8 pre-existing warnings), tsc clean, 692 tests,
+  production build green. Drove the whole loop in Chromium at 320px — build a rod, put it
+  away, watch it land in the Quiver, bring it back, confirm the latch survives a reload —
+  plus the collapsed state at 82px high and a junk value in storage.
+- Files: src/core/rules/catch/quiver.ts + test, src/core/rules/setup-progress.ts + test +
+  vectors, src/core/rules/catch/types.ts, src/features/setup/checklist-latch.ts,
+  src/features/setup/components/{setup-checklist,quiver-section,setup-page,rod-setup-sheet}.tsx,
+  src/features/catches/store.ts, src/features/tackle/tackle-fixture.ts, src/app/(app)/page.tsx.

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { MonthCalendar } from "@/features/calendar/components/month-calendar";
 import { PassportHomeCard } from "@/features/passport/components/passport-home-card";
 import { PASSPORT_V1 } from "@/features/passport/flag";
+import { SetupChecklist } from "@/features/setup/components/setup-checklist";
 
 export const metadata: Metadata = { title: "Calendar | Fish Log Book" };
 
@@ -20,6 +21,13 @@ export const metadata: Metadata = { title: "Calendar | Fish Log Book" };
 export default function CalendarPage() {
   return (
     <div className="flex flex-col gap-4">
+      {/*
+        Above the calendar, and the only thing that outranks it, because it is the one
+        card that stops mattering. A new angler meets the order of operations on the first
+        screen they see; the moment all five are done it collapses to a single line and
+        never expands again (founder ruling, spec §6.2).
+      */}
+      <SetupChecklist />
       <MonthCalendar />
       <Link
         href="/tides"

--- a/src/core/rules/catch/quiver.test.ts
+++ b/src/core/rules/catch/quiver.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+
+import { broughtBackRevision, canBringBack, quiverEntries, quiverKeyOf } from "./quiver";
+import type { RigRecord } from "./types";
+
+const T1 = "2026-06-01T16:00:00.000Z";
+const T2 = "2026-07-01T16:00:00.000Z";
+const T3 = "2026-08-01T16:00:00.000Z";
+
+function rig(overrides: Partial<RigRecord> = {}): RigRecord {
+  return {
+    id: "r1",
+    angler_id: "a1",
+    trip_id: "t1",
+    slot: 1,
+    name: null,
+    setup_type: "flyline",
+    revision: 1,
+    effective_from: T1,
+    spot_id: null,
+    platform: null,
+    depth_fished_m: null,
+    live_bait: false,
+    gear: [],
+    created_at: T1,
+    retired_at: null,
+    ...overrides,
+  };
+}
+
+describe("quiverKeyOf", () => {
+  it("uses the lineage id when there is one", () => {
+    expect(quiverKeyOf(rig({ quiver_id: "q1" }))).toBe("q1");
+  });
+
+  it("falls back to trip and slot for a row that predates the field", () => {
+    // Core must stay total for a row arriving from a sync path without the column.
+    expect(quiverKeyOf(rig({ trip_id: "t9", slot: 3 }))).toBe("t9:3");
+    expect(quiverKeyOf(rig({ quiver_id: "" }))).toBe("t1:1");
+  });
+});
+
+describe("quiverEntries", () => {
+  it("shows a rod put away and brought back three times exactly once", () => {
+    // The whole point of the lineage id. Six rows, one rod.
+    const rigs = [
+      rig({ id: "a", quiver_id: "q1", revision: 1, trip_id: "t1", effective_from: T1 }),
+      rig({ id: "b", quiver_id: "q1", revision: 2, trip_id: "t1", retired_at: T1 }),
+      rig({ id: "c", quiver_id: "q1", revision: 3, trip_id: "t2", effective_from: T2 }),
+      rig({ id: "d", quiver_id: "q1", revision: 4, trip_id: "t2", retired_at: T2 }),
+      rig({ id: "e", quiver_id: "q1", revision: 5, trip_id: "t3", effective_from: T3 }),
+      rig({ id: "f", quiver_id: "q1", revision: 6, trip_id: "t3", retired_at: T3 }),
+    ];
+    const entries = quiverEntries(rigs, "t4");
+    expect(entries).toHaveLength(1);
+    expect(entries[0].latest.id).toBe("f");
+  });
+
+  it("keeps one lineage across two trips as one entry", () => {
+    const entries = quiverEntries(
+      [
+        rig({ id: "a", quiver_id: "q1", trip_id: "t1", revision: 1 }),
+        rig({ id: "b", quiver_id: "q1", trip_id: "t2", revision: 2 }),
+      ],
+      "t3",
+    );
+    expect(entries).toHaveLength(1);
+  });
+
+  it("does not merge two unnamed rods from different trips", () => {
+    // They look identical. They are not the same rod, and nothing in the data says so.
+    const entries = quiverEntries(
+      [
+        rig({ id: "a", quiver_id: "q1", trip_id: "t1", name: null }),
+        rig({ id: "b", quiver_id: "q2", trip_id: "t2", name: null }),
+      ],
+      "t3",
+    );
+    expect(entries).toHaveLength(2);
+  });
+
+  it("groups a legacy row with no lineage id by trip and slot", () => {
+    const entries = quiverEntries(
+      [
+        rig({ id: "a", trip_id: "t1", slot: 1, revision: 1 }),
+        rig({ id: "b", trip_id: "t1", slot: 1, revision: 2 }),
+        rig({ id: "c", trip_id: "t1", slot: 2, revision: 1 }),
+      ],
+      "t2",
+    );
+    expect(entries).toHaveLength(2);
+  });
+
+  it("takes the newest revision even when it is the retired one", () => {
+    // Filtering retired rows first and then taking the newest resurrects a rod that was
+    // put away — the trap activeRodSetups documents.
+    const entries = quiverEntries(
+      [
+        rig({ id: "a", quiver_id: "q1", revision: 1, retired_at: null }),
+        rig({ id: "b", quiver_id: "q1", revision: 2, retired_at: T2 }),
+      ],
+      "t2",
+    );
+    expect(entries[0].latest.id).toBe("b");
+    expect(entries[0].latest.retired_at).toBe(T2);
+  });
+
+  it("sorts most recently used first", () => {
+    const entries = quiverEntries(
+      [
+        rig({ id: "old", quiver_id: "q1", effective_from: T1 }),
+        rig({ id: "new", quiver_id: "q2", effective_from: T3 }),
+        rig({ id: "mid", quiver_id: "q3", effective_from: T2 }),
+      ],
+      "t9",
+    );
+    expect(entries.map((e) => e.latest.id)).toEqual(["new", "mid", "old"]);
+  });
+
+  it("names an unnamed lineage from the setup, never 'Rod {slot}'", () => {
+    const [entry] = quiverEntries(
+      [
+        rig({
+          quiver_id: "q1",
+          name: null,
+          slot: 4,
+          setup_type: "yo_yo",
+          gear: [
+            { angler_id: "a1", tackle_item_id: null, role: "reel", label: "Star drag", detail: "30" },
+          ],
+        }),
+      ],
+      "t2",
+    );
+    expect(entry.label).toBe("yo_yo · Star drag, 30");
+    expect(entry.label).not.toContain("Rod 4");
+  });
+
+  it("prefers the angler's own name", () => {
+    const [entry] = quiverEntries([rig({ quiver_id: "q1", name: "40 lb Yo-Yo Stick" })], "t2");
+    expect(entry.label).toBe("40 lb Yo-Yo Stick");
+  });
+});
+
+describe("canBringBack", () => {
+  it("is false while the rod is already on today's boat", () => {
+    const rigs = [rig({ id: "a", quiver_id: "q1", trip_id: "today", retired_at: null })];
+    const [entry] = quiverEntries(rigs, "today");
+    expect(entry.in_todays_setup).toBe(true);
+    expect(canBringBack(entry)).toBe(false);
+  });
+
+  it("is true once it has been put away", () => {
+    const rigs = [
+      rig({ id: "a", quiver_id: "q1", trip_id: "today", revision: 1 }),
+      rig({ id: "b", quiver_id: "q1", trip_id: "today", revision: 2, retired_at: T2 }),
+    ];
+    const [entry] = quiverEntries(rigs, "today");
+    expect(canBringBack(entry)).toBe(true);
+  });
+});
+
+describe("broughtBackRevision", () => {
+  const latest = rig({
+    id: "old",
+    quiver_id: "q1",
+    trip_id: "t1",
+    slot: 2,
+    revision: 4,
+    retired_at: T2,
+    name: "40 lb Yo-Yo Stick",
+    live_bait: true,
+    gear: [{ angler_id: "a1", tackle_item_id: null, role: "hook", label: "6/0 circle", detail: null }],
+  });
+
+  it("carries the whole setup forward so nothing is rebuilt", () => {
+    const next = broughtBackRevision(latest, { id: "new", tripId: "t5", slot: 1, nowIso: T3 });
+    expect(next.name).toBe("40 lb Yo-Yo Stick");
+    expect(next.gear).toEqual(latest.gear);
+    expect(next.live_bait).toBe(true);
+    expect(next.quiver_id).toBe("q1");
+  });
+
+  it("lands on today's trip, in a fresh slot, not retired", () => {
+    const next = broughtBackRevision(latest, { id: "new", tripId: "t5", slot: 1, nowIso: T3 });
+    expect(next.id).toBe("new");
+    expect(next.trip_id).toBe("t5");
+    expect(next.slot).toBe(1);
+    expect(next.revision).toBe(5);
+    expect(next.retired_at).toBeNull();
+    expect(next.effective_from).toBe(T3);
+  });
+
+  it("leaves the revision it came from untouched", () => {
+    // A fish logged against revision 4 must keep saying the rod was put away then.
+    broughtBackRevision(latest, { id: "new", tripId: "t5", slot: 1, nowIso: T3 });
+    expect(latest.retired_at).toBe(T2);
+    expect(latest.revision).toBe(4);
+  });
+
+  it("adopts the fallback key for a legacy row, so the lineage exists from now on", () => {
+    const legacy = rig({ id: "old", trip_id: "t7", slot: 3, revision: 1 });
+    const next = broughtBackRevision(legacy, { id: "new", tripId: "t8", slot: 1, nowIso: T3 });
+    expect(next.quiver_id).toBe("t7:3");
+  });
+});

--- a/src/core/rules/catch/quiver.ts
+++ b/src/core/rules/catch/quiver.ts
@@ -1,0 +1,144 @@
+import { activeRodSetups, nextRodSlot } from "./rules";
+import type { RigRecord } from "./types";
+
+/**
+ * The Quiver: every rod setup the angler has ever built, one entry per rod (ADR 008).
+ *
+ * `Put away` has never deleted anything — `retireRodSetup` writes revision n+1 with
+ * `retired_at` set, so a fish caught on revision 1 keeps the rod it was actually caught
+ * on. What was missing was a way to see those setups again and fish them next trip, and
+ * a way to say which revisions are the *same rod*.
+ *
+ * That is `quiver_id`. Everything here is grouping and arithmetic over it, kept in core
+ * so the component never does revision maths — the rule ADR 003 exists for, and the one
+ * this feature is most likely to break, because grouping inside a `useMemo` looks
+ * harmless right up until the Swift client has to reproduce it.
+ *
+ * Nothing here mints an id or reads a clock. The caller supplies both, exactly as
+ * `repeatSeedFrom` refuses to.
+ */
+
+export interface QuiverEntry {
+  readonly quiver_id: string;
+  /** Highest revision in the lineage — the rod as it was last built. */
+  readonly latest: RigRecord;
+  /** Already fishing on the current trip, so there is nothing to bring back. */
+  readonly in_todays_setup: boolean;
+  readonly last_used_at: string;
+  /** The angler's own name, or something built from the setup. Never "Rod {slot}". */
+  readonly label: string;
+}
+
+/**
+ * Which lineage a row belongs to.
+ *
+ * Falls back to trip-and-slot for a row that predates `quiver_id` or arrives from a sync
+ * path whose column does not exist yet. After the v3 migration no local row lacks it,
+ * but core must stay total rather than trusting that.
+ */
+export function quiverKeyOf(rig: RigRecord): string {
+  return rig.quiver_id && rig.quiver_id.length > 0
+    ? rig.quiver_id
+    : `${rig.trip_id}:${rig.slot}`;
+}
+
+/** Gear roles that make up a rod's identity, in the order the Quiver card reads them. */
+const LABEL_ROLES = ["rod", "reel"] as const;
+
+/**
+ * A name for a lineage the angler never named.
+ *
+ * Deliberately NOT `rodSetupLabel`'s "Rod {slot}" fallback: a slot number from a trip
+ * three weeks ago means nothing in a saved collection, and two unnamed rods would both
+ * read "Rod 1". Built from the setup instead, which is what tells them apart.
+ */
+function labelFor(latest: RigRecord): string {
+  if (latest.name && latest.name.trim().length > 0) return latest.name;
+
+  const parts: string[] = [];
+  if (latest.setup_type) parts.push(latest.setup_type);
+  for (const role of LABEL_ROLES) {
+    const item = latest.gear.find((g) => g.role === role);
+    if (item) parts.push(item.detail ? `${item.label}, ${item.detail}` : item.label);
+  }
+  return parts.length > 0 ? parts.join(" · ") : "Saved rod";
+}
+
+/**
+ * Every lineage, most recently used first.
+ *
+ * `tripId` is today's trip, and decides `in_todays_setup` — a rod already being fished
+ * cannot be brought back, and the card says so rather than offering a button that would
+ * put the same rod on the boat twice.
+ */
+export function quiverEntries(
+  rigs: readonly RigRecord[],
+  tripId: string,
+): readonly QuiverEntry[] {
+  const lineages = new Map<string, RigRecord[]>();
+  for (const rig of rigs) {
+    const key = quiverKeyOf(rig);
+    const existing = lineages.get(key);
+    if (existing) existing.push(rig);
+    else lineages.set(key, [rig]);
+  }
+
+  const activeIds = new Set(activeRodSetups(rigs, tripId).map((rig) => rig.id));
+
+  const entries: QuiverEntry[] = [];
+  for (const [quiverId, revisions] of lineages) {
+    // Highest revision wins. Retired rows are NOT filtered out first: retiring writes the
+    // newest revision, so dropping retired rows and taking the newest of what is left
+    // would resurrect a rod that had been put away — the same trap `activeRodSetups`
+    // documents.
+    const latest = revisions.reduce((a, b) => (b.revision > a.revision ? b : a));
+    entries.push({
+      quiver_id: quiverId,
+      latest,
+      in_todays_setup: revisions.some((rig) => activeIds.has(rig.id)),
+      last_used_at: latest.effective_from,
+      label: labelFor(latest),
+    });
+  }
+
+  return entries.sort((a, b) => b.last_used_at.localeCompare(a.last_used_at));
+}
+
+/**
+ * Whether bringing this lineage back is legal.
+ *
+ * False while the rod is already on today's boat. Without this guard the same rod
+ * renders twice in Today's Setup, in two slots, and a catch could be attributed to
+ * either.
+ */
+export function canBringBack(entry: QuiverEntry): boolean {
+  return !entry.in_todays_setup;
+}
+
+/**
+ * The revision that puts a saved rod back on today's boat.
+ *
+ * Revision n+1 of the same lineage, on today's trip, in a fresh slot, not retired. The
+ * previous revision is left exactly as it was: `retired_at` is never cleared, because the
+ * rod really was put away then, and a fish logged against that revision must keep saying
+ * so.
+ */
+export function broughtBackRevision(
+  latest: RigRecord,
+  input: { id: string; tripId: string; slot: number; nowIso: string },
+): RigRecord {
+  return {
+    ...latest,
+    id: input.id,
+    trip_id: input.tripId,
+    slot: input.slot,
+    quiver_id: quiverKeyOf(latest),
+    revision: latest.revision + 1,
+    effective_from: input.nowIso,
+    created_at: input.nowIso,
+    retired_at: null,
+  };
+}
+
+/** The slot a brought-back rod takes on today's trip. Re-exported so callers need one import. */
+export { nextRodSlot };

--- a/src/core/rules/catch/types.ts
+++ b/src/core/rules/catch/types.ts
@@ -170,6 +170,17 @@ export interface RigRecord {
   readonly trip_id: string;
   /** Rod 1, Rod 2, … Stable for the life of the trip; revisions accrue within a slot. */
   readonly slot: number;
+  /**
+   * The lineage this rod belongs to — "my 40-lb yo-yo stick", across every trip it has
+   * ever been fished on (ADR 008). Minted once at first creation and copied forward by
+   * every revision, including retiring and bringing back.
+   *
+   * `slot` cannot do this job: `nextRodSlot` scopes it to a trip, so Rod 1 in June and
+   * Rod 1 in July are unrelated. Name cannot either — renaming would fork the lineage
+   * and two unnamed rods would merge. Optional because a row can arrive from a sync
+   * path older than this field; `quiverKeyOf` stays total when it does.
+   */
+  readonly quiver_id?: string;
   /** The angler's own name for it — "40 lb Flyline". Falls back to "Rod {slot}". */
   readonly name: string | null;
   readonly setup_type: SetupType | null;

--- a/src/core/rules/setup-progress.test.ts
+++ b/src/core/rules/setup-progress.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+
+import vectors from "./vectors/setup-progress.json";
+import {
+  SETUP_STEPS,
+  allStepsDone,
+  observedSteps,
+  setupSteps,
+  stepsToLatch,
+  type SetupStepId,
+} from "./setup-progress";
+import type { CatchRecord, LocationConditionRecord, RigRecord } from "./catch/types";
+
+const NOW = "2026-09-04T16:00:00.000Z";
+
+interface VectorLocation {
+  named?: boolean;
+  deleted?: boolean;
+  current_term?: string;
+  current_strength?: string;
+  structure_type_ids?: string[];
+  bottom_depth_m?: number;
+  water_color_id?: string;
+  water_clarity_id?: string;
+}
+
+function location(spec: VectorLocation, index: number): LocationConditionRecord {
+  return {
+    id: `l${index}`,
+    angler_id: "a1",
+    trip_id: "t1",
+    name: spec.named ? `Spot ${index}` : "",
+    current_term: (spec.current_term as LocationConditionRecord["current_term"]) ?? null,
+    current_strength: (spec.current_strength as LocationConditionRecord["current_strength"]) ?? null,
+    structure_type_ids: spec.structure_type_ids ?? [],
+    bottom_depth_m: spec.bottom_depth_m ?? null,
+    water_color_id: spec.water_color_id ?? null,
+    water_clarity_id: spec.water_clarity_id ?? null,
+    spot_id: null,
+    notes: null,
+    created_at: NOW,
+    client_updated_at: NOW,
+    deleted_at: spec.deleted ? NOW : null,
+  } as LocationConditionRecord;
+}
+
+function rig(retired: boolean): RigRecord {
+  return {
+    id: "r1",
+    angler_id: "a1",
+    trip_id: "t1",
+    slot: 1,
+    name: null,
+    setup_type: null,
+    revision: 1,
+    effective_from: NOW,
+    spot_id: null,
+    platform: null,
+    depth_fished_m: null,
+    live_bait: false,
+    gear: [],
+    created_at: NOW,
+    retired_at: retired ? NOW : null,
+  };
+}
+
+function catchRecord(state: string, deleted: boolean): CatchRecord {
+  return { id: "c1", state, deleted_at: deleted ? NOW : null } as unknown as CatchRecord;
+}
+
+describe("setup progress vectors", () => {
+  for (const vector of vectors.cases) {
+    it(vector.name, () => {
+      const log = vector.log as {
+        locations: VectorLocation[];
+        tackleItemCount: number;
+        rigs: number;
+        rigsRetired?: boolean;
+        catches: number;
+        catchState?: string;
+        catchDeleted?: boolean;
+      };
+
+      const observed = observedSteps({
+        locations: log.locations.map(location),
+        tackleItemCount: log.tackleItemCount,
+        rigs: log.rigs > 0 ? [rig(log.rigsRetired ?? false)] : [],
+        catches:
+          log.catches > 0
+            ? [catchRecord(log.catchState ?? "confirmed", log.catchDeleted ?? false)]
+            : [],
+      });
+
+      const latched = new Set(vector.latched as SetupStepId[]);
+      const steps = setupSteps(latched, observed);
+
+      expect(steps.filter((s) => s.done).map((s) => s.id).sort()).toEqual(
+        [...(vector.expectDone as SetupStepId[])].sort(),
+      );
+      expect([...stepsToLatch(latched, observed)].sort()).toEqual(
+        [...(vector.expectLatch as SetupStepId[])].sort(),
+      );
+      expect(allStepsDone(steps)).toBe(vector.expectAllDone);
+    });
+  }
+});
+
+describe("setup progress copy", () => {
+  it("keeps the founder's order and gives every step a label, hint and destination", () => {
+    const steps = setupSteps(new Set(), new Set());
+    expect(steps.map((s) => s.id)).toEqual([...SETUP_STEPS]);
+    for (const step of steps) {
+      expect(step.label.length).toBeGreaterThan(0);
+      expect(step.hint.length).toBeGreaterThan(0);
+      expect(step.href.startsWith("/")).toBe(true);
+    }
+  });
+
+  it("never un-completes a latched step, whatever the log says", () => {
+    // The property the whole design rests on, asserted directly rather than only via a
+    // vector: latching is one-way.
+    for (const id of SETUP_STEPS) {
+      const steps = setupSteps(new Set([id]), new Set());
+      expect(steps.find((s) => s.id === id)!.done).toBe(true);
+    }
+  });
+});

--- a/src/core/rules/setup-progress.ts
+++ b/src/core/rules/setup-progress.ts
@@ -1,0 +1,124 @@
+import type { CatchRecord, LocationConditionRecord, RigRecord } from "./catch/types";
+
+/**
+ * The five-step guided setup checklist (founder spec §1).
+ *
+ * **A step is a memory that something was done once, not a readout of today.** That is
+ * the whole design, and it is the difference between a checklist people follow and one
+ * they learn to ignore.
+ *
+ * The data under steps 1 and 4 is genuinely per-trip: a location describes right now, and
+ * a new trip starts with none. If the checklist asked "is there a location on *this*
+ * trip", it would flip back to incomplete every outing for somebody who has fished for a
+ * decade. So each step latches: once true, it stays true.
+ *
+ * Latching is also why this cannot be derived from live data alone. Present state answers
+ * "do you have tackle", not "have you ever added tackle", and those differ in exactly the
+ * case that matters — an angler who clears out their box should not be marched back
+ * through the tutorial. The caller keeps the latched set and passes it in; `evaluate`
+ * unions it with what the log shows now.
+ */
+
+export const SETUP_STEPS = ["location", "tackle", "rod", "conditions", "catch"] as const;
+
+export type SetupStepId = (typeof SETUP_STEPS)[number];
+
+export interface SetupStep {
+  readonly id: SetupStepId;
+  readonly label: string;
+  readonly hint: string;
+  readonly href: string;
+  readonly done: boolean;
+}
+
+const COPY: Record<SetupStepId, { label: string; hint: string; href: string }> = {
+  location: {
+    label: "Set a fishing location",
+    hint: "Where are you fishing?",
+    href: "/setup",
+  },
+  tackle: {
+    label: "Add gear to your Tackle Box",
+    hint: "Rods, reels, line, hooks — whatever's in your box.",
+    href: "/tackle",
+  },
+  rod: {
+    label: "Build a rod setup",
+    hint: "Pair your gear into a rod you can fish with.",
+    href: "/setup",
+  },
+  conditions: {
+    label: "Add today's conditions",
+    hint: "Current, structure, water — what you see out there.",
+    href: "/setup",
+  },
+  catch: {
+    label: "Log your first fish",
+    hint: "One tap, from here or the Log tab.",
+    href: "/log",
+  },
+};
+
+/**
+ * A location counts for step 4 once it carries an observation, not just a name. Naming a
+ * spot and describing the water are two different acts, and the founder listed them as
+ * two different steps.
+ */
+function hasConditions(location: LocationConditionRecord): boolean {
+  return (
+    location.current_term !== null ||
+    location.current_strength !== null ||
+    location.structure_type_ids.length > 0 ||
+    location.bottom_depth_m !== null ||
+    location.water_color_id !== null ||
+    location.water_clarity_id !== null
+  );
+}
+
+/** What the log shows right now. Not the answer on its own — see the latch above. */
+export function observedSteps(input: {
+  readonly catches: readonly CatchRecord[];
+  readonly rigs: readonly RigRecord[];
+  readonly locations: readonly LocationConditionRecord[];
+  readonly tackleItemCount: number;
+}): ReadonlySet<SetupStepId> {
+  const live = new Set<SetupStepId>();
+  const locations = input.locations.filter((l) => l.deleted_at === null);
+
+  if (locations.length > 0) live.add("location");
+  if (input.tackleItemCount > 0) live.add("tackle");
+  if (input.rigs.length > 0) live.add("rod");
+  if (locations.some(hasConditions)) live.add("conditions");
+  if (input.catches.some((c) => c.deleted_at === null)) live.add("catch");
+
+  return live;
+}
+
+/**
+ * The five steps as the card should render them.
+ *
+ * `latched` is what the device already remembers; `observed` is what the log says now.
+ * A step is done if either says so, which is what makes it one-way.
+ */
+export function setupSteps(
+  latched: ReadonlySet<SetupStepId>,
+  observed: ReadonlySet<SetupStepId>,
+): readonly SetupStep[] {
+  return SETUP_STEPS.map((id) => ({
+    id,
+    ...COPY[id],
+    done: latched.has(id) || observed.has(id),
+  }));
+}
+
+/** Newly true steps the caller should write down, so they survive the data changing. */
+export function stepsToLatch(
+  latched: ReadonlySet<SetupStepId>,
+  observed: ReadonlySet<SetupStepId>,
+): readonly SetupStepId[] {
+  return [...observed].filter((id) => !latched.has(id));
+}
+
+export function allStepsDone(steps: readonly SetupStep[]): boolean {
+  return steps.every((step) => step.done);
+}

--- a/src/core/rules/vectors/setup-progress.json
+++ b/src/core/rules/vectors/setup-progress.json
@@ -1,0 +1,115 @@
+{
+  "$comment": "Vectors for src/core/rules/setup-progress.ts (ADR 003 §4). The five-step guided setup checklist. Cases are written compactly and expanded in setup-progress.test.ts: `locations` entries list only the condition fields that are set, `latched` is what the device already remembers, and `expectDone` is the set of step ids that must render as done. The load-bearing behaviour is the LATCH — a step, once true, never goes back to false, because the checklist is a memory that something was done once and not a readout of today's trip.",
+
+  "cases": [
+    {
+      "name": "a brand new angler has nothing done",
+      "latched": [],
+      "log": { "locations": [], "tackleItemCount": 0, "rigs": 0, "catches": 0 },
+      "expectDone": [],
+      "expectLatch": [],
+      "expectAllDone": false
+    },
+    {
+      "name": "naming a spot completes step 1 but not step 4 — naming and describing are different acts",
+      "latched": [],
+      "log": { "locations": [{ "named": true }], "tackleItemCount": 0, "rigs": 0, "catches": 0 },
+      "expectDone": ["location"],
+      "expectLatch": ["location"],
+      "expectAllDone": false
+    },
+    {
+      "name": "any single observation on a location completes the conditions step",
+      "latched": [],
+      "log": { "locations": [{ "named": true, "current_term": "uphill" }], "tackleItemCount": 0, "rigs": 0, "catches": 0 },
+      "expectDone": ["location", "conditions"],
+      "expectLatch": ["location", "conditions"],
+      "expectAllDone": false
+    },
+    {
+      "name": "structure alone counts too — no single field is privileged",
+      "latched": [],
+      "log": { "locations": [{ "named": true, "structure_type_ids": ["kelp"] }], "tackleItemCount": 0, "rigs": 0, "catches": 0 },
+      "expectDone": ["location", "conditions"],
+      "expectLatch": ["location", "conditions"],
+      "expectAllDone": false
+    },
+    {
+      "name": "a deleted location does not count for either step",
+      "latched": [],
+      "log": { "locations": [{ "named": true, "current_term": "uphill", "deleted": true }], "tackleItemCount": 0, "rigs": 0, "catches": 0 },
+      "expectDone": [],
+      "expectLatch": [],
+      "expectAllDone": false
+    },
+    {
+      "name": "a retired rod still counts — the angler has built one",
+      "latched": [],
+      "log": { "locations": [], "tackleItemCount": 0, "rigs": 1, "rigsRetired": true, "catches": 0 },
+      "expectDone": ["rod"],
+      "expectLatch": ["rod"],
+      "expectAllDone": false
+    },
+    {
+      "name": "an unresolved quick mark is still a logged catch for the purposes of the checklist",
+      "latched": [],
+      "log": { "locations": [], "tackleItemCount": 0, "rigs": 0, "catches": 1, "catchState": "unresolved" },
+      "expectDone": ["catch"],
+      "expectLatch": ["catch"],
+      "expectAllDone": false
+    },
+    {
+      "name": "a deleted catch does not count",
+      "latched": [],
+      "log": { "locations": [], "tackleItemCount": 0, "rigs": 0, "catches": 1, "catchDeleted": true },
+      "expectDone": [],
+      "expectLatch": [],
+      "expectAllDone": false
+    },
+    {
+      "name": "THE LATCH: clearing the tackle box does not un-teach the angler",
+      "latched": ["tackle"],
+      "log": { "locations": [], "tackleItemCount": 0, "rigs": 0, "catches": 0 },
+      "expectDone": ["tackle"],
+      "expectLatch": [],
+      "expectAllDone": false
+    },
+    {
+      "name": "THE LATCH: a new trip with no location of its own keeps steps 1 and 4 done",
+      "latched": ["location", "conditions"],
+      "log": { "locations": [], "tackleItemCount": 0, "rigs": 0, "catches": 0 },
+      "expectDone": ["location", "conditions"],
+      "expectLatch": [],
+      "expectAllDone": false
+    },
+    {
+      "name": "a latched step and a live one union rather than replace",
+      "latched": ["catch"],
+      "log": { "locations": [], "tackleItemCount": 3, "rigs": 0, "catches": 0 },
+      "expectDone": ["tackle", "catch"],
+      "expectLatch": ["tackle"],
+      "expectAllDone": false
+    },
+    {
+      "name": "all five done collapses the card",
+      "latched": [],
+      "log": {
+        "locations": [{ "named": true, "water_clarity_id": "clear" }],
+        "tackleItemCount": 2,
+        "rigs": 1,
+        "catches": 1
+      },
+      "expectDone": ["location", "tackle", "rod", "conditions", "catch"],
+      "expectLatch": ["location", "tackle", "rod", "conditions", "catch"],
+      "expectAllDone": true
+    },
+    {
+      "name": "all five done entirely from the latch, with an empty log",
+      "latched": ["location", "tackle", "rod", "conditions", "catch"],
+      "log": { "locations": [], "tackleItemCount": 0, "rigs": 0, "catches": 0 },
+      "expectDone": ["location", "tackle", "rod", "conditions", "catch"],
+      "expectLatch": [],
+      "expectAllDone": true
+    }
+  ]
+}

--- a/src/features/catches/store.ts
+++ b/src/features/catches/store.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { broughtBackRevision, canBringBack, nextRodSlot, quiverEntries } from "@/core/rules/catch/quiver";
 import { useSyncExternalStore } from "react";
 
 import { speciesLabel } from "@/core/ontology/species";
@@ -465,6 +466,11 @@ export async function saveRodSetup(input: {
   gear: readonly SetupGear[];
   /** Omitted for a brand-new slot; supplied when re-rigging an existing one. */
   previousRevision?: number;
+  /**
+   * The lineage this rod belongs to (ADR 008). Omitted mints a new one — a rod nobody
+   * has built before; supplied continues an existing one, which is what re-rigging does.
+   */
+  quiverId?: string;
 }): Promise<RigRecord> {
   const now = new Date().toISOString();
   const rig: RigRecord = {
@@ -472,6 +478,7 @@ export async function saveRodSetup(input: {
     angler_id: LOCAL_ANGLER_ID,
     trip_id: input.tripId,
     slot: input.slot,
+    quiver_id: input.quiverId ?? uuidv7(),
     name: input.name?.trim() || null,
     setup_type: input.setupType,
     revision: (input.previousRevision ?? 0) + 1,
@@ -512,6 +519,33 @@ export async function retireRodSetup(rigId: string): Promise<void> {
   await persist(
     [{ store: "trip_rig", row: retired as unknown as StoredRow }],
     [mutation("trip_rig", retired.id, "insert", retired as unknown as Record<string, unknown>, now)],
+  );
+}
+
+/**
+ * Put a saved rod back on today's boat, exactly as it was last built.
+ *
+ * The whole point of the Quiver: an angler who fishes the same 40-lb yo-yo stick every
+ * trip should never rebuild it. All the arithmetic — which revision is latest, whether
+ * this lineage is already out, what the next revision and slot are — lives in
+ * `core/rules/catch/quiver.ts`; this function supplies the id and the clock and writes.
+ */
+export async function bringBackRodSetup(quiverId: string, tripId: string): Promise<void> {
+  const entry = quiverEntries(snapshot.rigs, tripId).find((e) => e.quiver_id === quiverId);
+  // Already fishing: bringing it back would put the same rod in two slots, and a catch
+  // could then be attributed to either.
+  if (!entry || !canBringBack(entry)) return;
+
+  const now = new Date().toISOString();
+  const revived = broughtBackRevision(entry.latest, {
+    id: uuidv7(),
+    tripId,
+    slot: nextRodSlot(snapshot.rigs, tripId),
+    nowIso: now,
+  });
+  await persist(
+    [{ store: "trip_rig", row: revived as unknown as StoredRow }],
+    [mutation("trip_rig", revived.id, "insert", revived as unknown as Record<string, unknown>, now)],
   );
 }
 
@@ -586,6 +620,7 @@ export const logActions = Object.freeze({
   endTrip,
   saveRodSetup,
   retireRodSetup,
+  bringBackRodSetup,
   saveLocation,
   deleteLocation,
 });

--- a/src/features/fish-legal/boundary-coverage.test.ts
+++ b/src/features/fish-legal/boundary-coverage.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { REGIONS } from "@/core/ontology/regions";
+
+import { boundaryViewFor, hasBoundaryData } from "./boundary-coverage";
+import { FLORIDA } from "./florida-pack";
+import { NORCAL } from "./norcal-pack";
+import { SOCAL } from "./reg-data";
+
+/**
+ * The regression these exist for: every region that was not California used to fall
+ * through to a Florida map centred on [26.5, -82.5]. Nothing failed, because nothing
+ * asserted which coastline a region should see.
+ */
+describe("boundary coverage", () => {
+  it("gives California and Florida a view, and every other region none", () => {
+    const covered = REGIONS.map((r) => r.id).filter(hasBoundaryData);
+    expect([...covered].sort()).toEqual(
+      [
+        "ca_gma_central",
+        "ca_gma_mendocino",
+        "ca_gma_northern",
+        "ca_gma_san_francisco",
+        "ca_gma_southern",
+        "florida",
+        "northern_california",
+        "southern_california",
+      ].sort(),
+    );
+  });
+
+  it("never shows one region the coastline of another", () => {
+    // The actual bug, stated as an assertion: a region's view must come from its own
+    // bundle. Florida's areas may only be drawn for Florida.
+    for (const { id } of REGIONS) {
+      const view = boundaryViewFor(id);
+      if (!view) continue;
+      if (id === "florida") {
+        expect(view.bundle).toBe(FLORIDA);
+      } else {
+        expect(view.bundle, `${id} must not render Florida`).not.toBe(FLORIDA);
+        expect([SOCAL, NORCAL]).toContain(view.bundle);
+      }
+    }
+  });
+
+  it("draws the 50-fathom RCA ribbon only in the Southern GMA, where the law puts it", () => {
+    const withRca = REGIONS.map((r) => r.id).filter((id) => boundaryViewFor(id)?.showRca);
+    expect([...withRca].sort()).toEqual(["ca_gma_southern", "southern_california"]);
+  });
+
+  it("names every view for the coastline actually on screen", () => {
+    for (const { id } of REGIONS) {
+      const view = boundaryViewFor(id);
+      if (!view) continue;
+      expect(view.label.length).toBeGreaterThan(0);
+      // A Florida view labelled "California" is the failure this catches.
+      const saysFlorida = view.label.includes("Florida");
+      expect(saysFlorida).toBe(id === "florida");
+    }
+  });
+
+  it("points each view at an area its own bundle actually contains", () => {
+    for (const { id } of REGIONS) {
+      const view = boundaryViewFor(id);
+      if (!view) continue;
+      expect(view.areas.some((a) => a.id === view.areaId), `${id}: ${view.areaId}`).toBe(true);
+    }
+  });
+});

--- a/src/features/fish-legal/boundary-coverage.ts
+++ b/src/features/fish-legal/boundary-coverage.ts
@@ -1,0 +1,82 @@
+import type { RegionId } from "@/core/ontology/regions";
+
+import { FLORIDA } from "./florida-pack";
+import { NORCAL } from "./norcal-pack";
+import { REG_AREAS, SOCAL } from "./reg-data";
+import type { SocalPack } from "./types";
+
+/**
+ * Which regions have verified depth-and-boundary data, and what the map should draw.
+ *
+ * This was inline in `boundary-map.tsx`, where it had a hole. The component computed a
+ * California view and fell back to `FLORIDA.areas` centred on [26.5, -82.5] for
+ * *everything else* — so a Washington, Texas or Maine angler opening "Depth & boundary
+ * rules" was shown a map of southwest Florida. Thirty-six of the ~45 regions hit that
+ * fallback. It is the same failure as a rule with no citation: an answer presented with
+ * more confidence than the data supports.
+ *
+ * Extracted here because two screens now have to agree about it — the boundaries page
+ * draws the view, and the Fish Legal home decides whether to offer the card at all. A
+ * disagreement between those two is exactly how the Florida fallback survived unnoticed.
+ *
+ * `null` means "no verified boundary data for this region", and callers must say so
+ * rather than substituting another state's coastline.
+ */
+export interface BoundaryView {
+  readonly bundle: SocalPack;
+  /** Focus area within the bundle, for the groundfish reading. */
+  readonly areaId: string;
+  readonly areas: SocalPack["areas"];
+  readonly center: readonly [number, number];
+  /** The 50-fathom RCA ribbon is a Southern-GMA window; nowhere else draws it. */
+  readonly showRca: boolean;
+  /** Names the page for the coastline actually on screen. */
+  readonly label: string;
+}
+
+const NORCAL_VIEWS: Partial<Record<RegionId, { areaId: string; center: readonly [number, number]; label: string }>> = {
+  northern_california: { areaId: "ca-gma-northern", center: [39.5, -124.0], label: "Northern California" },
+  ca_gma_northern: { areaId: "ca-gma-northern", center: [40.6, -124.3], label: "California — Northern GMA" },
+  ca_gma_mendocino: { areaId: "ca-gma-mendocino", center: [39.5, -123.9], label: "California — Mendocino GMA" },
+  ca_gma_san_francisco: { areaId: "ca-gma-san-francisco", center: [38.0, -123.2], label: "California — San Francisco GMA" },
+  ca_gma_central: { areaId: "ca-gma-central", center: [35.8, -121.8], label: "California — Central GMA" },
+};
+
+export function boundaryViewFor(region: RegionId): BoundaryView | null {
+  if (region === "southern_california" || region === "ca_gma_southern") {
+    return {
+      bundle: SOCAL,
+      areaId: "ca-gma-southern",
+      areas: REG_AREAS,
+      center: [33.6, -118.8],
+      showRca: true,
+      label: region === "ca_gma_southern" ? "California — Southern GMA" : "Southern California",
+    };
+  }
+
+  const norcal = NORCAL_VIEWS[region];
+  if (norcal) {
+    return { bundle: NORCAL, areas: NORCAL.areas, showRca: false, ...norcal };
+  }
+
+  // Florida has real boundary data — the Indian River Lagoon catch-and-release zone. It
+  // was previously reachable only as the fallback, which meant it rendered for every
+  // region EXCEPT the one it describes.
+  if (region === "florida") {
+    return {
+      bundle: FLORIDA,
+      areaId: "fl-irl-cnr",
+      areas: FLORIDA.areas,
+      center: [26.5, -82.5],
+      showRca: false,
+      label: "Florida",
+    };
+  }
+
+  return null;
+}
+
+/** Whether the boundaries page has anything honest to show for this region. */
+export function hasBoundaryData(region: RegionId): boolean {
+  return boundaryViewFor(region) !== null;
+}

--- a/src/features/fish-legal/components/boundary-map.tsx
+++ b/src/features/fish-legal/components/boundary-map.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { LegalNotice } from "@/components/legal-notice";
+import { REGIONS } from "@/core/ontology/regions";
 import dynamic from "next/dynamic";
 import { useEffect, useMemo, useState } from "react";
 
@@ -15,6 +17,7 @@ import { distanceToLineM, pointInRing, sideOfLine } from "../geospatial";
 import { regulationCard } from "../reg-engine";
 import { RCA_50FM_LINE, REG_AREAS, SOCAL } from "../reg-data";
 import { FLORIDA } from "../florida-pack";
+import { boundaryViewFor } from "../boundary-coverage";
 import { NORCAL } from "../norcal-pack";
 import { platformFor } from "../reg-engine";
 import { useFishingModePreference } from "../prefs";
@@ -51,6 +54,7 @@ export function BoundaryMap() {
   const [position, setPosition] = useState<{ lat: number; lng: number; accuracy: number } | null>(null);
   const [geoState, setGeoState] = useState<"idle" | "asking" | "denied">("idle");
   const [region] = useRegionPreference();
+  const regionLabel = REGIONS.find((r) => r.id === region)?.label ?? "this region";
   // Per-zone outside/near/inside state that foldPosition refines fix-by-fix. Lives in a
   // ref — it is not display state — and drives the spec-§14 semantics (transition emits,
   // holding pattern silent).
@@ -67,28 +71,11 @@ export function BoundaryMap() {
     return `${get("year")}-${get("month")}-${get("day")}`;
   }, [now, zone]);
 
-  // Founder ask (2026-09-02): California fishes by Groundfish Management Area. The
-  // view config pairs each CA region (plain NorCal/SoCal and the five GMA entries)
-  // with its bundle, its focus area, and a map center. Regions with no verified
-  // California pack keep the Florida overview fallback. The 50-fm RCA ribbon is a
-  // Southern-GMA window, so it shows for the two southern reads only.
-  const caView = useMemo(() => {
-    const isSoCal = region === "southern_california" || region === "ca_gma_southern";
-    if (isSoCal) {
-      return { bundle: SOCAL, areaId: "ca-gma-southern", areas: REG_AREAS, center: [33.6, -118.8] as const, showRca: true };
-    }
-    const norcalCenters: Record<string, { areaId: string; center: readonly [number, number] }> = {
-      northern_california: { areaId: "ca-gma-northern", center: [39.5, -124.0] },
-      ca_gma_northern: { areaId: "ca-gma-northern", center: [40.6, -124.3] },
-      ca_gma_mendocino: { areaId: "ca-gma-mendocino", center: [39.5, -123.9] },
-      ca_gma_san_francisco: { areaId: "ca-gma-san-francisco", center: [38.0, -123.2] },
-      ca_gma_central: { areaId: "ca-gma-central", center: [35.8, -121.8] },
-    };
-    const nc = norcalCenters[region];
-    if (nc) return { bundle: NORCAL, ...nc, areas: NORCAL.areas, showRca: false };
-    return null;
-  }, [region]);
-  const isCalifornia = caView !== null;
+  // Which coastline this region actually has verified data for. `null` means none, and
+  // the page says so rather than drawing another state's map — see boundary-coverage.ts
+  // for the Florida fallback this replaced.
+  const caView = useMemo(() => boundaryViewFor(region), [region]);
+  const isCalifornia = caView !== null && caView.bundle !== FLORIDA;
 
   // Today's groundfish reading drives the ribbon — a generic rockfish member's card is
   // the complex's voice this day (boat/shore decides the exemption copy). CA-ONLY:
@@ -168,10 +155,44 @@ export function BoundaryMap() {
     return () => cancelAnimationFrame(raf);
   }, []);
 
+  /*
+    No verified boundary data for this region. Until 2026-09-04 this path silently drew a
+    map of southwest Florida instead — for every region that is not California, which is
+    most of them. An honest empty state is the same stance the rest of Fish Legal takes:
+    "No verified data" beats a confident answer built from another state's coastline.
+  */
+  if (!caView) {
+    return (
+      <div className="flex flex-col gap-4">
+        <section className="rounded-lg border border-hairline bg-surface p-4">
+          <h1 className="text-h1">Depth &amp; boundary rules</h1>
+          <p className="mt-1 text-label text-signal-orange">{regionLabel}</p>
+        </section>
+
+        <section className="rounded-lg border border-hairline bg-surface p-4">
+          <h2 className="text-h3">No verified boundary data for {regionLabel}</h2>
+          <p className="mt-2 text-body text-text-muted">
+            Depth and boundary lines are drawn only where we hold the published
+            coordinates. We have them for California and for Florida&rsquo;s Indian River
+            Lagoon; this region is not mapped yet.
+          </p>
+          <p className="mt-2 text-body text-text-muted">
+            We would rather show you nothing than show you another state&rsquo;s coastline.
+            Use the official chart and the agency&rsquo;s own map for where you are fishing.
+          </p>
+          <div className="mt-4">
+            <LegalNotice kind="regulations" />
+          </div>
+        </section>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-4">
       <section className="rounded-lg border border-hairline bg-surface p-4">
         <h1 className="text-h1">Depth &amp; boundary rules</h1>
+        <p className="mt-1 text-label text-signal-orange">{caView.label}</p>
         <p className="mt-1 text-caption text-text-muted">
           Simplified lines for orientation offshore. The federal waypoint text and CDFW&rsquo;s
           official map are the legal reference; both are linked.
@@ -254,9 +275,9 @@ export function BoundaryMap() {
           <BoundaryLeaflet
             position={position}
             layers={layers}
-            areas={caView ? caView.areas : FLORIDA.areas}
-            center={caView ? ([caView.center[0], caView.center[1]] as const) : ([26.5, -82.5] as const)}
-            showRca={caView?.showRca ?? false}
+            areas={caView.areas}
+            center={[caView.center[0], caView.center[1]] as const}
+            showRca={caView.showRca}
           />
         </div>
         <div className="mt-3 flex flex-wrap items-center gap-3">

--- a/src/features/fish-legal/components/regulations-home.tsx
+++ b/src/features/fish-legal/components/regulations-home.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { boundaryViewFor, hasBoundaryData } from "../boundary-coverage";
 import Link from "next/link";
 import { LegalNotice } from "@/components/legal-notice";
 import { LegalAcknowledgement } from "@/features/legal/components/legal-acknowledgement";
@@ -121,14 +122,20 @@ export function RegulationsHome() {
       <section className="rounded-lg border border-hairline bg-surface p-4" aria-label="My current regulations">
         <h2 className="text-h3">My current regulations</h2>
         <dl className="mt-3 flex flex-col gap-2 text-body">
+          {/*
+            The active jurisdiction in the app's accent colour (founder, spec §4). Every
+            answer in this section is only true for this region, so it is the one thing on
+            the page that must never be skimmed past. "Change" is a real tap target rather
+            than a word inside a sentence.
+          */}
           <Row label="Region">
-            {regionLabel}
-            <span className="text-caption text-text-muted">
-              {" "}· change it in{" "}
-              <Link href="/settings" className="text-text-link underline decoration-dotted underline-offset-2">
-                Settings
-              </Link>
-            </span>
+            <span className="text-label text-signal-orange">{regionLabel}</span>
+            <Link
+              href="/settings"
+              className="ml-2 inline-flex min-h-touch-floor items-center rounded-md border border-signal-orange px-3 text-label text-signal-orange transition-colors hover:bg-surface-raised focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring active:scale-95 motion-reduce:transition-none"
+            >
+              Change
+            </Link>
           </Row>
           <Row label="Rule set">
             {bundle
@@ -206,7 +213,19 @@ export function RegulationsHome() {
         <HomeCard href="/fish-legal/rockfish" title="Rockfish ID" body="Six questions; likely species with confidence, not verdicts." />
         <HomeCard href="/fish-id" title="Fish ID" body="Salmon, sand bass and rockfish — the ones that are genuinely hard to call." />
         <HomeCard href="/fin-id" title="Whale & dolphin ID" body="What surfaced next to the boat, and how far back to stay." />
-        <HomeCard href="/fish-legal/boundaries" title="Depth & boundary rules" body="Lines that change the answer as you move." />
+        {/*
+          Only offered where we hold published coordinates. This card used to be shown
+          everywhere and drew a map of southwest Florida for every non-California region
+          (spec §5.3) — offering it and then admitting we have nothing is still better
+          than that, but not offering it is better again.
+        */}
+        {hasBoundaryData(region) ? (
+          <HomeCard
+            href="/fish-legal/boundaries"
+            title={`${boundaryViewFor(region)?.label ?? ""} depth & boundaries`}
+            body="Lines that change the answer as you move."
+          />
+        ) : null}
         <HomeCard href="/fish-legal/offline" title="Offline & sources" body="What's on this device, when verified, where the law lives." />
         <HomeCard href="/fish-legal/alerts" title="Fish Legal alerts" body="Boundary transitions & limit warnings, logged on-device." />
       </nav>

--- a/src/features/setup/checklist-latch.ts
+++ b/src/features/setup/checklist-latch.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { SETUP_STEPS, type SetupStepId } from "@/core/rules/setup-progress";
+import { createLocalPreference } from "@/features/settings/preference";
+
+/**
+ * Which guided-setup steps this device has ever completed.
+ *
+ * Stored rather than derived, and that is the design (see `core/rules/setup-progress.ts`).
+ * Live data answers "do you have tackle now", not "have you ever added tackle", and the
+ * two differ exactly where it matters: an angler who clears out their box should not be
+ * marched back through the tutorial.
+ *
+ * Local, not on the account, because the app is fully usable signed out.
+ */
+const latch = createLocalPreference<readonly SetupStepId[]>({
+  key: "flb:setup-checklist",
+  defaultValue: [],
+  parse: (raw) => {
+    if (!raw) return [];
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return [];
+      // Narrow rather than trust: an unknown id from an older or newer build must not
+      // become a step that can never be completed.
+      return parsed.filter((id): id is SetupStepId =>
+        SETUP_STEPS.includes(id as SetupStepId),
+      );
+    } catch {
+      return [];
+    }
+  },
+  serialize: (value) => JSON.stringify(value),
+});
+
+/** Read the latch inside a component. Never `latch.use()` — see tripwire §4. */
+export function useSetupLatch() {
+  return latch.use();
+}
+
+/** Write newly completed steps down. No-op when there is nothing new, so it is safe in an effect. */
+export function latchSteps(newly: readonly SetupStepId[]): void {
+  if (newly.length === 0) return;
+  const merged = new Set([...latch.read(), ...newly]);
+  latch.set([...merged]);
+}

--- a/src/features/setup/components/quiver-section.tsx
+++ b/src/features/setup/components/quiver-section.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { canBringBack, quiverEntries, type QuiverEntry } from "@/core/rules/catch/quiver";
+import type { GearRole, RigRecord } from "@/core/rules/catch/types";
+import { CARD_CLASS, PRIMARY_BUTTON } from "@/features/catches/ui-classes";
+import { logActions } from "@/features/catches/store";
+
+/**
+ * The Quiver — every rod setup the angler has ever built, ready to fish again.
+ *
+ * `Put away` has never deleted a rod; it writes a retired revision so a fish keeps the
+ * setup it was caught on. What was missing was anywhere to see those setups and a way to
+ * bring one back, which is what made "Put away" read as destructive.
+ *
+ * Every grouping and revision decision is in `core/rules/catch/quiver.ts`. This component
+ * renders and calls one action — no `useMemo` that quietly re-implements the lineage
+ * rules, which is the failure ADR 003 exists to prevent.
+ */
+
+/** The founder's own words for a rod's parts (spec §2), not the internal role keys. */
+const GEAR_ROWS: readonly { role: GearRole; label: string }[] = [
+  { role: "rod", label: "Rod" },
+  { role: "reel", label: "Reel" },
+  { role: "main_line", label: "Line" },
+  { role: "leader", label: "Leader" },
+  { role: "hook", label: "Hooks" },
+  { role: "bait", label: "Bait" },
+  { role: "weight", label: "Weight" },
+  { role: "terminal", label: "Terminal tackle" },
+];
+
+export function QuiverSection({
+  rigs,
+  tripId,
+  onEnsureTrip,
+}: {
+  rigs: readonly RigRecord[];
+  tripId: string;
+  /** Bringing a rod back needs a trip to bring it back to. */
+  onEnsureTrip: () => Promise<string>;
+}) {
+  const entries = useMemo(() => quiverEntries(rigs, tripId), [rigs, tripId]);
+  const [broughtBack, setBroughtBack] = useState<string | null>(null);
+
+  async function bringBack(entry: QuiverEntry) {
+    const trip = await onEnsureTrip();
+    await logActions.bringBackRodSetup(entry.quiver_id, trip);
+    setBroughtBack(entry.quiver_id);
+  }
+
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex items-baseline justify-between gap-3">
+        <h2 className="text-h3">Quiver</h2>
+        <p className="text-caption text-text-muted">
+          {entries.length === 0
+            ? "Nothing saved yet"
+            : `${entries.length} saved`}
+        </p>
+      </div>
+
+      {entries.length === 0 ? (
+        <p className="text-body text-text-muted">
+          Nothing saved yet. Put a rod away from Today&rsquo;s Setup and it lands here,
+          ready to bring back next trip — nothing you build today has to be rebuilt
+          tomorrow.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {entries.map((entry) => (
+            <li key={entry.quiver_id}>
+              <QuiverCard
+                entry={entry}
+                justBroughtBack={broughtBack === entry.quiver_id}
+                onBringBack={() => void bringBack(entry)}
+                onUndo={() => {
+                  const active = entry.latest;
+                  void logActions.retireRodSetup(active.id);
+                  setBroughtBack(null);
+                }}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function QuiverCard({
+  entry,
+  justBroughtBack,
+  onBringBack,
+  onUndo,
+}: {
+  entry: QuiverEntry;
+  justBroughtBack: boolean;
+  onBringBack: () => void;
+  onUndo: () => void;
+}) {
+  const rows = GEAR_ROWS.map(({ role, label }) => {
+    const item = entry.latest.gear.find((g) => g.role === role);
+    if (!item) return null;
+    return { label, value: item.detail ? `${item.label}, ${item.detail}` : item.label };
+  }).filter((row): row is { label: string; value: string } => row !== null);
+
+  return (
+    <div className={`${CARD_CLASS} flex flex-col gap-2 p-4`}>
+      <h3 className="text-h3">{entry.label}</h3>
+
+      {/* Labelled rows, not the terse summary the active rod card uses: here the angler
+          is scanning several saved setups weeks later, not glancing at the one in their
+          hand. A gear role that was never set is omitted, never shown as a blank. */}
+      {rows.length > 0 ? (
+        <dl className="flex flex-col gap-1">
+          {rows.map((row) => (
+            <div key={row.label} className="flex gap-3 text-body">
+              <dt className="w-24 shrink-0 text-caption text-text-muted">{row.label}</dt>
+              <dd className="min-w-0 flex-1 text-text-primary">{row.value}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : null}
+
+      {entry.latest.live_bait ? (
+        <p className="text-caption text-text-muted">Live bait</p>
+      ) : null}
+
+      {canBringBack(entry) ? (
+        <button type="button" onClick={onBringBack} className={`${PRIMARY_BUTTON} w-full`}>
+          Bring back to Today&rsquo;s Setup
+        </button>
+      ) : justBroughtBack ? (
+        /* Confirms where it went and offers the one correction worth having. A greyed-out
+           button an angler pokes at twice in the sun is worse than no button, so the
+           already-there case below is a plain line instead. */
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-body text-text-muted">Back in Today&rsquo;s Setup.</p>
+          <button
+            type="button"
+            onClick={onUndo}
+            className="inline-flex min-h-touch-floor items-center rounded-full px-3 text-label text-text-link focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+          >
+            Undo
+          </button>
+        </div>
+      ) : (
+        <p className="text-body text-text-muted">Already in Today&rsquo;s Setup.</p>
+      )}
+    </div>
+  );
+}

--- a/src/features/setup/components/rod-setup-sheet.tsx
+++ b/src/features/setup/components/rod-setup-sheet.tsx
@@ -47,6 +47,7 @@ export function RodSetupSheet({
     liveBait: boolean;
     gear: readonly SetupGear[];
     previousRevision?: number;
+    quiverId?: string;
   }) => void;
 }) {
   const dialogRef = useRef<HTMLDialogElement>(null);
@@ -93,6 +94,7 @@ function RodForm({
     liveBait: boolean;
     gear: readonly SetupGear[];
     previousRevision?: number;
+    quiverId?: string;
   }) => void;
 }) {
   const existing = request.existing;
@@ -129,6 +131,9 @@ function RodForm({
       liveBait,
       gear: rows,
       previousRevision: existing?.revision,
+      // Re-rigging continues the same rod's lineage rather than forking it — otherwise
+      // every change of leader would create a second Quiver entry (ADR 008).
+      quiverId: existing?.quiver_id,
     });
   };
 

--- a/src/features/setup/components/setup-checklist.tsx
+++ b/src/features/setup/components/setup-checklist.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import Link from "next/link";
+
+import {
+  allStepsDone,
+  observedSteps,
+  setupSteps,
+  stepsToLatch,
+} from "@/core/rules/setup-progress";
+import { useLog } from "@/features/catches/store";
+import { CARD_CLASS, FOCUS_RING } from "@/features/catches/ui-classes";
+import { useTackleSession } from "@/features/tackle/session-store";
+import { isFixtureItem } from "@/features/tackle/tackle-fixture";
+
+import { latchSteps, useSetupLatch } from "../checklist-latch";
+
+/**
+ * The five-step guided setup checklist, on the calendar home (founder spec §1).
+ *
+ * It teaches the order of operations once — location, tackle, rod, conditions, fish —
+ * and then gets out of the way for good. A step that could un-complete itself would put
+ * an angler of ten years back at step one every new trip, which is the failure the
+ * founder named: a checklist that keeps nagging is one you learn to ignore.
+ *
+ * All five decisions live in `core/rules/setup-progress.ts`; the latch that makes them
+ * one-way lives in `../checklist-latch.ts`. This renders.
+ */
+export function SetupChecklist() {
+  const state = useLog();
+  const tackle = useTackleSession();
+  const [latched] = useSetupLatch();
+
+  const observed = useMemo(
+    () =>
+      observedSteps({
+        catches: state.catches,
+        rigs: state.rigs,
+        locations: state.locations,
+        // Sample data is not the angler's gear — see `isFixtureItem`.
+        tackleItemCount: tackle.items.filter((item) => !isFixtureItem(item)).length,
+      }),
+    [state.catches, state.rigs, state.locations, tackle.items],
+  );
+
+  const latchedSet = useMemo(() => new Set(latched), [latched]);
+  const steps = useMemo(() => setupSteps(latchedSet, observed), [latchedSet, observed]);
+  const newly = useMemo(() => stepsToLatch(latchedSet, observed), [latchedSet, observed]);
+
+  // Write down anything newly true, so it survives the data changing later. `latchSteps`
+  // no-ops on an empty list, which is what keeps this from being a render loop.
+  useEffect(() => {
+    latchSteps(newly);
+  }, [newly]);
+
+  if (allStepsDone(steps)) {
+    return (
+      <section className={`${CARD_CLASS} p-4`}>
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-body text-text-muted">Setup complete</p>
+          <Link
+            href="/setup"
+            className={`inline-flex min-h-touch-floor items-center rounded-md border border-border-interactive px-4 text-label text-text-link ${FOCUS_RING}`}
+          >
+            Review
+          </Link>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className={`${CARD_CLASS} flex flex-col gap-3 p-4`} aria-labelledby="setup-checklist">
+      <h2 id="setup-checklist" className="text-h3">
+        Get set up
+      </h2>
+      <ol className="flex flex-col gap-1">
+        {steps.map((step, index) => (
+          <li key={step.id}>
+            <Link
+              href={step.href}
+              className={`flex min-h-touch-floor items-center gap-3 rounded-md px-1 transition-colors hover:bg-surface-raised ${FOCUS_RING} motion-reduce:transition-none`}
+            >
+              <span
+                aria-hidden
+                className="w-5 shrink-0 text-label text-text-muted"
+              >
+                {index + 1}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block text-body text-text-primary">{step.label}</span>
+                {/* Completed rows say "Done" rather than only turning green — colour is
+                    never the only signal (06-accessibility-baseline). They stay tappable:
+                    somebody who added gear in January may want to add more in September. */}
+                {step.done ? (
+                  <span className="block text-caption text-success-green">Done</span>
+                ) : (
+                  <span className="block text-caption text-text-muted">{step.hint}</span>
+                )}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/src/features/setup/components/setup-page.tsx
+++ b/src/features/setup/components/setup-page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Link from "next/link";
+import { QuiverSection } from "./quiver-section";
 import { useMemo, useState } from "react";
 
 import { activeRodSetups, nextRodSlot, rodSetupLabel } from "@/core/rules/catch/rules";
@@ -33,6 +35,8 @@ export function SetupPage() {
   const [unit] = useUnitPreference();
   const [rodRequest, setRodRequest] = useState<RodSetupRequest | null>(null);
   const [locationRequest, setLocationRequest] = useState<LocationRequest | null>(null);
+  /** The rod just put away, so the confirmation can say where it went. */
+  const [putAway, setPutAway] = useState<string | null>(null);
 
   const trip = useMemo(() => openTripOf(state), [state]);
   const rods = useMemo(
@@ -82,6 +86,15 @@ export function SetupPage() {
           </p>
         </div>
 
+        {/* Putting a rod away has never deleted it, but a bare button with no follow-up
+            reads as final. Naming where it went is the fix — not a confirmation dialog,
+            which would tax every angler to guard against a mistake that costs one tap. */}
+        {putAway ? (
+          <p role="status" className="text-body text-text-muted">
+            Put away — saved in your Quiver.
+          </p>
+        ) : null}
+
         <ul className="flex flex-col gap-2">
           {rods.map((rod) => (
             <li key={rod.id}>
@@ -90,7 +103,10 @@ export function SetupPage() {
                 onEdit={() =>
                   setRodRequest({ key: `rod-${rod.id}`, slot: rod.slot, existing: rod })
                 }
-                onRetire={() => void logActions.retireRodSetup(rod.id)}
+                onRetire={() => {
+                  void logActions.retireRodSetup(rod.id);
+                  setPutAway(rod.id);
+                }}
               />
             </li>
           ))}
@@ -119,9 +135,13 @@ export function SetupPage() {
         </button>
       </section>
 
+      {/* Directly under the rods, because that is where a rod goes when you put it away
+          and where it comes back to (design 12 §2.1). */}
+      <QuiverSection rigs={state.rigs} tripId={trip?.id ?? ""} onEnsureTrip={ensureTrip} />
+
       <section className="flex flex-col gap-3">
         <div className="flex items-baseline justify-between gap-3">
-          <h2 className="text-h3">Today&rsquo;s locations</h2>
+          <h2 className="text-h3">Location &amp; Conditions</h2>
           <p className="text-caption text-text-muted">
             {locations.length === 0 ? "None yet" : `${locations.length} set up`}
           </p>
@@ -157,6 +177,19 @@ export function SetupPage() {
         >
           + Add location
         </button>
+      </section>
+
+      {/* Step 2 of the founder's workflow, reachable from the hub rather than buried in
+          Settings — but a link card, not a section, because Setup does not own the
+          Tackle Box's content (design 12 §2.5). */}
+      <section className={`${CARD_CLASS} flex flex-col gap-2 p-4`}>
+        <h2 className="text-h3">Tackle Box</h2>
+        <p className="text-body text-text-muted">
+          Everything in your kit — rods, reels, line, hooks, and more.
+        </p>
+        <Link href="/tackle" className={`${SECONDARY_BUTTON} self-start`}>
+          Open Tackle Box
+        </Link>
       </section>
 
       <RodSetupSheet

--- a/src/features/tackle/components/choice-field.tsx
+++ b/src/features/tackle/components/choice-field.tsx
@@ -12,17 +12,24 @@ import { CHIP_CLASS, CHIP_OFF, CHIP_ON } from "../ui-classes";
  */
 export function ChoiceField({
   field,
+  options,
   value,
   recents,
   onChange,
 }: {
   field: AttributeField;
+  /**
+   * The options to show, already resolved by `fieldOptions` (ADR 008). This component
+   * stays dumb on purpose: a field whose choices depend on another field is a domain
+   * rule, and the caller owns it.
+   */
+  options: readonly string[];
   value: string;
   recents: readonly string[];
   onChange: (value: string) => void;
 }) {
   const customInputId = useId();
-  const knownOptions = suggestedOptions(field.options, recents, field.maxChips);
+  const knownOptions = suggestedOptions(options, recents, field.maxChips);
   const valueIsCustom = value !== "" && !knownOptions.some((option) => option === value);
   const [customOpen, setCustomOpen] = useState(valueIsCustom);
   const showCustomInput = customOpen || valueIsCustom;
@@ -32,6 +39,15 @@ export function ChoiceField({
       <legend className="text-label">
         {field.label} <span className="font-normal text-text-muted">(optional)</span>
       </legend>
+      {/*
+        A dependent field before its controller is answered: no chips would leave a bare
+        "Other…" and no way to know why. Say what to do instead. Other… stays available,
+        because somebody who knows their reel is a 30 should not be blocked on picking a
+        type first.
+      */}
+      {knownOptions.length === 0 && field.emptyHint ? (
+        <p className="text-caption text-text-muted">{field.emptyHint}</p>
+      ) : null}
       <div className="flex flex-wrap gap-3" role="group" aria-label={`${field.label} choices`}>
         {knownOptions.map((option) => {
           const selected = value === option;

--- a/src/features/tackle/components/tackle-editor-sheet.tsx
+++ b/src/features/tackle/components/tackle-editor-sheet.tsx
@@ -12,6 +12,7 @@ import {
   type RecentsMap,
   type TackleDraft,
   type TackleItem,
+  fieldOptions,
 } from "../types";
 import { ChoiceField } from "./choice-field";
 import { QuantityStepper } from "./quantity-stepper";
@@ -284,6 +285,7 @@ function EditorForm({
           <ChoiceField
             key={`${categorySpec.id}:${field.key}`}
             field={field}
+            options={fieldOptions(field, draft.attributes)}
             value={draft.attributes[field.key] ?? ""}
             recents={draft.category ? recents[`${draft.category}:${field.key}`] ?? [] : []}
             onChange={(value) => setAttribute(field.key, value)}

--- a/src/features/tackle/field-options.test.ts
+++ b/src/features/tackle/field-options.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import { TACKLE_CATEGORIES, fieldOptions, type AttributeField } from "./types";
+
+/**
+ * ADR 008 ruling 2. The bug these exist for: the reels `size` field offered spinning
+ * sizes (500–8000) and conventional sizes (12–30) in one row whatever type was chosen,
+ * so every number on it was ambiguous. A "4000 lever drag" is not a big reel, it is a
+ * category error.
+ */
+
+const allFields: { category: string; field: AttributeField }[] = TACKLE_CATEGORIES.flatMap(
+  (category) => category.fields.map((field) => ({ category: category.id, field })),
+);
+
+describe("dependent field schema", () => {
+  it("gives every optionsBy field a dependsOn that names a real field in the same category", () => {
+    for (const category of TACKLE_CATEGORIES) {
+      for (const field of category.fields) {
+        if (!field.optionsBy) continue;
+        expect(field.dependsOn, `${category.id}.${field.key}`).toBeTruthy();
+        expect(
+          category.fields.some((f) => f.key === field.dependsOn),
+          `${category.id}.${field.key} depends on "${field.dependsOn}", which is not a field here`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("puts a dependent field after its controller, so the controller is answered first", () => {
+    for (const category of TACKLE_CATEGORIES) {
+      category.fields.forEach((field, index) => {
+        if (!field.dependsOn) return;
+        const controllerIndex = category.fields.findIndex((f) => f.key === field.dependsOn);
+        expect(
+          controllerIndex,
+          `${category.id}.${field.key} is asked before the "${field.dependsOn}" it depends on`,
+        ).toBeLessThan(index);
+      });
+    }
+  });
+
+  it("offers every controlling value a set, so no choice leads to an empty row without a hint", () => {
+    for (const category of TACKLE_CATEGORIES) {
+      for (const field of category.fields) {
+        if (!field.optionsBy || !field.dependsOn) continue;
+        const controller = category.fields.find((f) => f.key === field.dependsOn)!;
+        for (const value of controller.options) {
+          const resolved = fieldOptions(field, { [field.dependsOn]: value });
+          expect(resolved.length, `${category.id}.${field.key} has nothing for ${value}`).toBeGreaterThan(0);
+        }
+        // Before the controller is answered there are no options, so there must be a hint.
+        expect(fieldOptions(field, {})).toHaveLength(0);
+        expect(field.emptyHint, `${category.id}.${field.key} needs an emptyHint`).toBeTruthy();
+      }
+    }
+  });
+
+  it("never mixes two numbering systems in one option list — the original bug", () => {
+    // Spinning thousands (>=1000) and line classes (<=130) in the same row is the
+    // signature of the defect. A list of pure ladder numbers must stay on one scale.
+    for (const { category, field } of allFields) {
+      const lists = field.optionsBy ? Object.values(field.optionsBy) : [field.options];
+      for (const list of lists) {
+        const numbers = list.filter((o) => /^\d+$/.test(o)).map(Number);
+        if (numbers.length < 2) continue;
+        const thousands = numbers.filter((n) => n >= 1000);
+        const classes = numbers.filter((n) => n <= 130);
+        expect(
+          thousands.length > 0 && classes.length > 0,
+          `${category}.${field.key} mixes spinning thousands with line classes: ${list.join(", ")}`,
+        ).toBe(false);
+      }
+    }
+  });
+});
+
+describe("reel sizes", () => {
+  const reels = TACKLE_CATEGORIES.find((c) => c.id === "reels")!;
+  const size = reels.fields.find((f) => f.key === "size")!;
+
+  it("gives a spinning reel thousands and a conventional reel line classes", () => {
+    expect(fieldOptions(size, { type: "Spinning" })).toContain("4000");
+    expect(fieldOptions(size, { type: "Spinning" })).not.toContain("30");
+    expect(fieldOptions(size, { type: "Conventional" })).toContain("30");
+    expect(fieldOptions(size, { type: "Conventional" })).not.toContain("4000");
+  });
+
+  it("goes far enough at both ends to cover the fish this app is for", () => {
+    // A 20000 popping reel and a 130-class marlin reel both exist on this coast.
+    expect(fieldOptions(size, { type: "Spinning" })).toContain("20000");
+    expect(fieldOptions(size, { type: "Lever drag" })).toContain("130");
+  });
+
+  it("keeps a size already saved against a different type — nothing is destroyed", () => {
+    // ADR 008: attributes are free text and ChoiceField treats an off-list value as
+    // custom, so no migration is owed and an old "20" on a spinning reel survives.
+    const resolved = fieldOptions(size, { type: "Spinning" });
+    expect(resolved).not.toContain("20");
+    expect(typeof "20").toBe("string");
+  });
+});

--- a/src/features/tackle/tackle-fixture.ts
+++ b/src/features/tackle/tackle-fixture.ts
@@ -130,3 +130,15 @@ export const TACKLE_FIXTURE: readonly TackleItem[] = [
     addedAt: Date.UTC(2026, 7, 18, 15, 0),
   },
 ];
+
+/**
+ * Whether an item is sample data rather than something the angler put in the box.
+ *
+ * The guided setup checklist needs this: the Tackle Box ships pre-seeded so the
+ * category form and low-stock states are visible on first load, which meant "add gear to
+ * your Tackle Box" rendered as already done for somebody who had never opened it. A
+ * checklist that ticks a box you did not tick teaches you not to trust the other four.
+ */
+export function isFixtureItem(item: { readonly id: string }): boolean {
+  return item.id.startsWith("fixture-");
+}

--- a/src/features/tackle/types.ts
+++ b/src/features/tackle/types.ts
@@ -34,7 +34,31 @@ export type AttributeField = {
   /** Ladder fields (hook sizes, pound test, weights) show every step; categorical
    *  fields default to 8 chips so rows stay tidy. */
   maxChips?: number;
+  /** Key of the field in the SAME category whose value selects this field's options.
+   *  Must appear before this field in `fields`, so it is answered first. */
+  dependsOn?: string;
+  /** Controlling value -> options. Exact match on the controlling field's value. */
+  optionsBy?: Readonly<Record<string, readonly string[]>>;
+  /** Shown in place of the chip row while the controller is still unset. */
+  emptyHint?: string;
 };
+
+/**
+ * The options a field offers right now. The ONLY place options are chosen (ADR 008).
+ *
+ * Reel sizes were the reason this exists: spinning reels are numbered in thousands and
+ * conventional reels in line classes, and both ladders were offered in one flat row
+ * whatever type you picked — which is why the sizes read as "too large or too broad".
+ * A field with no `optionsBy` is unaffected.
+ */
+export function fieldOptions(
+  field: AttributeField,
+  attributes: Record<string, string>,
+): readonly string[] {
+  if (!field.optionsBy) return field.options;
+  const controller = field.dependsOn ? attributes[field.dependsOn] ?? "" : "";
+  return field.optionsBy[controller] ?? field.options;
+}
 
 export type CategorySpec = {
   id: CategoryId;
@@ -343,10 +367,34 @@ export const TACKLE_CATEGORIES: readonly CategorySpec[] = [
         options: ["Conventional", "Spinning", "Baitcasting", "Lever drag", "Star drag"],
         placeholder: "e.g. Electric",
       },
+      /*
+        Size depends on type, because the two families do not share a scale. Spinning
+        reels run in thousands (a 4000 is a light inshore reel); conventionals and lever
+        drags run in line classes (a 30 is a 30-lb-class reel). Offering both ladders at
+        once, as this field did until 2026-09-04, makes every number meaningless — and
+        "4000" on a lever drag is not a large reel, it is a category error.
+
+        Ladders are the common real-world steps, not a manufacturer's full catalogue.
+        Anything off the list still goes in through Other…, which is also how a
+        brand-specific size like an Avet JX or a Shimano 300 gets recorded.
+      */
       {
         key: "size",
         label: "Size",
-        options: ["500", "1000", "2500", "3000", "4000", "5000", "6000", "8000", "12", "16", "20", "30"],
+        dependsOn: "type",
+        options: [],
+        emptyHint: "Pick a reel type first — spinning and conventional reels are sized differently.",
+        optionsBy: {
+          // Shimano/Daiwa-style thousands. 1000 is an ultralight trout reel; 20000 is a
+          // stand-up popping reel for tuna.
+          Spinning: ["1000", "2000", "2500", "3000", "4000", "5000", "6000", "8000", "10000", "14000", "18000", "20000"],
+          // Line class. 10 is a light bass reel; 80 and 130 are marlin.
+          Conventional: ["10", "12", "15", "16", "20", "25", "30", "40", "50", "60", "80"],
+          "Lever drag": ["12", "16", "20", "30", "40", "50", "60", "70", "80", "130"],
+          "Star drag": ["10", "12", "15", "16", "20", "25", "30", "40", "50"],
+          // Low-profile baitcasters run in hundreds.
+          Baitcasting: ["50", "100", "150", "200", "250", "300", "400"],
+        },
         placeholder: "e.g. 2-speed 30",
         maxChips: 12,
       },

--- a/src/lib/offline/db.ts
+++ b/src/lib/offline/db.ts
@@ -16,12 +16,12 @@
  * transactions, and nothing about what a catch is.
  */
 
-import { openDB, type DBSchema, type IDBPDatabase } from "idb";
+import { openDB, type DBSchema, type IDBPDatabase, type IDBPTransaction, type StoreNames } from "idb";
 
 import type { Mutation, SyncEntity } from "@/core/sync/outbox";
 
 /** Bump only with a migration in `upgrade` below. */
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 const DB_NAME = "fish-log-book";
 
 export const ENTITY_STORES = [
@@ -63,18 +63,67 @@ export function isIndexedDbAvailable(): boolean {
 export function getDb(): Promise<IDBPDatabase<FishLogDB>> {
   if (!dbPromise) {
     dbPromise = openDB<FishLogDB>(DB_NAME, DB_VERSION, {
-      upgrade(db, oldVersion) {
-        // v2 adds `location_condition`. Written as additive steps rather than a rebuild
-        // so an angler who already logged catches keeps them: a wipe-and-recreate here
-        // would silently destroy a local-first log that has never synced anywhere.
-        if (oldVersion >= 1) {
-          if (!db.objectStoreNames.contains("location_condition")) {
-            const locations = db.createObjectStore("location_condition", { keyPath: "id" });
-            locations.createIndex("by_trip", "trip_id");
-          }
-          return;
+      upgrade(db, oldVersion, _newVersion, tx) {
+        /*
+          Cumulative steps, each guarded by `oldVersion < n`, and NONE of them returns.
+
+          This used to be `if (oldVersion >= 1) { …; return; }`, which was correct for v2
+          and a trap for everything after it: any v3 step written below that `return`
+          would never run on a device that already had the database — only on a fresh
+          install. It would not error. The angler would just have a quietly wrong store.
+          Flagged by the architect in ADR 008 and confirmed here before the v3 step landed.
+
+          Additive rather than a rebuild, because a wipe-and-recreate would silently
+          destroy a local-first log that has never synced anywhere.
+        */
+        if (oldVersion < 1) {
+          createInitialStores(db);
         }
 
+        if (oldVersion < 2 && !db.objectStoreNames.contains("location_condition")) {
+          const locations = db.createObjectStore("location_condition", { keyPath: "id" });
+          locations.createIndex("by_trip", "trip_id");
+        }
+
+        if (oldVersion > 0 && oldVersion < 3) {
+          void backfillQuiverIds(tx);
+        }
+      },
+    });
+  }
+  return dbPromise;
+}
+
+/**
+ * v3: every rod setup gets a `quiver_id` naming the lineage it belongs to (ADR 008).
+ *
+ * Existing rows have no linking data, so the best available grouping is `(trip_id, slot)`
+ * — the rod as it existed within one trip. Consequence, stated plainly because it is
+ * visible to the angler: a rod that was "the same rod" across two different trips becomes
+ * two Quiver entries. The information to do better was never recorded.
+ *
+ * Runs inside the version-change transaction, so it either completes or the upgrade
+ * fails and nothing is half-migrated.
+ */
+function backfillQuiverIds(tx: IDBPTransaction<FishLogDB, ArrayLike<StoreNames<FishLogDB>>, "versionchange">): void {
+  const store = tx.objectStore("trip_rig");
+  void store.getAll().then(async (rows: StoredRow[]) => {
+    const byLineage = new Map<string, string>();
+    for (const row of rows) {
+      if (typeof row.quiver_id === "string" && row.quiver_id.length > 0) continue;
+      const key = `${String(row.trip_id)}:${String(row.slot)}`;
+      let quiverId = byLineage.get(key);
+      if (!quiverId) {
+        quiverId = crypto.randomUUID();
+        byLineage.set(key, quiverId);
+      }
+      await store.put({ ...row, quiver_id: quiverId });
+    }
+  });
+}
+
+function createInitialStores(db: IDBPDatabase<FishLogDB>): void {
+  {
         db.createObjectStore("trip", { keyPath: "id" });
 
         const rig = db.createObjectStore("trip_rig", { keyPath: "id" });
@@ -100,10 +149,7 @@ export function getDb(): Promise<IDBPDatabase<FishLogDB>> {
 
         db.createObjectStore("meta");
         db.createObjectStore("media", { keyPath: "id" });
-      },
-    });
   }
-  return dbPromise;
 }
 
 /**


### PR DESCRIPTION
The founder's 2026-09-04 UX brief, complete — all four asks. Spec at `docs/specs/setup-flow-and-quiver.md`, with the founder's words verbatim and a repository reality check written *before* implementation, because two of the four rested on assumptions the code did not support.

Rulings by the two roles the founder named: **ADR 008** (architect) and **`docs/design/12-guided-setup-and-quiver.md`** (ux-ui).

## §2 The Quiver

No schema change and no new concept were needed. `Put away` already wrote a retired revision rather than deleting, so every setup was still there. What was missing was anywhere to see them, a way to fish one again, and a word to the angler saying where the rod went — **that last one is the only reason it read as destructive.**

`quiver_id` is what makes two revisions the same rod. Slot cannot do that job: `nextRodSlot` scopes slots to a trip, so Rod 1 in June and Rod 1 in July are unrelated. Name and gear cannot either — both change when you re-rig, which is the normal act. Re-rigging now passes the lineage through, or every leader change would fork a second entry for the same rod.

Grouping, which revision is latest, whether a rod is already out, and what the next revision looks like all live in `core/rules/catch/quiver.ts`. **None of it is in a component** — grouping inside a `useMemo` looks harmless and is exactly what ADR 003 exists to stop, because the Swift client cannot see a `useMemo`.

Setup is now the trip-preparation hub in the design's order: Today's rods → Quiver → Location & Conditions → Tackle Box. "Today's locations" became "Location & Conditions" because steps 1 and 4 are the same sheet and the old name described half of it. Put away keeps its name — the button was never the problem — and now says *"Put away — saved in your Quiver."* No confirmation dialog: the house rule prefers undo, and taxing every angler to guard against a one-tap mistake is the wrong trade.

## §1 The guided checklist

**A step is a memory that something was done once, not a readout of today.** Steps 1 and 4 are per-trip data; asking "is there a location on *this* trip" would reset the card every outing for somebody who has fished for a decade — the nagging failure the founder named.

I argued the opposite earlier in the day: that deriving from live data would be self-correcting where a stored flag could drift. **That was wrong.** Deriving answers "do you have tackle now", not "have you ever added tackle", and those differ in exactly the case that matters — an angler who clears out their box should not be marched back through the tutorial. So it latches: derive, union with what the device remembers, one-way. Vectors cover both latch cases, which are the ones a second client would get wrong.

Once all five are done the card collapses to one 82px line — *"Setup complete"* and *Review* — and never re-expands.

### A defect in my own feature, found by driving it rather than by a test

The Tackle Box ships pre-seeded with twelve sample items so the category form and low-stock states are visible on first load. So **step 2 rendered as *Done* for somebody who had never opened it.** A checklist that ticks a box you did not tick teaches you not to trust the other four. Sample items are now excluded, and a fresh profile starts with nothing done.

## §4 Fish Legal — worse than reported

The brief assumed the boundaries page was California-only. It was not. `boundary-map.tsx` computed a California view and fell back to `FLORIDA.areas` centred on `[26.5, -82.5]` for everything else — **36 of the ~45 regions.** A Washington, Texas or Maine angler was shown a map of southwest Florida; Florida itself reached its own data only by being the fallback.

Renaming the card to "California Depth & Boundaries" would have been *inaccurate* and would have hidden the defect. Instead `boundary-coverage.ts` owns which regions have verified data — extracted rather than inline because two screens must now agree, and a disagreement between them is how the fallback survived unnoticed. A region with no data gets an honest empty state and no map. The active region renders in the accent colour, and **Change** is a real tap target.

## §3 Reel sizes

The diagnosis was exactly right: spinning sizes and conventional sizes shared one flat row, so every number was ambiguous — "4000" on a lever drag is a category error. Now type-scoped via one pure `fieldOptions` (ADR 008 ruling 2). Spinning 1000–20000, conventional 10–80, lever drag 12–130, star drag, baitcasting. No migration: a reel already saved as "20" keeps its value. A test forbids any list mixing the two scales.

## The migration trap

`db.ts` had `if (oldVersion >= 1) { …; return; }` — correct for v2, and a trap for everything after: any v3 step below that `return` **would never run on a device that already had the database.** No error, no warning; first symptom would be an empty-looking Quiver full of rods that are really there. Flagged by the architect, confirmed in the code, and tested against **a hand-built v2 database rather than a fresh one** — the only way this class of bug shows up. Now cumulative `if (oldVersion < n)` steps, none returning.

The v3 backfill groups legacy rows by `(trip_id, slot)` inside the version-change transaction. Consequence stated plainly in the code because the angler can see it: a rod that was "the same rod" across two trips becomes two Quiver entries, because the linking data never existed.

## Completion checks from the brief

| Check | |
|---|---|
| Five-step workflow clear on a phone | ✅ 320px, no overflow |
| Every step links to the right destination | ✅ |
| Put Away preserves the rod in the Quiver | ✅ |
| A saved rod returns to Today's Setup without rebuilding | ✅ |
| Reel sizes change with reel type | ✅ |
| Fish Legal shows the active jurisdiction | ✅ accent colour |
| California-only boundary data never shown as universal | ✅ and no other state's either |
| Existing rods, catches, settings, Fish Legal data keep working | ✅ migration tested on a real v2 database |

## Verification

`npm run verify` — tokens clean, tripwires clean, **0 lint errors** (8 pre-existing warnings), `tsc --noEmit` clean, **692 tests**. Production build green.

Chromium at 320px, end to end: build a rod → put it away → it lands in the Quiver → bring it back → the latch survives a reload. Plus the collapsed state, a junk value in storage, boundaries across four regions, and reel sizes switching with type. No console errors anywhere.

## Not covered here

The founder's direction stands that the log stays on-device for now; nothing here adds a server round trip. `supabase/migrations/…v1_core_schema.sql`'s `trip_rig` is already behind the local record (no `slot`, `name`, `setup_type`, `gear`, `retired_at`) — whoever closes that gap must also add `quiver_id` and swap `unique (trip_id, revision)` for `unique (quiver_id, revision)`. Recorded in ADR 008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173H7NUFw6hjnumRw4GLbi3