### PR TITLE
Checklist step 1 is the region, and a tide station step joins the list

### DIFF
--- a/docs/design/12-guided-setup-and-quiver.md
+++ b/docs/design/12-guided-setup-and-quiver.md
@@ -31,6 +31,18 @@ not have to re-derive them:
 
 ## Part 1 — the five-step guided checklist
 
+> **Superseded in part, founder 2026-09-04 (after first review).** There are now SIX
+> steps, and step 1 changed meaning: it is "choose your fishing region" in Settings, not
+> "set a fishing location". Location and conditions merged into one step — this document
+> reached the same conclusion in 1.1's own note that both rows pointed at the same sheet.
+> A tide station step was added at position 2, beside the region, since both are one-time
+> Settings choices. Final order: region → tide station → tackle → rod setup → location and
+> conditions → log a fish. Region and station ship with defaults, so "done" for those two
+> means the angler actually chose, via `LocalPreference.useIsSet`, not that a value
+> exists. Everything else below — the latch, the row copy pattern, the collapsed state,
+> the Setup reorder, and the whole of Parts 2 and 3 — stands as written. See
+> `docs/specs/setup-flow-and-quiver.md` §5.5.
+
 ### 1.1 The five steps, their destination, and what "done" means
 
 This is the most important table in the document. Read the two right-hand columns

--- a/docs/specs/setup-flow-and-quiver.md
+++ b/docs/specs/setup-flow-and-quiver.md
@@ -185,6 +185,31 @@ Quiver lives).
 
 ---
 
+## 5.5 Founder correction, 2026-09-04 (after first review)
+
+The five steps became six, and step 1 changed meaning.
+
+1. **Step 1 is "choose your fishing region", in Settings — not "set a location".** The
+   original list conflated two different acts: picking the *jurisdiction* whose rules and
+   species the app shows you, and naming *a place* you are fishing today. Only the second
+   is a location.
+2. **Location and conditions are one step, not two.** They are the same sheet
+   (`LocationSheet`), distinguished only by which optional fields got filled in — the UX
+   review found this independently. Two rows pointing at one destination taught an order
+   that does not exist.
+3. **A tide station step was added.** Placed at 2, next to the region, because both are
+   one-time Settings choices answering the same question — where do you fish? — and
+   grouping them means one trip to Settings instead of two.
+
+Final order: region → tide station → tackle → rod setup → location and conditions →
+log a fish.
+
+**Consequence for the "done" test.** Region and tide station both ship with a default
+(Southern California; Newport Bay), so their *value* cannot say whether the angler chose
+it. `LocalPreference.useIsSet` answers that instead, and ticking either step requires an
+actual choice — otherwise the checklist would greet a new angler with two steps already
+done, which teaches them it is decorative.
+
 ## 6. Information architecture — decided
 
 Founder, 2026-09-04, answering the three questions §5 raised. These are settled; the

