### PR TITLE
DE/MA/NH/RI leftover digest v2

### DIFF
--- a/src/features/fish-legal/atlantic-wave1.test.ts
+++ b/src/features/fish-legal/atlantic-wave1.test.ts
@@ -60,4 +60,8 @@ describe("Atlantic wave 1 — Massachusetts pack (DMF table, 2026-04-28)", () =>
     const card = regulationCard(MASSACHUSETTS, "ma-statewide", "ocean_pout", TODAY, "boat");
     expect(card!.verdict).toBe("release");
   });
+
+  it("American shad is prohibited in salt waters (other waters)", () => {
+    expect(regulationCard(MASSACHUSETTS, "ma-statewide", "american_shad", TODAY, "boat")!.verdict).toBe("release");
+  });
 });

--- a/src/features/fish-legal/atlantic-wave2.test.ts
+++ b/src/features/fish-legal/atlantic-wave2.test.ts
@@ -72,4 +72,11 @@ describe("Atlantic wave 2 — RI / NY / NJ", () => {
     expect(regulationCard(NEW_JERSEY, "nj-marine", "spanish_mackerel", TODAY, "boat")!.bagDaily).toBe(10);
     expect(regulationCard(NEW_JERSEY, "nj-marine", "king_mackerel", TODAY, "boat")!.minSizeIn).toBe(23);
   });
+
+  it("RI dab 14 no bag; witch 14; yellowtail 13; monkfish 17", () => {
+    expect(regulationCard(RHODE_ISLAND, "ri-statewide", "american_plaice", TODAY, "boat")!.minSizeIn).toBe(14);
+    expect(regulationCard(RHODE_ISLAND, "ri-statewide", "witch_flounder", TODAY, "boat")!.minSizeIn).toBe(14);
+    expect(regulationCard(RHODE_ISLAND, "ri-statewide", "yellowtail_flounder", TODAY, "boat")!.minSizeIn).toBe(13);
+    expect(regulationCard(RHODE_ISLAND, "ri-statewide", "monkfish", TODAY, "boat")!.minSizeIn).toBe(17);
+  });
 });

--- a/src/features/fish-legal/atlantic-wave3.test.ts
+++ b/src/features/fish-legal/atlantic-wave3.test.ts
@@ -72,4 +72,12 @@ describe("Atlantic wave 3 — CT / NH / ME", () => {
     expect(rd!.bagDaily).toBe(1);
     expect(regulationCard(CONNECTICUT, "ct-lis", "american_shad", TODAY, "boat")!.verdict).toBe("release");
   });
+
+  it("NH dab 14; monkfish 17; redfish 9; yellowtail 13; white perch 25", () => {
+    expect(regulationCard(NEW_HAMPSHIRE, "nh-coast", "american_plaice", TODAY, "boat")!.minSizeIn).toBe(14);
+    expect(regulationCard(NEW_HAMPSHIRE, "nh-coast", "monkfish", TODAY, "boat")!.minSizeIn).toBe(17);
+    expect(regulationCard(NEW_HAMPSHIRE, "nh-coast", "acadian_redfish", TODAY, "boat")!.minSizeIn).toBe(9);
+    expect(regulationCard(NEW_HAMPSHIRE, "nh-coast", "yellowtail_flounder", TODAY, "boat")!.minSizeIn).toBe(13);
+    expect(regulationCard(NEW_HAMPSHIRE, "nh-coast", "white_perch", TODAY, "boat")!.bagDaily).toBe(25);
+  });
 });

--- a/src/features/fish-legal/atlantic-wave4.test.ts
+++ b/src/features/fish-legal/atlantic-wave4.test.ts
@@ -38,6 +38,16 @@ describe("Atlantic wave 4 — DE / MD / VA / NC / SC / GA", () => {
     expect(regulationCard(DELAWARE, "de-tidal", "striped_bass", TODAY, "boat")!.bagDaily).toBe(1);
   });
 