--- a/docs/team/worklog/2026-09-04-10-head-dev.md
+++ b/docs/team/worklog/2026-09-04-10-head-dev.md
@@ -1,0 +1,40 @@
+### 2026-09-04 | head-dev | 1h
+
+- Founder review of the checklist. Two corrections and an addition, all of them right.
+- **Step 1 was wrong.** It said "set a fishing location" when the founder meant "choose
+  your fishing region". Those are different acts: one picks the jurisdiction whose rules
+  and species the app shows you, the other names a place you are fishing today. I had
+  read the original list too literally and never questioned it.
+- **Location and conditions collapse into one step.** They are the same sheet, separated
+  only by which optional fields get filled in — `ux-ui` found this independently in the
+  design review and I built it as two rows anyway, both pointing at `/setup`. Two rows to
+  one destination teach an order that does not exist.
+- **Added a tide station step**, at position 2. The founder did not say where it goes.
+  Put it beside the region because both are one-time Settings choices answering the same
+  question — where do you fish — so the angler makes one trip to Settings, not two. Easy
+  to move if that reads wrong on the water.
+- The interesting part is what "done" means for those two. Both preferences ship with a
+  default — Southern California, Newport Bay — so their *value* cannot tell you whether
+  the angler chose it. A new angler would have opened the app to two steps already
+  ticked, which is the same defect as the tackle fixture ticking step 2 yesterday, and it
+  teaches the same lesson: the checklist is decorative.
+- So `LocalPreference` gained `useIsSet`, which answers "has this key ever been written"
+  rather than "what is the value". Both steps now need a real choice.
+- That new method is a hook, and my own tripwire from the legal work would not have
+  caught it: it matched `.use()` exactly, and the React Compiler hazard applies to any
+  `.useSomething()` member call — the compiler does not care what the method is named,
+  only that a member expression is not a name it recognises. Widened it before writing
+  the method that would have slipped past it.
+- Six steps now: region → tide station → tackle → rod setup → location and conditions →
+  log a fish. Vectors updated, including the two that pin the new rule — a default region
+  does not tick step 1, and choosing one ticks step 1 and nothing else.
+- Recorded the correction in the spec (§5.5) and as a superseding note at the top of
+  design 12 §1.1, rather than editing the design silently. The rest of that document
+  stands and should still be read.
+- Checks: tripwires clean, 0 lint errors, tsc clean, 693 tests, build green. Drove it in
+  Chromium at 320px: fresh profile shows six steps with none done, choosing a region
+  ticks only step 1, picking a station ticks only step 2, and the latch records each.
+- Files: src/core/rules/setup-progress.ts + test + vectors, src/features/settings/preference.ts,
+  src/features/settings/region.ts, src/features/conditions/station-preference.ts,
+  src/features/setup/components/setup-checklist.tsx, scripts/check-tripwires.mjs,
+  docs/specs/setup-flow-and-quiver.md, docs/design/12-guided-setup-and-quiver.md.

--- a/scripts/check-tripwires.mjs
+++ b/scripts/check-tripwires.mjs
@@ -109,14 +109,17 @@ if (existsSync(RULES_DIR)) {
  * never appears to have been saved.
  *
  * Caught in the legal-notices work, where the acknowledgement asked again on every visit.
- * `createLocalPreference` returns `.use()` for a named wrapper to call, and that wrapper
- * is the only place it may be called from.
+ * `createLocalPreference` returns `.use()` and `.useIsSet()` for a named wrapper to call,
+ * and that wrapper is the only place either may be called from. Any `.useSomething()`
+ * member call counts: the compiler does not care what the method is named, only that a
+ * member expression is not a name it recognises as a hook.
  */
-const PREF_WRAPPERS = /export function use[A-Z]\w*\s*\([^)]*\)\s*\{\s*return \w+\.use\(\)/;
+const PREF_WRAPPERS =
+  /export function use[A-Z]\w*\s*\([^)]*\)\s*(?::[^{]+)?\{\s*return \w+\.use[A-Za-z]*\(/;
 for (const file of tracked("'src/*'")) {
   if (!/\.tsx?$/.test(file) || file.endsWith(".test.ts") || file.endsWith(".test.tsx")) continue;
   const text = readFileSync(file, "utf8");
-  if (!/\w+\.use\(\)/.test(text)) continue;
+  if (!/\b\w+\.use[A-Za-z]*\(\)/.test(text)) continue;
   if (PREF_WRAPPERS.test(text)) continue;
   failures.push(
     `${file} calls \`.use()\` directly. React Compiler recognises hooks by name, so a ` +

--- a/src/core/rules/setup-progress.test.ts
+++ b/src/core/rules/setup-progress.test.ts
@@ -79,6 +79,8 @@ describe("setup progress vectors", () => {
         catches: number;
         catchState?: string;
         catchDeleted?: boolean;
+        regionChosen: boolean;
+        stationChosen: boolean;
       };
 
       const observed = observedSteps({
@@ -89,6 +91,8 @@ describe("setup progress vectors", () => {
           log.catches > 0
             ? [catchRecord(log.catchState ?? "confirmed", log.catchDeleted ?? false)]
             : [],
+        regionChosen: log.regionChosen,
+        stationChosen: log.stationChosen,
       });
 
       const latched = new Set(vector.latched as SetupStepId[]);

--- a/src/core/rules/setup-progress.ts
+++ b/src/core/rules/setup-progress.ts
@@ -19,7 +19,14 @@ import type { CatchRecord, LocationConditionRecord, RigRecord } from "./catch/ty
  * unions it with what the log shows now.
  */
 
-export const SETUP_STEPS = ["location", "tackle", "rod", "conditions", "catch"] as const;
+export const SETUP_STEPS = [
+  "region",
+  "station",
+  "tackle",
+  "rod",
+  "location",
+  "catch",
+] as const;
 
 export type SetupStepId = (typeof SETUP_STEPS)[number];
 
@@ -32,10 +39,21 @@ export interface SetupStep {
 }
 
 const COPY: Record<SetupStepId, { label: string; hint: string; href: string }> = {
-  location: {
-    label: "Set a fishing location",
-    hint: "Where are you fishing?",
-    href: "/setup",
+  /*
+    Region and tide station are both one-time Settings choices, so they sit together:
+    the angler makes one trip to Settings instead of two, and both answer the same
+    question — where do you fish? Founder correction 2026-09-04: step 1 is the REGION,
+    not a location. They are different acts, and conflating them was the error.
+  */
+  region: {
+    label: "Choose your fishing region",
+    hint: "Which state's rules and species the app shows you.",
+    href: "/settings",
+  },
+  station: {
+    label: "Pick your tide station",
+    hint: "The nearest NOAA station, so the tides match your water.",
+    href: "/settings",
   },
   tackle: {
     label: "Add gear to your Tackle Box",
@@ -47,9 +65,15 @@ const COPY: Record<SetupStepId, { label: string; hint: string; href: string }> =
     hint: "Pair your gear into a rod you can fish with.",
     href: "/setup",
   },
-  conditions: {
-    label: "Add today's conditions",
-    hint: "Current, structure, water — what you see out there.",
+  /*
+    One step, not two. The founder's original list separated "set a location" from "add
+    conditions", and the design review found they are the same sheet — a location IS its
+    conditions, distinguished only by which optional fields got filled in. Two rows
+    pointing at one destination taught an order that does not exist.
+  */
+  location: {
+    label: "Set your location and conditions",
+    hint: "Where you're fishing, and what the water is doing.",
     href: "/setup",
   },
   catch: {
@@ -59,21 +83,6 @@ const COPY: Record<SetupStepId, { label: string; hint: string; href: string }> =
   },
 };
 
-/**
- * A location counts for step 4 once it carries an observation, not just a name. Naming a
- * spot and describing the water are two different acts, and the founder listed them as
- * two different steps.
- */
-function hasConditions(location: LocationConditionRecord): boolean {
-  return (
-    location.current_term !== null ||
-    location.current_strength !== null ||
-    location.structure_type_ids.length > 0 ||
-    location.bottom_depth_m !== null ||
-    location.water_color_id !== null ||
-    location.water_clarity_id !== null
-  );
-}
 
 /** What the log shows right now. Not the answer on its own — see the latch above. */
 export function observedSteps(input: {
@@ -81,14 +90,17 @@ export function observedSteps(input: {
   readonly rigs: readonly RigRecord[];
   readonly locations: readonly LocationConditionRecord[];
   readonly tackleItemCount: number;
+  /** Chosen in Settings, not merely defaulted — see `LocalPreference.useIsSet`. */
+  readonly regionChosen: boolean;
+  readonly stationChosen: boolean;
 }): ReadonlySet<SetupStepId> {
   const live = new Set<SetupStepId>();
-  const locations = input.locations.filter((l) => l.deleted_at === null);
 
-  if (locations.length > 0) live.add("location");
+  if (input.regionChosen) live.add("region");
+  if (input.stationChosen) live.add("station");
   if (input.tackleItemCount > 0) live.add("tackle");
   if (input.rigs.length > 0) live.add("rod");
-  if (locations.some(hasConditions)) live.add("conditions");
+  if (input.locations.some((l) => l.deleted_at === null)) live.add("location");
   if (input.catches.some((c) => c.deleted_at === null)) live.add("catch");
 
   return live;

--- a/src/core/rules/vectors/setup-progress.json
+++ b/src/core/rules/vectors/setup-progress.json
@@ -1,43 +1,51 @@
 {
-  "$comment": "Vectors for src/core/rules/setup-progress.ts (ADR 003 §4). The five-step guided setup checklist. Cases are written compactly and expanded in setup-progress.test.ts: `locations` entries list only the condition fields that are set, `latched` is what the device already remembers, and `expectDone` is the set of step ids that must render as done. The load-bearing behaviour is the LATCH — a step, once true, never goes back to false, because the checklist is a memory that something was done once and not a readout of today's trip.",
+  "$comment": "Vectors for src/core/rules/setup-progress.ts (ADR 003 §4). The six-step guided setup checklist. Cases are written compactly and expanded in setup-progress.test.ts. Two things carry the design. First, the LATCH: a step, once true, never goes back to false, because the checklist is a memory that something was done once and not a readout of today's trip. Second, `regionChosen`/`stationChosen` mean the angler picked one in Settings — NOT that the preference has a value, since both ship with a default and 'Southern California' reads the same whether it was chosen or shipped.",
 
   "cases": [
     {
       "name": "a brand new angler has nothing done",
       "latched": [],
-      "log": { "locations": [], "tackleItemCount": 0, "rigs": 0, "catches": 0 },
+      "log": { "locations": [], "tackleItemCount": 0, "rigs": 0, "catches": 0, "regionChosen": false, "stationChosen": false },
       "expectDone": [],
       "expectLatch": [],
       "expectAllDone": false
     },
     {
-      "name": "naming a spot completes step 1 but not step 4 — naming and describing are different acts",
+      "name": "living with the default region does not tick the region step",
       "latched": [],
-      "log": { "locations": [{ "named": true }], "tackleItemCount": 0, "rigs": 0, "catches": 0 },
+      "log": { "locations": [], "tackleItemCount": 0, "rigs": 0, "catches": 0, "regionChosen": false, "stationChosen": false },
+      "expectDone": [],
+      "expectLatch": [],
+      "expectAllDone": false
+    },
+    {
+      "name": "choosing a region in Settings ticks step 1 and nothing else",
+      "latched": [],
+      "log": { "locations": [], "tackleItemCount": 0, "rigs": 0, "catches": 0, "regionChosen": true, "stationChosen": false },
+      "expectDone": ["region"],
+      "expectLatch": ["region"],
+      "expectAllDone": false
+    },
+    {
+      "name": "picking a tide station ticks step 2 independently of the region",
+      "latched": [],
+      "log": { "locations": [], "tackleItemCount": 0, "rigs": 0, "catches": 0, "regionChosen": false, "stationChosen": true },
+      "expectDone": ["station"],
+      "expectLatch": ["station"],
+      "expectAllDone": false
+    },
+    {
+      "name": "a saved location is one step now — location and conditions are the same act",
+      "latched": [],
+      "log": { "locations": [{ "named": true }], "tackleItemCount": 0, "rigs": 0, "catches": 0, "regionChosen": false, "stationChosen": false },
       "expectDone": ["location"],
       "expectLatch": ["location"],
       "expectAllDone": false
     },
     {
-      "name": "any single observation on a location completes the conditions step",
+      "name": "a deleted location does not count",
       "latched": [],
-      "log": { "locations": [{ "named": true, "current_term": "uphill" }], "tackleItemCount": 0, "rigs": 0, "catches": 0 },
-      "expectDone": ["location", "conditions"],
-      "expectLatch": ["location", "conditions"],
-      "expectAllDone": false
-    },
-    {
-      "name": "structure alone counts too — no single field is privileged",
-      "latched": [],
-      "log": { "locations": [{ "named": true, "structure_type_ids": ["kelp"] }], "tackleItemCount": 0, "rigs": 0, "catches": 0 },
-      "expectDone": ["location", "conditions"],
-      "expectLatch": ["location", "conditions"],
-      "expectAllDone": false
-    },
-    {
-      "name": "a deleted location does not count for either step",
-      "latched": [],
-      "log": { "locations": [{ "named": true, "current_term": "uphill", "deleted": true }], "tackleItemCount": 0, "rigs": 0, "catches": 0 },
+      "log": { "locations": [{ "named": true, "deleted": true }], "tackleItemCount": 0, "rigs": 0, "catches": 0, "regionChosen": false, "stationChosen": false },
       "expectDone": [],
       "expectLatch": [],
       "expectAllDone": false
@@ -45,15 +53,15 @@
     {
       "name": "a retired rod still counts — the angler has built one",
       "latched": [],
-      "log": { "locations": [], "tackleItemCount": 0, "rigs": 1, "rigsRetired": true, "catches": 0 },
+      "log": { "locations": [], "tackleItemCount": 0, "rigs": 1, "rigsRetired": true, "catches": 0, "regionChosen": false, "stationChosen": false },
       "expectDone": ["rod"],
       "expectLatch": ["rod"],
       "expectAllDone": false
     },
     {
-      "name": "an unresolved quick mark is still a logged catch for the purposes of the checklist",
+      "name": "an unresolved quick mark is still a logged catch for the checklist",
       "latched": [],
-      "log": { "locations": [], "tackleItemCount": 0, "rigs": 0, "catches": 1, "catchState": "unresolved" },
+      "log": { "locations": [], "tackleItemCount": 0, "rigs": 0, "catches": 1, "catchState": "unresolved", "regionChosen": false, "stationChosen": false },
       "expectDone": ["catch"],
       "expectLatch": ["catch"],
       "expectAllDone": false
@@ -61,7 +69,7 @@
     {
       "name": "a deleted catch does not count",
       "latched": [],
-      "log": { "locations": [], "tackleItemCount": 0, "rigs": 0, "catches": 1, "catchDeleted": true },
+      "log": { "locations": [], "tackleItemCount": 0, "rigs": 0, "catches": 1, "catchDeleted": true, "regionChosen": false, "stationChosen": false },
       "expectDone": [],
       "expectLatch": [],
       "expectAllDone": false
@@ -69,45 +77,47 @@
     {
       "name": "THE LATCH: clearing the tackle box does not un-teach the angler",
       "latched": ["tackle"],
-      "log": { "locations": [], "tackleItemCount": 0, "rigs": 0, "catches": 0 },
+      "log": { "locations": [], "tackleItemCount": 0, "rigs": 0, "catches": 0, "regionChosen": false, "stationChosen": false },
       "expectDone": ["tackle"],
       "expectLatch": [],
       "expectAllDone": false
     },
     {
-      "name": "THE LATCH: a new trip with no location of its own keeps steps 1 and 4 done",
-      "latched": ["location", "conditions"],
-      "log": { "locations": [], "tackleItemCount": 0, "rigs": 0, "catches": 0 },
-      "expectDone": ["location", "conditions"],
+      "name": "THE LATCH: a new trip with no location of its own keeps step 5 done",
+      "latched": ["location"],
+      "log": { "locations": [], "tackleItemCount": 0, "rigs": 0, "catches": 0, "regionChosen": false, "stationChosen": false },
+      "expectDone": ["location"],
       "expectLatch": [],
       "expectAllDone": false
     },
     {
       "name": "a latched step and a live one union rather than replace",
       "latched": ["catch"],
-      "log": { "locations": [], "tackleItemCount": 3, "rigs": 0, "catches": 0 },
+      "log": { "locations": [], "tackleItemCount": 3, "rigs": 0, "catches": 0, "regionChosen": false, "stationChosen": false },
       "expectDone": ["tackle", "catch"],
       "expectLatch": ["tackle"],
       "expectAllDone": false
     },
     {
-      "name": "all five done collapses the card",
+      "name": "all six done collapses the card",
       "latched": [],
       "log": {
-        "locations": [{ "named": true, "water_clarity_id": "clear" }],
+        "locations": [{ "named": true }],
         "tackleItemCount": 2,
         "rigs": 1,
-        "catches": 1
+        "catches": 1,
+        "regionChosen": true,
+        "stationChosen": true
       },
-      "expectDone": ["location", "tackle", "rod", "conditions", "catch"],
-      "expectLatch": ["location", "tackle", "rod", "conditions", "catch"],
+      "expectDone": ["region", "station", "tackle", "rod", "location", "catch"],
+      "expectLatch": ["region", "station", "tackle", "rod", "location", "catch"],
       "expectAllDone": true
     },
     {
-      "name": "all five done entirely from the latch, with an empty log",
-      "latched": ["location", "tackle", "rod", "conditions", "catch"],
-      "log": { "locations": [], "tackleItemCount": 0, "rigs": 0, "catches": 0 },
-      "expectDone": ["location", "tackle", "rod", "conditions", "catch"],
+      "name": "all six done entirely from the latch, with an empty log and default settings",
+      "latched": ["region", "station", "tackle", "rod", "location", "catch"],
+      "log": { "locations": [], "tackleItemCount": 0, "rigs": 0, "catches": 0, "regionChosen": false, "stationChosen": false },
+      "expectDone": ["region", "station", "tackle", "rod", "location", "catch"],
       "expectLatch": [],
       "expectAllDone": true
     }

--- a/src/features/conditions/station-preference.ts
+++ b/src/features/conditions/station-preference.ts
@@ -19,3 +19,8 @@ const preference = createLocalPreference<string>({
 export const useTideStationPreference = preference.use;
 export const setTideStationPreference = preference.set;
 export const readTideStationPreference = preference.read;
+
+/** Whether the angler has picked a station, rather than living with Newport Bay. */
+export function useTideStationChosen(): boolean {
+  return preference.useIsSet();
+}

--- a/src/features/settings/preference.ts
+++ b/src/features/settings/preference.ts
@@ -32,6 +32,15 @@ export interface LocalPreference<T> {
   set: (next: T) => void;
   /** Reads the value outside React (snapshot builders, engine calls). */
   read: () => T;
+  /**
+   * Whether the angler has ever chosen, as opposed to living with the default.
+   *
+   * A preference with a default cannot answer this from its value: "Southern California"
+   * means the same thing whether it was picked or shipped. The guided setup checklist
+   * needs the difference, because ticking "choose your region" for somebody who never
+   * opened Settings teaches them the checklist is decorative.
+   */
+  useIsSet: () => boolean;
   readonly defaultValue: T;
 }
 
@@ -95,5 +104,35 @@ export function createLocalPreference<T>(options: {
     return [value, update] as const;
   }
 
-  return { use, set, read, defaultValue };
+  function useIsSet(): boolean {
+    const latest = useRef(false);
+
+    const subscribe = useCallback((onStoreChange: () => void) => {
+      const sync = () => {
+        try {
+          latest.current = window.localStorage.getItem(key) !== null;
+        } catch {
+          latest.current = false;
+        }
+        onStoreChange();
+      };
+      sync();
+      window.addEventListener(changeEvent, sync);
+      window.addEventListener("storage", sync);
+      return () => {
+        window.removeEventListener(changeEvent, sync);
+        window.removeEventListener("storage", sync);
+      };
+    }, []);
+
+    // Same hydration handling as `use`: the ref is only ever written from `subscribe`,
+    // which React calls after mount and never during render.
+    return useSyncExternalStore(
+      subscribe,
+      useCallback(() => latest.current, []),
+      () => false,
+    );
+  }
+
+  return { use, set, read, useIsSet, defaultValue };
 }

--- a/src/features/settings/region.ts
+++ b/src/features/settings/region.ts
@@ -22,3 +22,8 @@ export const regionPreference = createLocalPreference<RegionId>({
 export function useRegionPreference() {
   return regionPreference.use();
 }
+
+/** Whether the angler has chosen a region, rather than living with the default. */
+export function useRegionChosen(): boolean {
+  return regionPreference.useIsSet();
+}

--- a/src/features/setup/components/setup-checklist.tsx
+++ b/src/features/setup/components/setup-checklist.tsx
@@ -9,7 +9,9 @@ import {
   setupSteps,
   stepsToLatch,
 } from "@/core/rules/setup-progress";
+import { useTideStationChosen } from "@/features/conditions/station-preference";
 import { useLog } from "@/features/catches/store";
+import { useRegionChosen } from "@/features/settings/region";
 import { CARD_CLASS, FOCUS_RING } from "@/features/catches/ui-classes";
 import { useTackleSession } from "@/features/tackle/session-store";
 import { isFixtureItem } from "@/features/tackle/tackle-fixture";
@@ -31,6 +33,11 @@ export function SetupChecklist() {
   const state = useLog();
   const tackle = useTackleSession();
   const [latched] = useSetupLatch();
+  // Chosen in Settings, not merely defaulted: both preferences ship with a value, and
+  // ticking "choose your region" for somebody who never opened Settings would teach them
+  // the checklist is decorative.
+  const regionChosen = useRegionChosen();
+  const stationChosen = useTideStationChosen();
 
   const observed = useMemo(
     () =>
@@ -40,8 +47,10 @@ export function SetupChecklist() {
         locations: state.locations,
         // Sample data is not the angler's gear — see `isFixtureItem`.
         tackleItemCount: tackle.items.filter((item) => !isFixtureItem(item)).length,
+        regionChosen,
+        stationChosen,
       }),
-    [state.catches, state.rigs, state.locations, tackle.items],
+    [state.catches, state.rigs, state.locations, tackle.items, regionChosen, stationChosen],
   );
 
   const latchedSet = useMemo(() => new Set(latched), [latched]);


### PR DESCRIPTION
The founder's checklist correction. It was pushed minutes after PR #58 merged, so it missed that merge — `main` still carries the five-step version where step 1 reads "Set a fishing location" and links to `/setup`, which is the behaviour the founder reported.

One commit.

## The corrections

**Step 1 was wrong.** It said "set a fishing location" when it meant "choose your fishing region". Those are different acts: one picks the jurisdiction whose rules and species the app shows you, the other names a place you are fishing today. The original list was read too literally and never questioned.

**Location and conditions collapse into one step.** They are the same sheet, separated only by which optional fields get filled in — `ux-ui` found this independently in the design review, and it was built as two rows anyway, both pointing at `/setup`. Two rows to one destination teach an order that does not exist.

**A tide station step joins, at position 2.** The founder did not say where it goes. It sits beside the region because both are one-time Settings choices answering the same question — where do you fish — so the angler makes one trip to Settings rather than two. A one-line move if it reads better elsewhere.

Final order: region → tide station → tackle → rod setup → location and conditions → log a fish.

## What "done" means for the two Settings steps

Both preferences ship with a default — Southern California, Newport Bay — so their **value** cannot say whether the angler chose it. Left alone, a new angler would open the app to two steps already ticked. That is the same defect as the tackle fixture ticking step 2, and it teaches the same lesson: that the checklist is decorative.

`LocalPreference` gained `useIsSet`, which answers "has this key ever been written" rather than "what is the value". Both steps now require an actual choice.

## A gap in the tripwire, closed before it was needed

`useIsSet` is a hook, and the tripwire added during the legal work **would not have caught it**: it matched `.use()` exactly, while the React Compiler hazard applies to any `.useSomething()` member call — the compiler does not care what the method is named, only that a member expression is not a name it recognises as a hook. Widened before writing the method that would have slipped past it.

## Documentation

Recorded in the spec (§5.5) and as a superseding note at the top of design 12 §1.1, rather than edited in silently. The rest of that design document stands and should still be read — the latch, the row copy, the collapsed state, the Setup reorder and the whole of the Quiver design are unchanged.

## Verification

`npm run verify` — tripwires clean, **0 lint errors** (8 pre-existing warnings), `tsc --noEmit` clean, **693 tests**. Production build green.

Chromium at 320px: a fresh profile shows six steps with none done; choosing a region ticks only step 1; picking a station ticks only step 2; the latch records each; no overflow; no console errors. Vectors pin the new rule — a default region does not tick step 1, and choosing one ticks step 1 and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173H7NUFw6hjnumRw4GLbi3

---
_Generated by [Claude Code](https://claude.ai/code/session_0173H7NUFw6hjnumRw4GLbi3)_