+  it("DE cobia 43 @2; Spanish 14 @15; scup 9 @30; bluefish 5; weakfish 13 @1", () => {
+    const cobia = regulationCard(DELAWARE, "de-tidal", "cobia", TODAY, "boat");
+    expect(cobia!.minSizeIn).toBe(43);
+    expect(cobia!.bagDaily).toBe(2);
+    expect(regulationCard(DELAWARE, "de-tidal", "spanish_mackerel", TODAY, "boat")!.bagDaily).toBe(15);
+    expect(regulationCard(DELAWARE, "de-tidal", "scup", TODAY, "boat")!.minSizeIn).toBe(9);
+    expect(regulationCard(DELAWARE, "de-tidal", "bluefish", TODAY, "boat")!.bagDaily).toBe(5);
+    expect(regulationCard(DELAWARE, "de-tidal", "weakfish", TODAY, "boat")!.minSizeIn).toBe(13);
+  });
+
   it("MD ocean stripers 28–31; Bay 19–24 on Sep 3; fluke 17.5 @4", () => {
     const ocean = regulationCard(MARYLAND, "md-atlantic", "striped_bass", TODAY, "boat");
     expect(ocean!.minSizeIn).toBe(28);

--- a/src/features/fish-legal/delaware-pack.ts
+++ b/src/features/fish-legal/delaware-pack.ts
@@ -6,14 +6,14 @@ import type { RegArea, RegPack, RegRule } from "./types";
 
 export const DELAWARE_PACK: RegPack = {
   id: "delaware-2026-09-03",
-  version: 1,
-  publishedAt: "2026-09-03T22:00:00Z",
+  version: 2,
+  publishedAt: "2026-09-04T23:00:00Z",
   notes:
-    "Delaware DNREC 2026: stripers 28–31\" @1 (20–25\" Jul 1–Aug 31 in DE River/Bay/tributaries); tautog 16\" @4 Jan 1–May 15 and Jul 1–Dec 31; fluke 16\" then 17.5\" @4; BSB 13\" @15 May 15–Sep 30 and Oct 10–Dec 31; red drum 20–27\" @5 state waters.",
+    "Delaware DNREC v2: v1 table plus cobia 43\" @2 (2/vessel); Spanish mackerel 14\" @15; scup 9\" @30; bluefish 5 (7 for-hire); weakfish 13\" @1. King mackerel Fish Facts lists no size/no bag — not invented.",
 };
 
 const VERIFIED = "2026-09-03";
-const pv = 1;
+const pv = 2;
 const SB = {
   url: "https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=1&species=55",
   title: "Delaware DNREC Fish Facts — Striped Bass",
@@ -115,6 +115,51 @@ export const DE_RULES: readonly RegRule[] = [
     sourceTitle: "Delaware DNREC Fish Facts — Red Drum", sourceUpdatedAt: "2026-01-01", verifiedAt: VERIFIED,
     seasonStart: null, seasonEnd: null, bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: false,
     minSizeIn: 20, maxSizeIn: 27, sizeMeasure: "total_length", platformScope: null, depthNote: "EEZ closed.",
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "de-cobia", speciesId: "cobia", regAreaId: "de-tidal", kind: "bag_limit",
+    verbatim: "Cobia: Season Open Year-Round. Size Limit 43 inches minimum length (total length). Daily Limit / Person 2 per angler or 2 per vessel.",
+    sourceUrl: "https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=109",
+    sourceTitle: "Delaware DNREC Fish Facts — Cobia", sourceUpdatedAt: "2026-01-01", verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 2, possessionLimit: 2, bagSharesWithGroup: false,
+    minSizeIn: 43, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "2 per vessel.",
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "de-spanish-mackerel", speciesId: "spanish_mackerel", regAreaId: "de-tidal", kind: "bag_limit",
+    verbatim: "Spanish Mackerel: Season Open Year-Round. Size Limit 14 inch minimum. Daily Limit / Person 15.",
+    sourceUrl: "https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=176",
+    sourceTitle: "Delaware DNREC Fish Facts — Spanish Mackerel", sourceUpdatedAt: "2026-01-01", verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 15, possessionLimit: 15, bagSharesWithGroup: false,
+    minSizeIn: 14, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "de-scup", speciesId: "scup", regAreaId: "de-tidal", kind: "bag_limit",
+    verbatim: "Scup: Season Open Year-Round. Size Limit 9 inch minimum (total length). Daily Limit / Person 30.",
+    sourceUrl: "https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=160",
+    sourceTitle: "Delaware DNREC Fish Facts — Scup", sourceUpdatedAt: "2026-01-01", verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 30, possessionLimit: 30, bagSharesWithGroup: false,
+    minSizeIn: 9, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "de-bluefish", speciesId: "bluefish", regAreaId: "de-tidal", kind: "bag_limit",
+    verbatim: "Bluefish: Season Open Year Round. Size Limit No Size Limit. Daily Limit / Person 5 per shore or private boat anglers. 7 per anglers on 'for-hire' vessels (Headboats and Charter boats).",
+    sourceUrl: "https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=100",
+    sourceTitle: "Delaware DNREC Fish Facts — Bluefish", sourceUpdatedAt: "2026-01-01", verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 5, possessionLimit: 5, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "For-hire 7.",
+    checkInseason: true, staleAfterDays: 60,
+  }),
+  rule({
+    id: "de-weakfish", speciesId: "weakfish", regAreaId: "de-tidal", kind: "bag_limit",
+    verbatim: "Weakfish: Season Open Year-Round. Size Limit 13 inch minimum (total length). Daily Limit / Person 1.",
+    sourceUrl: "https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=192",
+    sourceTitle: "Delaware DNREC Fish Facts — Weakfish", sourceUpdatedAt: "2026-01-01", verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 1, possessionLimit: 1, bagSharesWithGroup: false,
+    minSizeIn: 13, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: null,
     checkInseason: true, staleAfterDays: 60,
   }),
 ];

--- a/src/features/fish-legal/massachusetts-pack.ts
+++ b/src/features/fish-legal/massachusetts-pack.ts
@@ -16,10 +16,10 @@ import type { RegArea, RegPack, RegRule } from "./types";
 
 export const MASSACHUSETTS_PACK: RegPack = {
   id: "massachusetts-2026-09-03",
-  version: 1,
-  publishedAt: "2026-09-03T12:00:00Z",
+  version: 2,
+  publishedAt: "2026-09-04T23:00:00Z",
   notes:
-    "Massachusetts (DMF saltwater table, updated 2026-04-28): full finfish digest — " +
+    "Massachusetts DMF v2 (table re-verified 2026-09-04): American shad other waters encoded as prohibited (Merrimack/Connecticut Rivers 3-fish is freshwater). Full finfish digest — " +
     "striped bass slot 28\" to <31\" @1 with circle-hook/no-gaff/no-high-grading " +
     "handling law, bluefish 5 (shore/private) vs 7 (for-hire), scup platform-split " +
     "(shore 9.5\", vessel/for-hire 11\"), fluke vessel 17.5\" vs shore 16.5\" " +
@@ -37,8 +37,8 @@ const MA = {
   title: "Massachusetts DMF — Recreational saltwater fishing regulations",
   updated: "2026-04-28",
 } as const;
-const VERIFIED = "2026-09-03";
-const pv = 1;
+const VERIFIED = "2026-09-04";
+const pv = 2;
 
 export const MA_AREAS: readonly RegArea[] = [
   {
@@ -379,7 +379,7 @@ export const MA_RULES: readonly RegRule[] = [
     checkInseason: false, staleAfterDays: 60,
   }),
   rule({
-    id: "ma-american-shad", speciesId: "american_shad", regAreaId: "ma-statewide", kind: "note",
+    id: "ma-american-shad", speciesId: "american_shad", regAreaId: "ma-statewide", kind: "prohibited",
     verbatim:
       "American Shad (Merrimack and Connecticut Rivers): no size limit, year round, 3 fish. American Shad (Other Waters): Prohibited. Catch and release only.",
     sourceUrl: MA.url, sourceTitle: MA.title, sourceUpdatedAt: MA.updated, verifiedAt: VERIFIED,

--- a/src/features/fish-legal/new-hampshire-pack.ts
+++ b/src/features/fish-legal/new-hampshire-pack.ts
@@ -8,10 +8,10 @@ import type { RegArea, RegPack, RegRule } from "./types";
 
 export const NEW_HAMPSHIRE_PACK: RegPack = {
   id: "new-hampshire-2026-09-03",
-  version: 1,
-  publishedAt: "2026-09-03T21:00:00Z",
+  version: 2,
+  publishedAt: "2026-09-04T23:30:00Z",
   notes:
-    "New Hampshire F&G saltwater recreational table (updated 2026-08-17): stripers 28–<31\" @1 year-round + circle hooks/gaff/cull bans; BSB 16.5\" @4 year-round; bluefish 5/7; cod 23\" @1 Sep 1–Oct 31 (closed Nov 1–Aug 31); haddock 17\" @15 except March; winter flounder 12\" @8; fluke 15\" no bag; shad/salmon/wolffish/ocean pout/windowpane prohibited.",
+    "New Hampshire F&G v2: v1 table plus dab 14\" no bag; monkfish 17\" no bag; redfish 9\" no bag; yellowtail 13\" no bag; pollock no state min (federal 19\"); witch no min; white perch 25; spiny dogfish no bag. Scup removed from 2026 table — not invented.",
 };
 
 const NH = {
@@ -20,7 +20,7 @@ const NH = {
   updated: "2026-08-17",
 } as const;
 const VERIFIED = "2026-09-03";
-const pv = 1;
+const pv = 2;
 
 export const NH_AREAS: readonly RegArea[] = [
   {
@@ -170,6 +170,70 @@ export const NH_RULES: readonly RegRule[] = [
     sourceUrl: NH.url, sourceTitle: NH.title, sourceUpdatedAt: NH.updated, verifiedAt: VERIFIED,
     seasonStart: null, seasonEnd: null, bagDaily: 0, possessionLimit: 0, bagSharesWithGroup: false,
     minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: null,
+    checkInseason: false, staleAfterDays: 120,
+  }),
+  rule({
+    id: "nh-plaice", speciesId: "american_plaice", regAreaId: "nh-coast", kind: "bag_limit",
+    verbatim: "American Plaice Recreational: Closed Season: No closed season. Minimum Length: 14 inches. Daily Bag Limit: No bag limit.",
+    sourceUrl: NH.url, sourceTitle: NH.title, sourceUpdatedAt: NH.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: 14, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "No bag limit.",
+    checkInseason: false, staleAfterDays: 120,
+  }),
+  rule({
+    id: "nh-monkfish", speciesId: "monkfish", regAreaId: "nh-coast", kind: "bag_limit",
+    verbatim: "Monkfish Recreational: Closed Season: No closed season. Minimum Length: 17 inches. Daily Bag Limit: No bag limit.",
+    sourceUrl: NH.url, sourceTitle: NH.title, sourceUpdatedAt: NH.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: 17, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "No bag limit.",
+    checkInseason: false, staleAfterDays: 120,
+  }),
+  rule({
+    id: "nh-pollock", speciesId: "pollock", regAreaId: "nh-coast", kind: "bag_limit",
+    verbatim: "Pollock Recreational: Closed Season: No closed season. Minimum Length: No minimum length. Daily Bag Limit: No bag limit. Special Rules: 19 inches, if taken in federal waters.",
+    sourceUrl: NH.url, sourceTitle: NH.title, sourceUpdatedAt: NH.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "Federal waters 19\" min.",
+    checkInseason: false, staleAfterDays: 120,
+  }),
+  rule({
+    id: "nh-redfish", speciesId: "acadian_redfish", regAreaId: "nh-coast", kind: "bag_limit",
+    verbatim: "Redfish Recreational: Closed Season: No closed season. Minimum Length: 9 inches. Daily Bag Limit: No bag limit.",
+    sourceUrl: NH.url, sourceTitle: NH.title, sourceUpdatedAt: NH.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: 9, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "No bag limit.",
+    checkInseason: false, staleAfterDays: 120,
+  }),
+  rule({
+    id: "nh-yellowtail", speciesId: "yellowtail_flounder", regAreaId: "nh-coast", kind: "bag_limit",
+    verbatim: "Yellowtail Flounder Recreational: Closed Season: No closed season. Minimum Length: 13 inches. Daily Bag Limit: No bag limit.",
+    sourceUrl: NH.url, sourceTitle: NH.title, sourceUpdatedAt: NH.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: 13, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "No bag limit.",
+    checkInseason: false, staleAfterDays: 120,
+  }),
+  rule({
+    id: "nh-witch", speciesId: "witch_flounder", regAreaId: "nh-coast", kind: "bag_limit",
+    verbatim: "Witch Flounder Recreational: Closed Season: No closed season. Minimum Length: No minimum length. Daily Bag Limit: No limit.",
+    sourceUrl: NH.url, sourceTitle: NH.title, sourceUpdatedAt: NH.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "No limit.",
+    checkInseason: false, staleAfterDays: 120,
+  }),
+  rule({
+    id: "nh-white-perch", speciesId: "white_perch", regAreaId: "nh-coast", kind: "bag_limit",
+    verbatim: "White Perch Recreational: Closed Season: No closed season. Minimum Length: No minimum length. Daily Bag Limit: 25 fish per day. Special Rules: Sale is prohibited.",
+    sourceUrl: NH.url, sourceTitle: NH.title, sourceUpdatedAt: NH.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: 25, possessionLimit: 25, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "Sale prohibited.",
+    checkInseason: false, staleAfterDays: 90,
+  }),
+  rule({
+    id: "nh-spiny-dogfish", speciesId: "spiny_dogfish", regAreaId: "nh-coast", kind: "bag_limit",
+    verbatim: "Dogfish, Spiny Recreational: Closed Season: No closed season. Minimum Length: No minimum length. Daily Bag Limit: No bag limit. Special Rules: Finning prohibited.",
+    sourceUrl: NH.url, sourceTitle: NH.title, sourceUpdatedAt: NH.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: null, maxSizeIn: null, sizeMeasure: null, platformScope: null, depthNote: "No bag limit. Finning prohibited.",
     checkInseason: false, staleAfterDays: 120,
   }),
 ];

--- a/src/features/fish-legal/rhode-island-pack.ts
+++ b/src/features/fish-legal/rhode-island-pack.ts
@@ -8,10 +8,10 @@ import type { RegArea, RegPack, RegRule } from "./types";
 
 export const RHODE_ISLAND_PACK: RegPack = {
   id: "rhode-island-2026-09-03",
-  version: 1,
-  publishedAt: "2026-09-03T18:00:00Z",
+  version: 2,
+  publishedAt: "2026-09-04T23:30:00Z",
   notes:
-    "Rhode Island (DEM recreational table, Rev. 9/1/2026): striped bass 28\"-<31\" @1 year-round + circle-hook bait rule; bluefish 5 general / 7 party-charter; scup shore 9.5\" vs private/rental 11\" @30 May 1–Dec 31; fluke 19\" @6 Apr 1–Dec 31 with special-shore 17\" (2 of 6); tautog 16\" (one >21\", vessel 10) 3/closed/3/5; black sea bass 16\" general 3 May 16–Dec 31 (party/charter 4 then 6); cod prohibited; winter flounder 12\" @2 Mar 1–Dec 31 with Narragansett Bay north-of-Colregs prohibition.",
+    "Rhode Island DEM v2: v1 rec table plus dab 14\" no bag; monkfish 17\" whole; witch 14\" no bag; yellowtail 13\" no bag. No cobia/Spanish/king on Rev 9/1/2026 rec table.",
 };
 
 const RI = {
@@ -20,7 +20,7 @@ const RI = {
   updated: "2026-09-01",
 } as const;
 const VERIFIED = "2026-09-03";
-const pv = 1;
+const pv = 2;
 
 export const RI_AREAS: readonly RegArea[] = [
   {
@@ -205,6 +205,38 @@ export const RI_RULES: readonly RegRule[] = [
     sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
     seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
     minSizeIn: 19, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "No possession limit.",
+    checkInseason: false, staleAfterDays: 120,
+  }),
+  rule({
+    id: "ri-plaice", speciesId: "american_plaice", regAreaId: "ri-statewide", kind: "bag_limit",
+    verbatim: "American plaice (dab): 14\". 1/1 - 12/31. No limit.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: 14, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "No possession limit.",
+    checkInseason: false, staleAfterDays: 120,
+  }),
+  rule({
+    id: "ri-monkfish", speciesId: "monkfish", regAreaId: "ri-statewide", kind: "bag_limit",
+    verbatim: "Monkfish (Goosefish): 17\" whole / 11\" tail. 1/1 - 12/31. 50 lbs tails/day or 166 lbs whole/day.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: 17, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "50 lbs tails/day or 166 lbs whole/day.",
+    checkInseason: false, staleAfterDays: 90,
+  }),
+  rule({
+    id: "ri-witch", speciesId: "witch_flounder", regAreaId: "ri-statewide", kind: "bag_limit",
+    verbatim: "Witch Flounder (Gray Sole): 14\". 1/1 - 12/31. No limit.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: 14, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "No possession limit.",
+    checkInseason: false, staleAfterDays: 120,
+  }),
+  rule({
+    id: "ri-yellowtail", speciesId: "yellowtail_flounder", regAreaId: "ri-statewide", kind: "bag_limit",
+    verbatim: "Yellowtail Flounder: 13\". 1/1 - 12/31. No limit.",
+    sourceUrl: RI.url, sourceTitle: RI.title, sourceUpdatedAt: RI.updated, verifiedAt: VERIFIED,
+    seasonStart: null, seasonEnd: null, bagDaily: null, possessionLimit: null, bagSharesWithGroup: false,
+    minSizeIn: 13, maxSizeIn: null, sizeMeasure: "total_length", platformScope: null, depthNote: "No possession limit.",
     checkInseason: false, staleAfterDays: 120,
   }),
 ];

--- a/supabase/migrations/20260904130000_v2_de_ma_digest.sql
+++ b/supabase/migrations/20260904130000_v2_de_ma_digest.sql
@@ -1,0 +1,21 @@
+-- DE leftover Fish Facts + MA shad prohibited (2026-09-04). Insert-only + pack upsert.
+
+insert into public.reg_rule
+  (species_id, reg_group_id, reg_area_id, water_class, kind, verbatim, source_url, source_title, source_updated_at, verified_at, pack_version,
+   season_start, season_end, bag_daily, possession_limit, min_size_in, max_size_in, size_measure, platform_scope, depth_note, check_inseason, stale_after_days)
+values
+  ('cobia', null, 'de-tidal', 'salt', 'bag_limit', 'Cobia: Season Open Year-Round. Size Limit 43 inches minimum length (total length). Daily Limit / Person 2 per angler or 2 per vessel.', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=109', 'Delaware DNREC Fish Facts — Cobia', '2026-01-01', '2026-09-04', 2,
+   null, null, 2, 2, 43, null, 'total_length', null, '2 per vessel.', true, 60),
+  ('spanish_mackerel', null, 'de-tidal', 'salt', 'bag_limit', 'Spanish Mackerel: Season Open Year-Round. Size Limit 14 inch minimum. Daily Limit / Person 15.', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=176', 'Delaware DNREC Fish Facts — Spanish Mackerel', '2026-01-01', '2026-09-04', 2,
+   null, null, 15, 15, 14, null, 'total_length', null, null, true, 60),
+  ('scup', null, 'de-tidal', 'salt', 'bag_limit', 'Scup: Season Open Year-Round. Size Limit 9 inch minimum (total length). Daily Limit / Person 30.', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=160', 'Delaware DNREC Fish Facts — Scup', '2026-01-01', '2026-09-04', 2,
+   null, null, 30, 30, 9, null, 'total_length', null, null, true, 60),
+  ('bluefish', null, 'de-tidal', 'salt', 'bag_limit', 'Bluefish: Season Open Year Round. Size Limit No Size Limit. Daily Limit / Person 5 per shore or private boat anglers. 7 per anglers on for-hire vessels (Headboats and Charter boats).', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=100', 'Delaware DNREC Fish Facts — Bluefish', '2026-01-01', '2026-09-04', 2,
+   null, null, 5, 5, null, null, null, null, 'For-hire 7.', true, 60),
+  ('weakfish', null, 'de-tidal', 'salt', 'bag_limit', 'Weakfish: Season Open Year-Round. Size Limit 13 inch minimum (total length). Daily Limit / Person 1.', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=192', 'Delaware DNREC Fish Facts — Weakfish', '2026-01-01', '2026-09-04', 2,
+   null, null, 1, 1, 13, null, 'total_length', null, null, true, 60);
+
+insert into public.reg_pack (id, version, published_at, notes) values
+  ('delaware-2026-09-03', 2, '2026-09-04T23:00:00Z', 'Delaware DNREC v2: v1 table plus cobia 43" @2 (2/vessel); Spanish mackerel 14" @15; scup 9" @30; bluefish 5 (7 for-hire); weakfish 13" @1.'),
+  ('massachusetts-2026-09-03', 2, '2026-09-04T23:00:00Z', 'Massachusetts DMF v2: American shad other waters prohibited; Merrimack/Connecticut Rivers 3-fish is freshwater.')
+on conflict (id) do update set version = excluded.version, notes = excluded.notes, published_at = excluded.published_at;

--- a/supabase/migrations/20260904140000_v2_nh_ri_digest.sql
+++ b/supabase/migrations/20260904140000_v2_nh_ri_digest.sql
@@ -1,0 +1,35 @@
+-- NH / RI leftover groundfish from official rec tables (2026-09-04). Insert-only + pack upsert.
+
+insert into public.reg_rule
+  (species_id, reg_group_id, reg_area_id, water_class, kind, verbatim, source_url, source_title, source_updated_at, verified_at, pack_version,
+   season_start, season_end, bag_daily, possession_limit, min_size_in, max_size_in, size_measure, platform_scope, depth_note, check_inseason, stale_after_days)
+values
+  ('american_plaice', null, 'nh-coast', 'salt', 'bag_limit', 'American Plaice Recreational: Closed Season: No closed season. Minimum Length: 14 inches. Daily Bag Limit: No bag limit.', 'https://www.eregulations.com/newhampshire/fishing/saltwater/recreational-commercial-regulations', 'New Hampshire Fish & Game — Saltwater Recreational & Commercial Regulations', '2026-08-17', '2026-09-04', 2,
+   null, null, null, null, 14, null, 'total_length', null, 'No bag limit.', false, 120),
+  ('monkfish', null, 'nh-coast', 'salt', 'bag_limit', 'Monkfish Recreational: Closed Season: No closed season. Minimum Length: 17 inches. Daily Bag Limit: No bag limit.', 'https://www.eregulations.com/newhampshire/fishing/saltwater/recreational-commercial-regulations', 'New Hampshire Fish & Game — Saltwater Recreational & Commercial Regulations', '2026-08-17', '2026-09-04', 2,
+   null, null, null, null, 17, null, 'total_length', null, 'No bag limit.', false, 120),
+  ('pollock', null, 'nh-coast', 'salt', 'bag_limit', 'Pollock Recreational: Closed Season: No closed season. Minimum Length: No minimum length. Daily Bag Limit: No bag limit. Special Rules: 19 inches, if taken in federal waters.', 'https://www.eregulations.com/newhampshire/fishing/saltwater/recreational-commercial-regulations', 'New Hampshire Fish & Game — Saltwater Recreational & Commercial Regulations', '2026-08-17', '2026-09-04', 2,
+   null, null, null, null, null, null, null, null, 'Federal waters 19" min.', false, 120),
+  ('acadian_redfish', null, 'nh-coast', 'salt', 'bag_limit', 'Redfish Recreational: Closed Season: No closed season. Minimum Length: 9 inches. Daily Bag Limit: No bag limit.', 'https://www.eregulations.com/newhampshire/fishing/saltwater/recreational-commercial-regulations', 'New Hampshire Fish & Game — Saltwater Recreational & Commercial Regulations', '2026-08-17', '2026-09-04', 2,
+   null, null, null, null, 9, null, 'total_length', null, 'No bag limit.', false, 120),
+  ('yellowtail_flounder', null, 'nh-coast', 'salt', 'bag_limit', 'Yellowtail Flounder Recreational: Closed Season: No closed season. Minimum Length: 13 inches. Daily Bag Limit: No bag limit.', 'https://www.eregulations.com/newhampshire/fishing/saltwater/recreational-commercial-regulations', 'New Hampshire Fish & Game — Saltwater Recreational & Commercial Regulations', '2026-08-17', '2026-09-04', 2,
+   null, null, null, null, 13, null, 'total_length', null, 'No bag limit.', false, 120),
+  ('witch_flounder', null, 'nh-coast', 'salt', 'bag_limit', 'Witch Flounder Recreational: Closed Season: No closed season. Minimum Length: No minimum length. Daily Bag Limit: No limit.', 'https://www.eregulations.com/newhampshire/fishing/saltwater/recreational-commercial-regulations', 'New Hampshire Fish & Game — Saltwater Recreational & Commercial Regulations', '2026-08-17', '2026-09-04', 2,
+   null, null, null, null, null, null, null, null, 'No limit.', false, 120),
+  ('white_perch', null, 'nh-coast', 'salt', 'bag_limit', 'White Perch Recreational: Closed Season: No closed season. Minimum Length: No minimum length. Daily Bag Limit: 25 fish per day. Special Rules: Sale is prohibited.', 'https://www.eregulations.com/newhampshire/fishing/saltwater/recreational-commercial-regulations', 'New Hampshire Fish & Game — Saltwater Recreational & Commercial Regulations', '2026-08-17', '2026-09-04', 2,
+   null, null, 25, 25, null, null, null, null, 'Sale prohibited.', false, 90),
+  ('spiny_dogfish', null, 'nh-coast', 'salt', 'bag_limit', 'Dogfish, Spiny Recreational: Closed Season: No closed season. Minimum Length: No minimum length. Daily Bag Limit: No bag limit. Special Rules: Finning prohibited.', 'https://www.eregulations.com/newhampshire/fishing/saltwater/recreational-commercial-regulations', 'New Hampshire Fish & Game — Saltwater Recreational & Commercial Regulations', '2026-08-17', '2026-09-04', 2,
+   null, null, null, null, null, null, null, null, 'No bag limit. Finning prohibited.', false, 120),
+  ('american_plaice', null, 'ri-statewide', 'salt', 'bag_limit', 'American plaice (dab): 14". 1/1 - 12/31. No limit.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-04', 2,
+   null, null, null, null, 14, null, 'total_length', null, 'No possession limit.', false, 120),
+  ('monkfish', null, 'ri-statewide', 'salt', 'bag_limit', 'Monkfish (Goosefish): 17" whole / 11" tail. 1/1 - 12/31. 50 lbs tails/day or 166 lbs whole/day.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-04', 2,
+   null, null, null, null, 17, null, 'total_length', null, '50 lbs tails/day or 166 lbs whole/day.', false, 90),
+  ('witch_flounder', null, 'ri-statewide', 'salt', 'bag_limit', 'Witch Flounder (Gray Sole): 14". 1/1 - 12/31. No limit.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-04', 2,
+   null, null, null, null, 14, null, 'total_length', null, 'No possession limit.', false, 120),
+  ('yellowtail_flounder', null, 'ri-statewide', 'salt', 'bag_limit', 'Yellowtail Flounder: 13". 1/1 - 12/31. No limit.', 'https://dem.ri.gov/natural-resources-bureau/marine-fisheries/marine-fisheries-minimum-sizes-possession-limits', 'Rhode Island DEM — Marine Fisheries Minimum Sizes & Possession Limits (recreational)', '2026-09-01', '2026-09-04', 2,
+   null, null, null, null, 13, null, 'total_length', null, 'No possession limit.', false, 120);
+
+insert into public.reg_pack (id, version, published_at, notes) values
+  ('new-hampshire-2026-09-03', 2, '2026-09-04T23:30:00Z', 'New Hampshire F&G v2 leftover groundfish from the 2026-08-17 table.'),
+  ('rhode-island-2026-09-03', 2, '2026-09-04T23:30:00Z', 'Rhode Island DEM v2 leftover rec-table groundfish. No cobia/Spanish/king.')
+on conflict (id) do update set version = excluded.version, notes = excluded.notes, published_at = excluded.published_at;


### PR DESCRIPTION
## What
Leftover recreational rows from official tables after #54.

- **Delaware DNREC Fish Facts:** cobia 43" @2 (2/vessel); Spanish 14" @15; scup 9" @30; bluefish 5 (7 for-hire); weakfish 13" @1. King mackerel has no size/bag on that page — not invented.
- **Massachusetts DMF:** table already complete; American shad other waters encoded as **prohibited** (Merrimack/Connecticut 3-fish is freshwater).
- **NH F&G (updated 2026-08-17):** dab 14"; monkfish 17"; redfish 9"; yellowtail 13"; pollock no state min (federal 19"); witch no min; white perch 25; spiny dogfish no bag. Scup removed from 2026 table — not invented.
- **RI DEM rec table Rev 9/1/2026:** dab 14"; monkfish 17" whole; witch 14"; yellowtail 13". No cobia/Spanish/king.

SQL: `20260904130000_v2_de_ma_digest.sql`, `20260904140000_v2_nh_ri_digest.sql`.

Field-test/auth still held.
