### PR TITLE
Boat Games, Phase 1: local one-phone games with Captain's Cup, Fish Cricket and Make the Cut

### DIFF
--- a/docs/architecture/decisions/009-boat-games-participant-ownership.md
+++ b/docs/architecture/decisions/009-boat-games-participant-ownership.md
@@ -1,0 +1,133 @@
+# 009 — Boat Games: participant ownership, and the event fold
+
+**Date:** 2026-09-04 · **Status:** accepted
+**Answers:** the founder's Boat Games handoff — "the architect should determine whether
+guest catches extend the existing catch model or remain game-event records until claimed."
+**Depends on:** `003-web-prototype-boundary.md` (pure core, vectors, folder law),
+`004-offline-store-and-sync.md` (IndexedDB is the read path, ids minted on device),
+`005-front-end-architecture.md` §2 (tokens).
+**Supersedes:** nothing. **Amends:** `docs/specs/fishing-passport-wildlife-boat-games.md`
+Part IV — the modes ship under the handoff's names (Boat Games, Captain's Cup, Fish
+Cricket, Make the Cut), and the local one-device game comes first rather than at Phase 4.
+
+## Context
+
+The handoff asks for a game where four anglers on one boat score catches on the host's
+phone, offline, with no accounts. The single hard requirement: *"If Mike catches a fish
+and Elliott records it on Elliott's phone, Mike's catch must not appear in Elliott's
+personal Passport, catch history, personal bests, or statistics."*
+
+That is not a preference. It is a correctness constraint on data the founder already has
+on his phone, with no server to re-derive from.
+
+**The Passport reads the catch store wholesale.** `usePassport()`
+(`src/features/passport/data.ts:77`) hands `log.catches` — every row in the IndexedDB
+`catch` store — to `speciesSummaries`, `evaluateBadges` and `evaluateSlams`. Nothing in
+`src/core/` or `src/features/passport/` filters by `angler_id`; grep finds the column only
+in test fixtures and in the four places `src/features/catches/` writes
+`LOCAL_ANGLER_ID`. It is written and never read.
+
+So a guest's yellowtail written to the `catch` store is, in the same tick: a new species
+in the founder's My Species grid, progress toward his badges, and a leg of his slam. There
+is no filter to "add later" — it would have to be added in five call sites and kept
+correct forever, and the first time someone forgets, the founder's Passport inflates
+quietly and there is no way to tell which fish were his.
+
+## The call
+
+### 1. A game catch is a `game_event`. It is not a `catch` row.
+
+Three new IndexedDB stores at `DB_VERSION = 4`: `game_session`, `game_participant`,
+`game_event`.
+
+`game_event` carries its own `species_id`, `length_mm`, `weight_g`, `disposition` and
+`caught_at` — everything scoring needs. It does not need a catch row to exist, and for a
+guest there is nothing to reference: the event *is* the record.
+
+`game_event.catch_id` is nullable and set in exactly one case: the host tapped **also log
+this to my book**, and the catch was then minted through the ordinary
+`features/catches/create.ts` path so it arrives with its rig, location, conditions and
+regulation snapshot like every other fish. The event references it; it never copies it.
+This is spec §28's rule ("game events reference catches; they do not copy an editable
+duplicate") in the direction the spec anticipated, and the guest direction is the case the
+spec did not have to answer because it assumed accounts.
+
+Consequences, stated plainly because they are visible to the angler:
+
+- A guest's fish is not in anyone's Passport, because it is not in anyone's log. Correct.
+- The host's own fish is in his log **only if he opted in**. A host who taps through a
+  fast game entry and never opts in ends the trip with fish in the game and not in his
+  book. That is the founder's chosen trade (fast entry beats complete records when three
+  people are hauling fish), and the results screen should offer a bulk "log my game
+  catches" so it is recoverable rather than lost.
+- Phase 2 claiming needs no un-contamination step. A guest who creates an account claims
+  their `participant_id`, and their events mint catch rows under *their* user. Nothing has
+  to be moved out of anyone else's log, because it was never in it.
+
+### 2. Game stores are written outside the outbox.
+
+`commit()` in `src/lib/offline/db.ts` writes a row and its outbox mutation in one
+transaction, and `ENTITY_STORES` is the syncable set. Adding the game stores to it would
+queue mutations for Supabase tables that do not exist — every one would come back 4xx,
+land in `rejected`, and put a permanent **needs attention** badge on the founder's phone
+for a feature that is working correctly.
+
+Phase 1 games are local-only, so they get their own write path (`commitLocal`, same
+one-transaction discipline, no outbox). Phase 2 adds them to `ENTITY_STORES` at the same
+time it adds the tables.
+
+### 3. The scoreboard is a pure fold over events, never a stored number.
+
+`src/core/rules/games/` — pure, no I/O, vector-policed, the same shape as
+`core/rules/catch`. One function: `score(rules, events) -> Standings`.
+
+This is not tidiness. It is how four acceptance criteria stop being things to remember:
+
+- **"A catch cannot score twice."** Every event carries a client-minted uuidv7 as its
+  idempotency key; the fold folds a key once. A double-tap on a moving boat writes one
+  row or two rows with the same key, and either way scores once.
+- **Undo and corrections.** Undo appends a `void` event naming the voided event's id and
+  re-folds. A correction appends a `revise` event. Nothing is ever mutated, so correction
+  history is free rather than a column somebody has to maintain.
+- **Three modes, one engine.** Captain's Cup, Fish Cricket and Make the Cut are three
+  `rules` configs over one fold, not three scoring systems. The future modes in the
+  handoff (Species Sprint, Grand Slam, Bingo, Exact 21) are further configs.
+- **Rounds are events, not a clock.** `round_advanced` is an event with a sequence number.
+  A multi-day game advances when the host says so. The timer on a within-session game is a
+  *display* of `started_at` plus a duration — it never decides anything. Offline, the
+  device clock is the only clock and it can be changed in Settings; a game that ends
+  because someone adjusted their phone is a bug this shape does not have.
+
+### 4. Legal eligibility is snapshotted per event, from the pack that was current.
+
+`regulationCard()` already returns a `KeepVerdict` and the numbers behind it, and
+`buildRegulationSnapshot()` already freezes it onto a catch. A `game_event` snapshots the
+same reading at scoring time, so a pack update next season does not rewrite a finished
+game — the same stance the catch log already takes.
+
+Scoring rules that fall out of it:
+
+- Retained against a `release` verdict → zero points, flagged. The fish stays in the game
+  record; only its score is zero.
+- Released → full points. The game never needs a fish killed.
+- No pack for the region → the card is null, and null means *nothing verified was
+  knowable*, not *prohibited*. It scores normally and snapshots `legal_status: unknown`.
+  Silence is not proof, in either direction.
+
+**Gap this surfaced.** The handoff says protected species cannot be *selected as targets*.
+`RegulationCard` cannot currently express that: `verdict: "release"` covers both "this
+species is prohibited" and "the season is closed today", and those want opposite answers —
+a prohibited species must not be a target, a closed-season species is a perfectly good
+catch-and-release target. The reason is only in `verdictReason`, a human sentence, and
+matching on it is the kind of string-sniffing that breaks silently when someone improves
+the wording. `reg-engine.ts` needs to expose the distinction it already computes
+internally (it has the `prohibited` row in hand at line ~144). Small, additive, and it
+belongs to Fish Legal rather than to Games.
+
+## What this does not decide
+
+- **Handicap.** The handoff lists it under player setup, but no mode says what it does.
+  Taken as a per-participant integer added once to the starting score and shown on the
+  scoreboard — the only reading that works across all three modes. Flagged for the founder.
+- **Connected play, photos, verification, leaderboards, tournaments.** Out of Phase 1 by
+  the handoff's own instruction.

--- a/docs/team/channel/2026-09-04-01-head-dev-to-coo.md
+++ b/docs/team/channel/2026-09-04-01-head-dev-to-coo.md
@@ -1,0 +1,48 @@
+### 2026-09-04 | head-dev -> coo, fish-legal lane
+
+**`main` is red, and it is not the Boat Games branch that did it.**
+
+`src/features/fish-legal/reg-data-parity.test.ts` fails on `main` at 8b273f6 (the merge of
+PR #60, NH/RI/DE/MA leftovers):
+
+```
+× every later pack's rule verbatim sentence exists in its migration
+  expected [ 'de-bluefish' ] to deeply equal []
+```
+
+Checked it on a clean worktree of `origin/main` itself, so this is the base branch and not
+a merge artefact on my side.
+
+**Cause.** The Delaware pack and its migration disagree by two apostrophes.
+
+`delaware-pack.ts:149` has:
+
+```
+7 per anglers on 'for-hire' vessels (Headboats and Charter boats).
+```
+
+`supabase/migrations/20260904130000_v2_de_ma_digest.sql:13` has:
+
+```
+7 per anglers on for-hire vessels (Headboats and Charter boats).
+```
+
+A single quote inside a SQL string literal needs doubling, and the quotes were dropped
+rather than escaped. The parity test is doing exactly its job: catching a migration that
+does not say what the pack says.
+
+**Proposed patch** — one line in the migration, escaping rather than deleting:
+
+```sql
+'... Daily Limit / Person 5 per shore or private boat anglers. 7 per anglers on ''for-hire'' vessels (Headboats and Charter boats).'
+```
+
+**I have not applied it.** It is the fish-legal lane's file and house rule §3 says I do not
+touch another lane's work. Flagging it rather than fixing it in my branch, so it does not
+ride into a Boat Games review.
+
+Worth a look at whether any other pack rule has an apostrophe in its verbatim text — same
+mistake would be silent everywhere the sentence happens not to have one, and this one only
+surfaced because Delaware's source wrote "for-hire" in quotes.
+
+— head-dev (Boat Games lane, `claude/boat-games-handoff-0gu8n8`)

--- a/docs/team/worklog/2026-09-04-11-head-dev.md
+++ b/docs/team/worklog/2026-09-04-11-head-dev.md
@@ -51,14 +51,28 @@ start on a boat with no signal, with people who do not have the app.
   counters on the board now reset with the score they sit beside, and the whole-game totals are
   kept separately for the results screen. That one only showed up on a real screen; every unit
   test passed while it was wrong.
-- Checks: tripwires clean, 0 lint errors, tsc clean, 766 tests, build green, all four routes static.
+- **Finished the host's own log, and found teams were half-built.** The "also add to my own log"
+  toggle now really does put the host's fish in their own Fish Log, through the ordinary catch
+  flow so it arrives with its trip and rig and legal snapshot like any other fish. Checked in the
+  database: a guest's fish still writes nothing, the host opting in writes exactly one catch and
+  the game points at it, and the host leaving the toggle off writes nothing. The crossing lives in
+  one file that checks for itself that the angler is the host, and a test fails if any other file
+  in Boat Games grows the same import.
+- **Teams could be set up but were never scored.** You could name the sides Adults and Kids, assign
+  four people, play the whole game — and the board showed four individuals and announced a person
+  as the winner. The engine had been totalling the teams all along; nothing displayed it. The board
+  now leads with the team scores and shows the individuals underneath as the breakdown, and the
+  result names the side. Also stopped marking a person as "leading" in a team game, because in a
+  team game they are not.
+- Checks: tripwires clean, 0 lint errors, tsc clean, 770 tests, build green, all four routes static.
 - Files: `src/core/rules/games/*`, `src/features/games/*`, `src/app/(app)/games/*`,
   `src/lib/offline/db.ts`, `src/app/(app)/log/page.tsx`,
   `docs/architecture/decisions/009-boat-games-participant-ownership.md`.
-- **Next, and honestly:** the host's "also add to my own log" toggle records the intent but does
-  not yet mint the catch — that needs the catch-flow integration and is the one piece of Phase 1
-  I have left unfinished. Teams are supported but I only drove single players through the browser.
-  Nobody has used any of this on an actual boat, which is the only test that counts.
+- **Next, and honestly:** everything on the founder's Phase 1 list is now built and driven in a
+  browser — all three games, teams, offline, the host's own log. What is untested is the messy
+  part: four people actually passing a phone around with wet hands while fish are coming over the
+  rail. Nobody has used this on a boat, which is the only test that counts, and I would expect the
+  first real trip to change the catch-entry screen more than anything else here.
 
 **One thing for another lane.** Every detail screen in the app — `/catch/[id]`, `/trip/[id]`,
 `/spots/[id]`, both passport detail routes — builds as a dynamic route, which ADR 005 §5 says

--- a/docs/team/worklog/2026-09-04-11-head-dev.md
+++ b/docs/team/worklog/2026-09-04-11-head-dev.md
@@ -1,0 +1,59 @@
+### 2026-09-04 | head-dev | Boat Games, Phase 1
+
+Built the local, one-phone version of Boat Games the founder handed off: a game you can
+start on a boat with no signal, with people who do not have the app.
+
+- **Read the handoff against the code first, and found three things that changed the plan.**
+  Boat Games was already specced under different names (Boat Battle / Species Cricket /
+  Last Angler Standing) and sat at Phase 4 behind accounts; the founder confirmed the new
+  names and the local-first order. The nav bar is measured-full at six, so Boat Games hangs
+  off the Log screen instead. And the founder's worry about guest catches contaminating his
+  Passport turned out to be worse than he framed it.
+- **The Passport reads every catch on the phone.** `usePassport` hands the whole catch store
+  to species summaries, badges and slams, and nothing anywhere filters by `angler_id` — that
+  column is written in four places and read in none. So a guest's fish saved as a catch would
+  have been a new species in his grid, progress on his badges and a leg of his slam, with no
+  way afterwards to tell whose fish was whose. Written up as ADR 009.
+- **So a game catch is its own kind of record.** It carries its own species and size and never
+  becomes a catch row. Only the host is offered "also add to my own log". A guest who makes an
+  account later can claim their fish, and nothing has to be untangled first, because their fish
+  were never in anybody else's log.
+- **One engine, three games.** The scoreboard is worked out from the list of events every time
+  it is drawn rather than stored as a running total. That is what makes the promises hold:
+  the same fish cannot score twice however many times a wet thumb hits the button, undo is just
+  another entry rather than arithmetic in reverse, and Captain's Cup, Fish Cricket and Make the
+  Cut are three sets of settings rather than three scoring systems. The next games are settings too.
+- **The safeguards are in the engine, not the screen.** A protected fish scores nothing. A fish
+  kept when the law said put it back scores nothing and says why. A released fish scores exactly
+  what keeping it would have. A region with no legal pack scores normally — unknown is not the
+  same as prohibited, and treating it as prohibited would break the game everywhere we have no data.
+- **Two things I had to do differently than planned.** The game screens are `/games/play?id=`
+  rather than `/games/[id]`, because a path parameter makes the route dynamic and ADR 005 forbids
+  that — it puts a network round trip in front of the first paint, which is the feature failing at
+  the only moment it matters. And the countdown had to be rewritten off `useEffect`; the obvious
+  version tripped a lint rule that was right to stop it.
+- **Drove a whole game in Chromium at 320px.** Three players, three fish, undo, review, rules,
+  finish, results. No horizontal overflow on any screen, no console errors, and the scores were
+  right by hand (including the head start applying once, not per fish). Also checked with the
+  network switched off, and after closing and reopening in a new tab — both fine.
+- **Checked the important claim in the database, not just on screen.** After a guest logs a
+  bluefin: 0 rows in the catch store, 0 in the sync queue, 1 game event. Then wrote tests that
+  fail if someone later reaches for the catch store, and confirmed they actually fail by breaking
+  it three ways on purpose.
+- **Two things I fixed after looking at it.** An angler with a head start showed a score with
+  nothing explaining it, and picking a species left twelve other species on screen pushing the
+  save button most of a screen down.
+- Checks: tripwires clean, 0 lint errors, tsc clean, 763 tests, build green, all four routes static.
+- Files: `src/core/rules/games/*`, `src/features/games/*`, `src/app/(app)/games/*`,
+  `src/lib/offline/db.ts`, `src/app/(app)/log/page.tsx`,
+  `docs/architecture/decisions/009-boat-games-participant-ownership.md`.
+- **Next, and honestly:** Fish Cricket and Make the Cut are implemented and unit-tested but have
+  not been played through in a browser the way Captain's Cup has — that is the next thing to do.
+  The host's "also add to my own log" toggle records the intent but does not yet mint the catch;
+  that needs the catch-flow integration. Nobody has used any of this on an actual boat.
+
+**One thing for another lane.** Every detail screen in the app — `/catch/[id]`, `/trip/[id]`,
+`/spots/[id]`, both passport detail routes — builds as a dynamic route, which ADR 005 §5 says
+plainly that no product route may be. They all key off ids that only exist on the device, so
+they can never be prerendered as they stand. It is a latent hole in the offline story that
+predates this work and is not mine to change, but somebody should own it.

--- a/docs/team/worklog/2026-09-04-11-head-dev.md
+++ b/docs/team/worklog/2026-09-04-11-head-dev.md
@@ -40,17 +40,25 @@ start on a boat with no signal, with people who do not have the app.
   bluefin: 0 rows in the catch store, 0 in the sync queue, 1 game event. Then wrote tests that
   fail if someone later reaches for the catch store, and confirmed they actually fail by breaking
   it three ways on purpose.
-- **Two things I fixed after looking at it.** An angler with a head start showed a score with
-  nothing explaining it, and picking a species left twelve other species on screen pushing the
-  save button most of a screen down.
-- Checks: tripwires clean, 0 lint errors, tsc clean, 763 tests, build green, all four routes static.
+- **Played all three games in the browser, not just Captain's Cup.** Fish Cricket does the darts
+  rule properly — three kelp bass closes the target and scores nothing, the fourth scores. Make
+  the Cut eliminated the angler with no fish at the end of day 1, greyed them out, ranked them
+  last and moved everyone to day 2.
+- **Three things I fixed after looking at it.** An angler with a head start showed a score with
+  nothing explaining it. Picking a species left twelve other species on screen pushing the save
+  button most of a screen down. And the day-2 board read "1 fish · 1 species" next to a score of
+  zero — yesterday's fish beside today's score, which makes a scoreboard look broken. The
+  counters on the board now reset with the score they sit beside, and the whole-game totals are
+  kept separately for the results screen. That one only showed up on a real screen; every unit
+  test passed while it was wrong.
+- Checks: tripwires clean, 0 lint errors, tsc clean, 766 tests, build green, all four routes static.
 - Files: `src/core/rules/games/*`, `src/features/games/*`, `src/app/(app)/games/*`,
   `src/lib/offline/db.ts`, `src/app/(app)/log/page.tsx`,
   `docs/architecture/decisions/009-boat-games-participant-ownership.md`.
-- **Next, and honestly:** Fish Cricket and Make the Cut are implemented and unit-tested but have
-  not been played through in a browser the way Captain's Cup has — that is the next thing to do.
-  The host's "also add to my own log" toggle records the intent but does not yet mint the catch;
-  that needs the catch-flow integration. Nobody has used any of this on an actual boat.
+- **Next, and honestly:** the host's "also add to my own log" toggle records the intent but does
+  not yet mint the catch — that needs the catch-flow integration and is the one piece of Phase 1
+  I have left unfinished. Teams are supported but I only drove single players through the browser.
+  Nobody has used any of this on an actual boat, which is the only test that counts.
 
 **One thing for another lane.** Every detail screen in the app — `/catch/[id]`, `/trip/[id]`,
 `/spots/[id]`, both passport detail routes — builds as a dynamic route, which ADR 005 §5 says

--- a/docs/team/worklog/2026-09-04-11-head-dev.md
+++ b/docs/team/worklog/2026-09-04-11-head-dev.md
@@ -64,7 +64,14 @@ start on a boat with no signal, with people who do not have the app.
   now leads with the team scores and shows the individuals underneath as the breakdown, and the
   result names the side. Also stopped marking a person as "leading" in a team game, because in a
   team game they are not.
-- Checks: tripwires clean, 0 lint errors, tsc clean, 770 tests, build green, all four routes static.
+- **Found a real double-tap bug by trying to prove my own fix was unnecessary.** The founder's
+  handoff lists duplicate button taps as something the game has to survive, so I had guarded the
+  buttons. Clicking fast in a browser could not tell my guard apart from the naive version, so
+  rather than assume, I weakened it on purpose and fired five clicks in one go: **one fish was
+  written five times**, all sharing a sequence number. On a phone that is briefly busy — which is
+  every phone on a boat — that is one yellowtail scoring five times. The stronger guard writes
+  one. Same test, so I know which half was doing the work.
+- Checks: tripwires clean, 0 lint errors, tsc clean, 772 tests, build green, all four routes static.
 - Files: `src/core/rules/games/*`, `src/features/games/*`, `src/app/(app)/games/*`,
   `src/lib/offline/db.ts`, `src/app/(app)/log/page.tsx`,
   `docs/architecture/decisions/009-boat-games-participant-ownership.md`.

--- a/src/app/(app)/games/new/page.tsx
+++ b/src/app/(app)/games/new/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
+
+import { NewGame } from "@/features/games/components/new-game";
+import { BOAT_GAMES_V1 } from "@/features/games/flag";
+
+export const metadata: Metadata = { title: "Start a game | Fish Log Book" };
+
+/**
+ * `NewGame` reads the query string for the mode and for a draft to resume, and
+ * `useSearchParams` requires a Suspense boundary above it or the route is forced dynamic
+ * — which ADR 005 §5 forbids, because the static shell is what lets a cold load paint on
+ * a boat with no signal.
+ */
+export default function NewGamePage() {
+  if (!BOAT_GAMES_V1) notFound();
+  return (
+    <Suspense fallback={<p className="p-space-5 text-body text-text-muted">Loading…</p>}>
+      <NewGame />
+    </Suspense>
+  );
+}

--- a/src/app/(app)/games/page.tsx
+++ b/src/app/(app)/games/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { GamesHome } from "@/features/games/components/games-home";
+import { BOAT_GAMES_V1 } from "@/features/games/flag";
+
+export const metadata: Metadata = { title: "Boat Games | Fish Log Book" };
+
+/**
+ * /games — Boat Games home.
+ *
+ * Reached from the Log screen, not from the nav bar. `shell-nav.tsx` records the measured
+ * widths behind that: six labels already wrap to two rows below 384px, and a seventh puts
+ * every phone on two rows. `shell-nav.test.ts` pins the count so adding one stays a
+ * decision rather than a patch.
+ */
+export default function GamesPage() {
+  if (!BOAT_GAMES_V1) notFound();
+  return <GamesHome />;
+}

--- a/src/app/(app)/games/play/page.tsx
+++ b/src/app/(app)/games/play/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
+
+import { ScoreboardRoute } from "@/features/games/components/scoreboard";
+import { BOAT_GAMES_V1 } from "@/features/games/flag";
+
+export const metadata: Metadata = { title: "Game | Fish Log Book" };
+
+/**
+ * /games/play?id=… — the live scoreboard.
+ *
+ * The game id is a query parameter rather than a path segment on purpose. A dynamic
+ * segment makes the route `ƒ`, and ADR 005 §5 is explicit that no product route may become
+ * dynamic: a dynamic route cannot be prerendered, so opening it puts a network round trip
+ * in front of the first paint. For most screens that is a slow load; for this one it is the
+ * feature failing at the only moment it matters, because Boat Games' whole promise is that
+ * a game runs in airplane mode. A game id is minted on the device and can never be listed
+ * in `generateStaticParams`, so the query string is the only shape that stays static.
+ */
+export default function GamePlayPage() {
+  if (!BOAT_GAMES_V1) notFound();
+  return (
+    <Suspense fallback={<p className="p-space-5 text-body text-text-muted">Opening the game…</p>}>
+      <ScoreboardRoute />
+    </Suspense>
+  );
+}

--- a/src/app/(app)/games/result/page.tsx
+++ b/src/app/(app)/games/result/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
+
+import { GameResultsRoute } from "@/features/games/components/game-results";
+import { BOAT_GAMES_V1 } from "@/features/games/flag";
+
+export const metadata: Metadata = { title: "Result | Fish Log Book" };
+
+/** Query parameter rather than a path segment, for the reason in `../play/page.tsx`. */
+export default function GameResultPage() {
+  if (!BOAT_GAMES_V1) notFound();
+  return (
+    <Suspense fallback={<p className="p-space-5 text-body text-text-muted">Reading the scorecard…</p>}>
+      <GameResultsRoute />
+    </Suspense>
+  );
+}

--- a/src/app/(app)/log/page.tsx
+++ b/src/app/(app)/log/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Suspense } from "react";
 
 import { FishLog } from "@/features/catches/components/fish-log";
+import { GamesEntry } from "@/features/games/components/games-entry";
+import { BOAT_GAMES_V1 } from "@/features/games/flag";
 
 export const metadata: Metadata = { title: "Fish Log | Fish Log Book" };
 
@@ -14,13 +16,24 @@ export const metadata: Metadata = { title: "Fish Log | Fish Log Book" };
  *
  * Suspense wraps the log because the fish-log reads `?add=` (calendar backfill, founder
  * Historical §1) through useSearchParams — static prerendering has no URL to read.
+ *
+ * Boat Games hangs off this screen rather than the nav bar (see src/app/(app)/games/page.tsx
+ * for the measurement that decided it). It renders above the log because a running game is
+ * the one thing more urgent than the list of what you have already caught.
  */
 export default function FishLogPage() {
   // Unit preference lives on `angler.unit_preference` and is not wired to a session yet;
   // imperial is the documented default (see the schema's `angler` table).
   return (
-    <Suspense>
-      <FishLog unitSystem="imperial" />
-    </Suspense>
+    <>
+      {BOAT_GAMES_V1 ? (
+        <div className="mx-auto max-w-reading pt-space-3">
+          <GamesEntry />
+        </div>
+      ) : null}
+      <Suspense>
+        <FishLog unitSystem="imperial" />
+      </Suspense>
+    </>
   );
 }

--- a/src/core/rules/games/modes.ts
+++ b/src/core/rules/games/modes.ts
@@ -1,0 +1,208 @@
+/**
+ * The three Phase 1 games, as configurations of one engine (ADR 009 §3).
+ *
+ * Nothing in this file is code the fold has to know about. A mode is a `GameRules`
+ * value, which is why Species Sprint, Grand Slam, Exact 21 and the rest arrive later as
+ * more of these rather than as more scoring systems.
+ */
+
+import type { GameMode, GameRules, SpeciesPointRule } from "./types";
+
+/**
+ * The founder's default tiers. Deliberately NOT a global truth about fish: a calico bass
+ * is an ordinary afternoon in Newport and a notable day off Seattle, so this is a
+ * *starting template* the captain edits, and the game stores the edited copy.
+ */
+export const POINT_TIERS = {
+  common: 1,
+  standard: 3,
+  featured: 5,
+  trophy: 8,
+} as const;
+
+export type PointTier = keyof typeof POINT_TIERS;
+
+export interface PointTemplate {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly tiers: readonly SpeciesPointRule[];
+}
+
+/**
+ * Southern California, the region the app knows best. Group ids (`rockfish`) match every
+ * species that rolls up to them, so the table stays short and still covers the fish
+ * nobody can name to species on a rolling deck.
+ */
+export const SOCAL_TEMPLATE: PointTemplate = {
+  id: "socal",
+  name: "Southern California",
+  description: "Bass and bonito are the everyday fish; yellowtail and bluefin are the day-makers.",
+  tiers: [
+    { species_id: "pacific_mackerel", points: POINT_TIERS.common },
+    { species_id: "surfperch", points: POINT_TIERS.common },
+    { species_id: "croaker", points: POINT_TIERS.common },
+    { species_id: "kelp_bass", points: POINT_TIERS.standard },
+    { species_id: "barred_sand_bass", points: POINT_TIERS.standard },
+    { species_id: "spotted_sand_bass", points: POINT_TIERS.standard },
+    { species_id: "rockfish", points: POINT_TIERS.standard },
+    { species_id: "pacific_bonito", points: POINT_TIERS.standard },
+    { species_id: "california_halibut", points: POINT_TIERS.featured },
+    { species_id: "white_seabass", points: POINT_TIERS.featured },
+    { species_id: "yellowtail", points: POINT_TIERS.featured },
+    { species_id: "bluefin_tuna", points: POINT_TIERS.trophy },
+    { species_id: "yellowfin_tuna", points: POINT_TIERS.trophy },
+    { species_id: "dorado", points: POINT_TIERS.trophy },
+  ],
+};
+
+/** Every fish the same. The honest default when nobody wants to argue about a table. */
+export const FLAT_TEMPLATE: PointTemplate = {
+  id: "flat",
+  name: "Every fish counts the same",
+  description: "One point per fish, whatever it is. Simplest possible game.",
+  tiers: [],
+};
+
+export const POINT_TEMPLATES: readonly PointTemplate[] = [SOCAL_TEMPLATE, FLAT_TEMPLATE];
+
+const NO_BONUSES = {
+  first_blood: 0,
+  new_species: 0,
+  personal_best: 0,
+  release: 0,
+  biggest_of_round: 0,
+} as const;
+
+/**
+ * Captain's Cup as it ships. Points per species, a bonus for the things worth
+ * encouraging, and a three-catch cap so nobody wins the day on one school of mackerel.
+ */
+export function captainsCupDefaults(): GameRules {
+  return {
+    mode: "captains_cup",
+    scoring: {
+      tiers: SOCAL_TEMPLATE.tiers,
+      default_points: POINT_TIERS.common,
+      eligible_species: null,
+      repeat: { kind: "capped", count: 3 },
+      bonuses: {
+        ...NO_BONUSES,
+        first_blood: 2,
+        new_species: 3,
+        personal_best: 3,
+        // A release is worth a point on its own. The game must never make keeping a fish
+        // the scoring choice — legal-and-returned should be at least as good a day.
+        release: 1,
+        biggest_of_round: 5,
+      },
+    },
+    rounds: { count: 1, minutes: 240, multi_day: false, carry_scores: true },
+    cricket: null,
+    elimination: null,
+    tiebreaker: "most_species",
+    host_approval: false,
+    late_join: true,
+  };
+}
+
+export function fishCricketDefaults(): GameRules {
+  return {
+    mode: "fish_cricket",
+    scoring: {
+      tiers: SOCAL_TEMPLATE.tiers,
+      default_points: POINT_TIERS.common,
+      eligible_species: null,
+      repeat: { kind: "unlimited" },
+      bonuses: { ...NO_BONUSES },
+    },
+    rounds: { count: 1, minutes: 240, multi_day: false, carry_scores: true },
+    cricket: {
+      targets: ["kelp_bass", "rockfish", "pacific_bonito", "california_halibut", "yellowtail"],
+      marks_to_close: 3,
+      size_bonus_marks: true,
+      personal_best_marks: false,
+    },
+    elimination: null,
+    tiebreaker: "most_species",
+    host_approval: false,
+    late_join: false,
+  };
+}
+
+export function makeTheCutDefaults(): GameRules {
+  return {
+    mode: "make_the_cut",
+    scoring: {
+      tiers: SOCAL_TEMPLATE.tiers,
+      default_points: POINT_TIERS.common,
+      eligible_species: null,
+      repeat: { kind: "capped", count: 3 },
+      bonuses: { ...NO_BONUSES, biggest_of_round: 5 },
+    },
+    // Three fishing days, closed by the captain. A multi-day game must never end because
+    // somebody's phone changed timezone at the dock (ADR 009 §3).
+    rounds: { count: 3, minutes: null, multi_day: true, carry_scores: false },
+    cricket: null,
+    elimination: { rule: { kind: "lowest" }, by_team: false },
+    tiebreaker: "biggest_fish",
+    host_approval: false,
+    late_join: false,
+  };
+}
+
+export function defaultsFor(mode: GameMode): GameRules {
+  switch (mode) {
+    case "captains_cup":
+      return captainsCupDefaults();
+    case "fish_cricket":
+      return fishCricketDefaults();
+    case "make_the_cut":
+      return makeTheCutDefaults();
+  }
+}
+
+export interface ModeSummary {
+  readonly mode: GameMode;
+  readonly name: string;
+  readonly tagline: string;
+  readonly duration: string;
+  readonly how: readonly string[];
+}
+
+/** What the game list shows: what it is, how long it takes, how it works. */
+export const MODES: readonly ModeSummary[] = [
+  {
+    mode: "captains_cup",
+    name: "Captain's Cup",
+    tagline: "Every fish is worth points. Most points wins.",
+    duration: "A few hours, or a whole day",
+    how: [
+      "The captain sets what each fish is worth.",
+      "Bonuses for your first fish, a new species, a personal best, and the biggest of the day.",
+      "Only the first three of any one species score, so one hot bite can't run away with it.",
+    ],
+  },
+  {
+    mode: "fish_cricket",
+    name: "Fish Cricket",
+    tagline: "Close out your targets before anyone else, then score on them.",
+    duration: "Half a day",
+    how: [
+      "Pick a handful of target species. Three of each closes it.",
+      "A measured fish counts double toward closing.",
+      "Once you've closed a target you score on it — until everyone else closes it too.",
+    ],
+  },
+  {
+    mode: "make_the_cut",
+    name: "Make the Cut",
+    tagline: "Lowest score goes home at the end of each day.",
+    duration: "Two to four fishing days",
+    how: [
+      "Everyone fishes the day. Lowest score is out when the captain closes it.",
+      "Scores start fresh each day, so a bad morning isn't the end of it.",
+      "Knocked out? Keep logging — your fish still count on the trip, just not the cup.",
+    ],
+  },
+];

--- a/src/core/rules/games/results.ts
+++ b/src/core/rules/games/results.ts
@@ -1,0 +1,81 @@
+/**
+ * End-of-game awards, derived from the same folded events as the scoreboard.
+ *
+ * Trimmed on the founder's call to the ones worth having before anybody has played a real
+ * game on a real boat: the winner, the biggest fish, the most species, and what went back
+ * in the water. "Best comeback" and "most valuable catch" are derivable from this same
+ * event list and were deliberately held — a results screen with ten tiles nobody reads is
+ * worse than four they do.
+ *
+ * Pure, like everything else here.
+ */
+
+import type { GameStandings, ScoredEvent } from "./scoring";
+import type { GameParticipant } from "./types";
+
+export interface Award {
+  readonly kind: "biggest_fish" | "most_species" | "released";
+  readonly label: string;
+  /** The participant who earned it, or null when nobody did. */
+  readonly participant_id: string | null;
+  readonly detail: string;
+}
+
+/** The biggest scoring fish of the whole game, by weight and then length. */
+export function biggestFish(standings: GameStandings): ScoredEvent | null {
+  let best: ScoredEvent | null = null;
+  for (const scored of standings.events) {
+    if (scored.status !== "scored" || scored.event.kind !== "catch") continue;
+    const weight = scored.event.weight_g ?? 0;
+    const length = scored.event.length_mm ?? 0;
+    if (weight === 0 && length === 0) continue;
+    const bw = best?.event.weight_g ?? 0;
+    const bl = best?.event.length_mm ?? 0;
+    if (best === null || weight > bw || (weight === bw && length > bl)) best = scored;
+  }
+  return best;
+}
+
+export function awards(
+  standings: GameStandings,
+  participants: readonly GameParticipant[],
+): readonly Award[] {
+  const nameOf = (id: string | null) =>
+    participants.find((p) => p.id === id)?.display_name ?? "Nobody";
+
+  const out: Award[] = [];
+
+  const biggest = biggestFish(standings);
+  if (biggest !== null) {
+    out.push({
+      kind: "biggest_fish",
+      label: "Biggest fish",
+      participant_id: biggest.event.participant_id,
+      detail: nameOf(biggest.event.participant_id),
+    });
+  }
+
+  const mostSpecies = [...standings.rows].sort(
+    (a, b) => b.unique_species.length - a.unique_species.length,
+  )[0];
+  if (mostSpecies && mostSpecies.unique_species.length > 0) {
+    out.push({
+      kind: "most_species",
+      label: "Most species",
+      participant_id: mostSpecies.participant_id,
+      detail: `${nameOf(mostSpecies.participant_id)} · ${mostSpecies.unique_species.length}`,
+    });
+  }
+
+  const released = standings.rows.reduce((sum, r) => sum + r.released, 0);
+  if (released > 0) {
+    out.push({
+      kind: "released",
+      label: "Put back",
+      participant_id: null,
+      detail: `${released} ${released === 1 ? "fish" : "fish"} released`,
+    });
+  }
+
+  return out;
+}

--- a/src/core/rules/games/results.ts
+++ b/src/core/rules/games/results.ts
@@ -13,6 +13,19 @@
 import type { GameStandings, ScoredEvent } from "./scoring";
 import type { GameParticipant } from "./types";
 
+/**
+ * The teams that won, when the game had teams at all.
+ *
+ * Separate from `winner_ids` on purpose: in a team game the individual leader is a fact
+ * about a person, and the result is a fact about a side. Adults can win while the highest
+ * single score sits on the Kids bench.
+ */
+export function winningTeams(standings: GameStandings): readonly string[] {
+  if (standings.teams.length === 0) return [];
+  const top = standings.teams[0].points;
+  return standings.teams.filter((t) => t.points === top).map((t) => t.team_id);
+}
+
 export interface Award {
   readonly kind: "biggest_fish" | "most_species" | "released";
   readonly label: string;

--- a/src/core/rules/games/scoring.test.ts
+++ b/src/core/rules/games/scoring.test.ts
@@ -1,0 +1,470 @@
+import { describe, expect, it } from "vitest";
+
+import { SPECIES, speciesById } from "@/core/ontology/species";
+import { POINT_TEMPLATES, captainsCupDefaults, fishCricketDefaults, makeTheCutDefaults } from "./modes";
+import { repeatValue, score, speciesMatches, type ScoringContext } from "./scoring";
+import type { GameEvent, GameParticipant, GameRules } from "./types";
+import vectors from "../vectors/games.json";
+
+/** The real ontology, so a template naming a fish that does not exist fails here. */
+const CTX: ScoringContext = {
+  rollsUpTo: (id) => speciesById(id)?.rollsUpTo ?? null,
+  isProtected: (id) => speciesById(id)?.takeStatus === "protected",
+};
+
+function player(id: string, over: Partial<GameParticipant> = {}): GameParticipant {
+  return {
+    id,
+    session_id: "s1",
+    display_name: id,
+    color_key: "signal-orange",
+    team_id: null,
+    handicap_points: 0,
+    is_host: false,
+    claimed_user_id: null,
+    joined_at: "2026-09-04T14:00:00.000Z",
+    removed_at: null,
+    ...over,
+  };
+}
+
+let seq = 0;
+function fish(participant: string, species: string | null, over: Partial<GameEvent> = {}): GameEvent {
+  seq += 1;
+  return {
+    id: `e${seq}`,
+    session_id: "s1",
+    kind: "catch",
+    participant_id: participant,
+    round: 1,
+    seq,
+    created_at: `2026-09-04T14:${String(seq).padStart(2, "0")}:00.000Z`,
+    species_id: species,
+    species_other: null,
+    length_mm: null,
+    weight_g: null,
+    disposition: "released",
+    personal_best: false,
+    new_species: false,
+    catch_id: null,
+    legal: null,
+    voids_event_id: null,
+    adjustment_points: null,
+    note: null,
+    approved: true,
+    ...over,
+  };
+}
+
+function control(over: Partial<GameEvent>): GameEvent {
+  seq += 1;
+  return fish("", null, { kind: "round_advanced", participant_id: null, seq, id: `c${seq}`, ...over });
+}
+
+/** Captain's Cup with the bonuses off, so a test asserts one thing at a time. */
+function plainCup(over: Partial<GameRules> = {}): GameRules {
+  const base = captainsCupDefaults();
+  return {
+    ...base,
+    scoring: {
+      ...base.scoring,
+      bonuses: { first_blood: 0, new_species: 0, personal_best: 0, release: 0, biggest_of_round: 0 },
+    },
+    ...over,
+  };
+}
+
+const pointsOf = (s: ReturnType<typeof score>, id: string) =>
+  s.rows.find((r) => r.participant_id === id)?.points ?? null;
+
+describe("repeatValue — vectors", () => {
+  for (const v of vectors.repeatValue) {
+    it(v.why, () => {
+      expect(repeatValue(v.base, v.prior, v.rule as never)).toBe(v.expect);
+    });
+  }
+});
+
+describe("speciesMatches — vectors", () => {
+  for (const v of vectors.speciesMatches) {
+    it(v.why, () => {
+      expect(speciesMatches(v.species, v.rule, CTX)).toBe(v.expect);
+    });
+  }
+});
+
+describe("point templates", () => {
+  it("name only species the ontology actually has", () => {
+    const known = new Set(SPECIES.map((s) => s.id));
+    for (const template of POINT_TEMPLATES) {
+      for (const tier of template.tiers) {
+        expect(known, `${template.id} names "${tier.species_id}"`).toContain(tier.species_id);
+      }
+    }
+  });
+
+  it("never award points for a protected species", () => {
+    for (const template of POINT_TEMPLATES) {
+      for (const tier of template.tiers) {
+        expect(speciesById(tier.species_id)?.takeStatus).not.toBe("protected");
+      }
+    }
+  });
+});
+
+describe("Captain's Cup", () => {
+  it("scores a fish at its tier", () => {
+    const s = score(plainCup(), [player("a")], [fish("a", "yellowtail")], CTX);
+    expect(pointsOf(s, "a")).toBe(5);
+  });
+
+  it("scores an unlisted eligible species at the default", () => {
+    const s = score(plainCup(), [player("a")], [fish("a", "opaleye")], CTX);
+    expect(pointsOf(s, "a")).toBe(1);
+  });
+
+  it("matches a group tier through roll-up", () => {
+    const s = score(plainCup(), [player("a")], [fish("a", "vermilion_rockfish")], CTX);
+    expect(pointsOf(s, "a")).toBe(3);
+  });
+
+  it("prefers an exact species tier over its group", () => {
+    const rules = plainCup();
+    const withExact: GameRules = {
+      ...rules,
+      scoring: {
+        ...rules.scoring,
+        tiers: [...rules.scoring.tiers, { species_id: "vermilion_rockfish", points: 7 }],
+      },
+    };
+    const s = score(withExact, [player("a")], [fish("a", "vermilion_rockfish")], CTX);
+    expect(pointsOf(s, "a")).toBe(7);
+  });
+
+  it("caps repeats of one species at three", () => {
+    const s = score(
+      plainCup(),
+      [player("a")],
+      [1, 2, 3, 4, 5].map(() => fish("a", "yellowtail")),
+      CTX,
+    );
+    expect(pointsOf(s, "a")).toBe(15);
+    expect(s.rows[0].scoring_catches).toBe(3);
+    expect(s.rows[0].total_catches).toBe(5);
+  });
+
+  it("adds a handicap once, not per catch", () => {
+    const s = score(
+      plainCup(),
+      [player("a", { handicap_points: 10 })],
+      [fish("a", "yellowtail"), fish("a", "kelp_bass")],
+      CTX,
+    );
+    expect(pointsOf(s, "a")).toBe(18);
+  });
+
+  it("pays the bonuses the founder asked for", () => {
+    const s = score(
+      captainsCupDefaults(),
+      [player("a")],
+      [fish("a", "yellowtail", { new_species: true, personal_best: true, disposition: "released" })],
+      CTX,
+    );
+    // 5 tier + 2 first blood + 3 new species + 3 personal best + 1 release
+    expect(pointsOf(s, "a")).toBe(14);
+  });
+
+  it("pays first blood exactly once in a game", () => {
+    const s = score(
+      captainsCupDefaults(),
+      [player("a"), player("b")],
+      [fish("a", "kelp_bass"), fish("b", "kelp_bass"), fish("a", "kelp_bass")],
+      CTX,
+    );
+    const firstBlood = s.events.flatMap((e) => e.bonuses).filter((b) => b.kind === "first_blood");
+    expect(firstBlood).toHaveLength(1);
+  });
+});
+
+describe("the safeguards the game may never get wrong", () => {
+  it("scores a protected species zero, and says so", () => {
+    const protectedSpecies = SPECIES.find((s) => s.takeStatus === "protected");
+    expect(protectedSpecies, "the ontology has a protected species to test with").toBeDefined();
+    const s = score(plainCup(), [player("a")], [fish("a", protectedSpecies!.id)], CTX);
+    expect(pointsOf(s, "a")).toBe(0);
+    expect(s.events[0].status).toBe("zero_protected");
+    expect(s.events[0].reason).toBeTruthy();
+  });
+
+  it("scores a fish kept against a release verdict zero", () => {
+    const s = score(
+      plainCup(),
+      [player("a")],
+      [
+        fish("a", "yellowtail", {
+          disposition: "kept",
+          legal: {
+            verdict: "release",
+            reason: "Season closed today in this management area.",
+            pack_id: "socal",
+            pack_version: 3,
+            protected_species: false,
+          },
+        }),
+      ],
+      CTX,
+    );
+    expect(pointsOf(s, "a")).toBe(0);
+    expect(s.events[0].status).toBe("zero_illegal_retention");
+  });
+
+  it("pays a legal release in full — a fish never has to be killed to score", () => {
+    const legal = {
+      verdict: "keep" as const,
+      reason: "Open season.",
+      pack_id: "socal",
+      pack_version: 3,
+      protected_species: false,
+    };
+    const kept = score(plainCup(), [player("a")], [fish("a", "yellowtail", { disposition: "kept", legal })], CTX);
+    const released = score(plainCup(), [player("a")], [fish("a", "yellowtail", { disposition: "released", legal })], CTX);
+    expect(pointsOf(released, "a")).toBe(pointsOf(kept, "a"));
+  });
+
+  it("treats an unknown legal reading as unknown, not as prohibited", () => {
+    const s = score(plainCup(), [player("a")], [fish("a", "yellowtail", { legal: null, disposition: "kept" })], CTX);
+    expect(pointsOf(s, "a")).toBe(5);
+  });
+
+  it("gives an unresolved Quick Mark nothing until the species is named", () => {
+    const s = score(plainCup(), [player("a")], [fish("a", null)], CTX);
+    expect(pointsOf(s, "a")).toBe(0);
+    expect(s.events[0].status).toBe("zero_unresolved");
+  });
+
+  it("scores nothing for a species outside the eligible list", () => {
+    const rules = plainCup();
+    const s = score(
+      { ...rules, scoring: { ...rules.scoring, eligible_species: ["yellowtail"] } },
+      [player("a")],
+      [fish("a", "kelp_bass")],
+      CTX,
+    );
+    expect(s.events[0].status).toBe("zero_not_eligible");
+  });
+});
+
+describe("a catch cannot score twice", () => {
+  it("folds a duplicated event id exactly once", () => {
+    const one = fish("a", "yellowtail");
+    const s = score(plainCup(), [player("a")], [one, { ...one }, { ...one, seq: one.seq + 50 }], CTX);
+    expect(pointsOf(s, "a")).toBe(5);
+    expect(s.rows[0].total_catches).toBe(1);
+  });
+
+  it("scores the same whatever order the events arrive in", () => {
+    const events = [fish("a", "yellowtail"), fish("a", "kelp_bass"), fish("a", "dorado")];
+    const forward = score(plainCup(), [player("a")], events, CTX);
+    const backward = score(plainCup(), [player("a")], [...events].reverse(), CTX);
+    expect(pointsOf(backward, "a")).toBe(pointsOf(forward, "a"));
+  });
+
+  it("orders by seq, not by the device clock", () => {
+    const first = fish("a", "yellowtail", { created_at: "2030-01-01T00:00:00.000Z" });
+    const second = fish("a", "kelp_bass", { created_at: "2001-01-01T00:00:00.000Z" });
+    const s = score(plainCup(), [player("a")], [first, second], CTX);
+    expect(s.events.map((e) => e.event.id)).toEqual([first.id, second.id]);
+  });
+});
+
+describe("undo and correction", () => {
+  it("takes back the points of a voided catch", () => {
+    const caught = fish("a", "yellowtail");
+    const undo = control({ kind: "void", voids_event_id: caught.id });
+    const s = score(plainCup(), [player("a")], [caught, undo], CTX);
+    expect(pointsOf(s, "a")).toBe(0);
+    expect(s.events[0].status).toBe("voided");
+  });
+
+  it("keeps the voided catch in the record rather than deleting it", () => {
+    const caught = fish("a", "yellowtail");
+    const s = score(plainCup(), [player("a")], [caught, control({ kind: "void", voids_event_id: caught.id })], CTX);
+    expect(s.events.some((e) => e.event.id === caught.id)).toBe(true);
+    expect(s.rows[0].total_catches).toBe(1);
+  });
+
+  it("applies a host adjustment with its note", () => {
+    const s = score(
+      plainCup(),
+      [player("a")],
+      [fish("a", "yellowtail"), control({ kind: "adjustment", participant_id: "a", adjustment_points: -5, note: "Wrong angler." })],
+      CTX,
+    );
+    expect(pointsOf(s, "a")).toBe(0);
+  });
+
+  it("holds a catch at zero while the captain has not approved it", () => {
+    const rules: GameRules = { ...plainCup(), host_approval: true };
+    const s = score(rules, [player("a")], [fish("a", "yellowtail", { approved: false })], CTX);
+    expect(pointsOf(s, "a")).toBe(0);
+    expect(s.events[0].status).toBe("pending_approval");
+  });
+});
+
+describe("Fish Cricket", () => {
+  const cricket = fishCricketDefaults();
+
+  it("takes three marks to close a target, and the closing fish does not score", () => {
+    const s = score(cricket, [player("a"), player("b")], [
+      fish("a", "kelp_bass"),
+      fish("a", "kelp_bass"),
+      fish("a", "kelp_bass"),
+    ], CTX);
+    expect(s.rows.find((r) => r.participant_id === "a")?.marks.kelp_bass).toBe(3);
+    expect(pointsOf(s, "a")).toBe(0);
+  });
+
+  it("scores on a closed target while an opponent still has it open", () => {
+    const s = score(cricket, [player("a"), player("b")], [
+      fish("a", "kelp_bass"),
+      fish("a", "kelp_bass"),
+      fish("a", "kelp_bass"),
+      fish("a", "kelp_bass"),
+    ], CTX);
+    expect(pointsOf(s, "a")).toBe(3);
+  });
+
+  it("stops paying once every opponent has closed it too", () => {
+    const s = score(cricket, [player("a"), player("b")], [
+      fish("a", "kelp_bass"), fish("a", "kelp_bass"), fish("a", "kelp_bass"),
+      fish("b", "kelp_bass"), fish("b", "kelp_bass"), fish("b", "kelp_bass"),
+      fish("a", "kelp_bass"),
+    ], CTX);
+    expect(pointsOf(s, "a")).toBe(0);
+  });
+
+  it("counts a measured fish double toward closing", () => {
+    const s = score(cricket, [player("a"), player("b")], [
+      fish("a", "kelp_bass", { weight_g: 2000 }),
+      fish("a", "kelp_bass", { weight_g: 2000 }),
+    ], CTX);
+    expect(s.rows.find((r) => r.participant_id === "a")?.marks.kelp_bass).toBe(3);
+  });
+
+  it("ignores a species that is not a target", () => {
+    const s = score(cricket, [player("a"), player("b")], [fish("a", "pacific_mackerel")], CTX);
+    expect(pointsOf(s, "a")).toBe(0);
+  });
+});
+
+describe("Make the Cut", () => {
+  const cut = makeTheCutDefaults();
+
+  it("eliminates the lowest score when the captain closes the day", () => {
+    const s = score(cut, [player("a"), player("b"), player("c")], [
+      fish("a", "yellowtail"),
+      fish("b", "kelp_bass"),
+      control({}),
+    ], CTX);
+    expect(s.rows.find((r) => r.participant_id === "c")?.eliminated_round).toBe(1);
+    expect(s.rows.find((r) => r.participant_id === "a")?.eliminated_round).toBeNull();
+  });
+
+  it("eliminates everyone tied at the bottom rather than picking one", () => {
+    const s = score(cut, [player("a"), player("b"), player("c")], [
+      fish("a", "yellowtail"),
+      control({}),
+    ], CTX);
+    expect(s.rows.find((r) => r.participant_id === "b")?.eliminated_round).toBe(1);
+    expect(s.rows.find((r) => r.participant_id === "c")?.eliminated_round).toBe(1);
+  });
+
+  it("resets scores between days when the rules say so", () => {
+    const s = score(cut, [player("a"), player("b")], [
+      fish("a", "yellowtail"),
+      control({}),
+      fish("a", "kelp_bass"),
+    ], CTX);
+    expect(pointsOf(s, "a")).toBe(3);
+  });
+
+  it("keeps logging an eliminated angler's fish, but stops scoring them", () => {
+    const s = score(cut, [player("a"), player("b")], [
+      fish("a", "yellowtail"),
+      control({}),
+      fish("b", "yellowtail"),
+    ], CTX);
+    const b = s.rows.find((r) => r.participant_id === "b");
+    expect(b?.total_catches).toBe(1);
+    expect(b?.points).toBe(0);
+    expect(s.events[2].status).toBe("zero_eliminated");
+  });
+
+  it("never ranks an eliminated angler above one still fishing", () => {
+    const s = score(cut, [player("a"), player("b"), player("c")], [
+      fish("a", "yellowtail"),
+      fish("b", "kelp_bass"),
+      control({}),
+    ], CTX);
+    expect(s.rows[s.rows.length - 1].eliminated_round).not.toBeNull();
+  });
+});
+
+describe("standings", () => {
+  it("gives equal scores an equal rank", () => {
+    const s = score(plainCup(), [player("a"), player("b")], [
+      fish("a", "yellowtail"),
+      fish("b", "yellowtail"),
+    ], CTX);
+    expect(s.rows.map((r) => r.rank)).toEqual([1, 1]);
+  });
+
+  /*
+    Both anglers finish on exactly 5, so the tiebreaker is the only thing that can order
+    them — and the same events must order differently under a different tiebreaker. An
+    earlier version of this test had one angler ahead on points, which would have passed
+    with the tiebreaker deleted entirely.
+  */
+  const tiedEvents = () => [
+    fish("a", "yellowtail", { weight_g: 9000 }), // 5 points, one species, a big fish
+    fish("b", "pacific_bonito"), // 3
+    fish("b", "pacific_mackerel"), // 1
+    fish("b", "opaleye"), // 1 — also 5, across three species, all unmeasured
+  ];
+
+  it("breaks a tie on unique species when the rules say so", () => {
+    const s = score({ ...plainCup(), tiebreaker: "most_species" }, [player("a"), player("b")], tiedEvents(), CTX);
+    expect(pointsOf(s, "a")).toBe(pointsOf(s, "b"));
+    expect(s.rows[0].participant_id).toBe("b");
+  });
+
+  it("breaks the same tie the other way on biggest fish", () => {
+    const s = score({ ...plainCup(), tiebreaker: "biggest_fish" }, [player("a"), player("b")], tiedEvents(), CTX);
+    expect(pointsOf(s, "a")).toBe(pointsOf(s, "b"));
+    expect(s.rows[0].participant_id).toBe("a");
+  });
+
+  it("totals a team from its members", () => {
+    const s = score(plainCup(), [
+      player("a", { team_id: "port" }),
+      player("b", { team_id: "port" }),
+      player("c", { team_id: "starboard" }),
+    ], [fish("a", "yellowtail"), fish("b", "kelp_bass"), fish("c", "kelp_bass")], CTX);
+    expect(s.teams.find((t) => t.team_id === "port")?.points).toBe(8);
+    expect(s.teams[0].team_id).toBe("port");
+  });
+
+  it("ignores a player removed before the game began", () => {
+    const s = score(plainCup(), [player("a"), player("b", { removed_at: "2026-09-04T13:00:00.000Z" })], [
+      fish("b", "yellowtail"),
+    ], CTX);
+    expect(s.rows).toHaveLength(1);
+    expect(s.events[0].status).toBe("voided");
+  });
+
+  it("reports a paused game as paused", () => {
+    const s = score(plainCup(), [player("a")], [control({ kind: "paused" })], CTX);
+    expect(s.paused).toBe(true);
+    expect(score(plainCup(), [player("a")], [control({ kind: "paused" }), control({ kind: "resumed" })], CTX).paused).toBe(false);
+  });
+});

--- a/src/core/rules/games/scoring.test.ts
+++ b/src/core/rules/games/scoring.test.ts
@@ -589,3 +589,24 @@ describe("team games are won by a side, not a person", () => {
     expect(winningTeams(s)).toEqual([]);
   });
 });
+
+describe("a fish cannot score twice on a wet phone", () => {
+  it("scores one fish once even if the same event is written twice with different sequences", () => {
+    // The shape a stale sequence counter would produce: one tap, two rows, same id.
+    const one = fish("a", "yellowtail");
+    const s = score(plainCup(), [player("a")], [one, { ...one, seq: one.seq + 1 }], CTX);
+    expect(pointsOf(s, "a")).toBe(5);
+    expect(s.rows[0].total_catches).toBe(1);
+  });
+
+  it("keeps a total order even when two events share a sequence number", () => {
+    // Two genuinely different fish that raced for the same seq. They must both count, and
+    // every device must fold them in the same order — hence the id tiebreak.
+    const a = fish("a", "yellowtail");
+    const b = { ...fish("a", "kelp_bass"), seq: a.seq };
+    const forward = score(plainCup(), [player("a")], [a, b], CTX);
+    const backward = score(plainCup(), [player("a")], [b, a], CTX);
+    expect(pointsOf(forward, "a")).toBe(8);
+    expect(forward.events.map((e) => e.event.id)).toEqual(backward.events.map((e) => e.event.id));
+  });
+});

--- a/src/core/rules/games/scoring.test.ts
+++ b/src/core/rules/games/scoring.test.ts
@@ -513,3 +513,46 @@ describe("end-of-game awards", () => {
     expect(most?.participant_id).toBe("b");
   });
 });
+
+describe("a round reset resets what the board shows, not the game's totals", () => {
+  const cut = makeTheCutDefaults();
+
+  it("clears the displayed counters alongside the score", () => {
+    // The bug this pins: a day-2 board reading "1 fish · 1 species" beside a score of 0,
+    // because the fish were yesterday's and the score was not. Caught on a real screen.
+    const s = score(cut, [player("a"), player("b")], [
+      fish("a", "yellowtail", { disposition: "released" }),
+      fish("b", "kelp_bass"),
+      control({}),
+    ], CTX);
+    const a = s.rows.find((r) => r.participant_id === "a");
+    expect(a?.points).toBe(0);
+    expect(a?.scoring_catches).toBe(0);
+    expect(a?.unique_species).toEqual([]);
+    expect(a?.released).toBe(0);
+  });
+
+  it("keeps the whole game's totals for the results screen", () => {
+    const s = score(cut, [player("a"), player("b")], [
+      fish("a", "yellowtail", { disposition: "released" }),
+      fish("b", "kelp_bass"),
+      control({}),
+    ], CTX);
+    const a = s.rows.find((r) => r.participant_id === "a");
+    expect(a?.total_catches).toBe(1);
+    expect(a?.total_species).toBe(1);
+    expect(a?.total_released).toBe(1);
+  });
+
+  it("leaves both alone when scores carry between rounds", () => {
+    const carry = { ...cut, rounds: { ...cut.rounds, carry_scores: true } };
+    const s = score(carry, [player("a"), player("b")], [
+      fish("a", "yellowtail"),
+      fish("b", "kelp_bass"),
+      control({}),
+    ], CTX);
+    const a = s.rows.find((r) => r.participant_id === "a");
+    expect(a?.points).toBe(5);
+    expect(a?.scoring_catches).toBe(1);
+  });
+});

--- a/src/core/rules/games/scoring.test.ts
+++ b/src/core/rules/games/scoring.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { SPECIES, speciesById } from "@/core/ontology/species";
 import { POINT_TEMPLATES, captainsCupDefaults, fishCricketDefaults, makeTheCutDefaults } from "./modes";
+import { awards, biggestFish } from "./results";
 import { repeatValue, score, speciesMatches, type ScoringContext } from "./scoring";
 import type { GameEvent, GameParticipant, GameRules } from "./types";
 import vectors from "../vectors/games.json";
@@ -466,5 +467,49 @@ describe("standings", () => {
     const s = score(plainCup(), [player("a")], [control({ kind: "paused" })], CTX);
     expect(s.paused).toBe(true);
     expect(score(plainCup(), [player("a")], [control({ kind: "paused" }), control({ kind: "resumed" })], CTX).paused).toBe(false);
+  });
+});
+
+describe("end-of-game awards", () => {
+  it("finds the biggest scoring fish by weight, then length", () => {
+    const s = score(plainCup(), [player("a"), player("b")], [
+      fish("a", "yellowtail", { weight_g: 5000, length_mm: 700 }),
+      fish("b", "yellowtail", { weight_g: 5000, length_mm: 900 }),
+      fish("a", "kelp_bass", { weight_g: 1000 }),
+    ], CTX);
+    expect(biggestFish(s)?.event.participant_id).toBe("b");
+  });
+
+  it("ignores a fish that scored nothing", () => {
+    const s = score(plainCup(), [player("a"), player("b")], [
+      fish("a", "yellowtail", { weight_g: 1000 }),
+      fish("b", null, { weight_g: 99_000 }), // unresolved, so it never scored
+    ], CTX);
+    expect(biggestFish(s)?.event.participant_id).toBe("a");
+  });
+
+  it("has no biggest fish when nobody measured anything", () => {
+    const s = score(plainCup(), [player("a")], [fish("a", "yellowtail")], CTX);
+    expect(biggestFish(s)).toBeNull();
+  });
+
+  it("totals the released fish across everyone", () => {
+    const s = score(plainCup(), [player("a"), player("b")], [
+      fish("a", "yellowtail", { disposition: "released" }),
+      fish("b", "kelp_bass", { disposition: "released" }),
+      fish("b", "kelp_bass", { disposition: "kept" }),
+    ], CTX);
+    const released = awards(s, [player("a"), player("b")]).find((x) => x.kind === "released");
+    expect(released?.detail).toBe("2 fish released");
+  });
+
+  it("names the angler with the most species", () => {
+    const s = score(plainCup(), [player("a"), player("b")], [
+      fish("a", "yellowtail"),
+      fish("b", "kelp_bass"),
+      fish("b", "opaleye"),
+    ], CTX);
+    const most = awards(s, [player("a"), player("b")]).find((x) => x.kind === "most_species");
+    expect(most?.participant_id).toBe("b");
   });
 });

--- a/src/core/rules/games/scoring.test.ts
+++ b/src/core/rules/games/scoring.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { SPECIES, speciesById } from "@/core/ontology/species";
 import { POINT_TEMPLATES, captainsCupDefaults, fishCricketDefaults, makeTheCutDefaults } from "./modes";
-import { awards, biggestFish } from "./results";
+import { awards, biggestFish, winningTeams } from "./results";
 import { repeatValue, score, speciesMatches, type ScoringContext } from "./scoring";
 import type { GameEvent, GameParticipant, GameRules } from "./types";
 import vectors from "../vectors/games.json";
@@ -554,5 +554,38 @@ describe("a round reset resets what the board shows, not the game's totals", () 
     const a = s.rows.find((r) => r.participant_id === "a");
     expect(a?.points).toBe(5);
     expect(a?.scoring_catches).toBe(1);
+  });
+});
+
+describe("team games are won by a side, not a person", () => {
+  const teamed = () => [
+    player("a", { team_id: "Adults" }),
+    player("b", { team_id: "Adults" }),
+    player("c", { team_id: "Kids" }),
+    player("d", { team_id: "Kids" }),
+  ];
+
+  it("names the winning team even when the top individual is on the losing side", () => {
+    // Ruby out-fishes everyone, and still loses: two steady Adults beat one hot Kid.
+    const s = score(plainCup(), teamed(), [
+      fish("c", "bluefin_tuna"), // 8 — the biggest single score in the game
+      fish("a", "yellowtail"), // 5
+      fish("b", "yellowtail"), // 5 — Adults 10, Kids 8
+    ], CTX);
+    expect(s.rows[0].participant_id).toBe("c");
+    expect(winningTeams(s)).toEqual(["Adults"]);
+  });
+
+  it("returns both sides on a genuine tie", () => {
+    const s = score(plainCup(), teamed(), [
+      fish("a", "yellowtail"),
+      fish("c", "yellowtail"),
+    ], CTX);
+    expect(winningTeams(s)).toEqual(["Adults", "Kids"]);
+  });
+
+  it("returns nothing at all when the game had no teams", () => {
+    const s = score(plainCup(), [player("a")], [fish("a", "yellowtail")], CTX);
+    expect(winningTeams(s)).toEqual([]);
   });
 });

--- a/src/core/rules/games/scoring.ts
+++ b/src/core/rules/games/scoring.ts
@@ -1,0 +1,635 @@
+/**
+ * The Boat Games scoring fold (ADR 009 §3).
+ *
+ * One function decides every score in every mode: `score(rules, participants, events)`.
+ * Nothing is stored — the scoreboard is *derived* on every read, and that is what makes
+ * four of the founder's acceptance criteria structural rather than things to remember:
+ *
+ *   - **A catch cannot score twice.** Events fold by `id`, once. A double-tap on a wet
+ *     screen either writes one row or writes two rows carrying the same id, and IndexedDB
+ *     `put` makes those the same row.
+ *   - **Undo works.** A `void` event names the event it undoes and the fold skips it.
+ *     Nothing is mutated or deleted, so a correction is additive and the history survives.
+ *   - **Three modes, one engine.** Captain's Cup, Fish Cricket and Make the Cut differ
+ *     only in their `GameRules`. So will Species Sprint, Grand Slam and the rest.
+ *   - **Order never depends on the clock.** Events fold in `seq` order. Offline the device
+ *     clock is the only clock available and the angler can change it in Settings; a game
+ *     must not reorder itself because somebody fixed their timezone at the dock.
+ *
+ * Pure. The two facts it needs about a species — what it rolls up to, and whether it is
+ * protected — arrive as functions, the same way `evaluateBadges` takes `waterClassOf`,
+ * so this file can be tested without the ontology and the Swift client can be checked
+ * against the same vectors.
+ */
+
+import type {
+  GameEvent,
+  GameParticipant,
+  GameRules,
+  RepeatRule,
+  Tiebreaker,
+} from "./types";
+
+/** The two ontology facts the fold needs, injected so the rules stay pure (ADR 003 §3). */
+export interface ScoringContext {
+  /** The group a species belongs to (`vermilion_rockfish` -> `rockfish`), or null. */
+  readonly rollsUpTo: (speciesId: string) => string | null;
+  /** Protected in the ontology, independent of any regional pack. */
+  readonly isProtected: (speciesId: string) => boolean;
+}
+
+/**
+ * Why an event scored what it did. Every zero has a named reason, because "this fish got
+ * nothing" is the moment an angler needs a sentence and not a shrug.
+ */
+export type EventScoreStatus =
+  | "scored"
+  | "voided"
+  | "pending_approval"
+  | "zero_unresolved"
+  | "zero_not_eligible"
+  | "zero_protected"
+  | "zero_illegal_retention"
+  | "zero_repeat_cap"
+  | "zero_eliminated";
+
+export interface AppliedBonus {
+  readonly kind: "first_blood" | "new_species" | "personal_best" | "release" | "biggest_of_round";
+  readonly points: number;
+}
+
+export interface ScoredEvent {
+  readonly event: GameEvent;
+  readonly points: number;
+  readonly base_points: number;
+  readonly bonuses: readonly AppliedBonus[];
+  readonly status: EventScoreStatus;
+  /** One plain sentence, ready to render. Null when it simply scored. */
+  readonly reason: string | null;
+  /** Marks added, for Fish Cricket. Zero in the other modes. */
+  readonly marks: number;
+  /** The target this catch counted toward, for Fish Cricket. */
+  readonly target: string | null;
+}
+
+export interface Standing {
+  readonly participant_id: string;
+  readonly team_id: string | null;
+  readonly points: number;
+  readonly handicap: number;
+  readonly scoring_catches: number;
+  readonly total_catches: number;
+  readonly released: number;
+  readonly unique_species: readonly string[];
+  /** Fish Cricket: target -> marks accrued (capped at `marks_to_close`). */
+  readonly marks: Readonly<Record<string, number>>;
+  readonly closed: readonly string[];
+  /** Make the Cut: the round at the end of which they were eliminated. */
+  readonly eliminated_round: number | null;
+  readonly rank: number;
+}
+
+export interface TeamStanding {
+  readonly team_id: string;
+  readonly points: number;
+  readonly participant_ids: readonly string[];
+  readonly eliminated_round: number | null;
+  readonly rank: number;
+}
+
+export interface GameStandings {
+  readonly rows: readonly Standing[];
+  readonly teams: readonly TeamStanding[];
+  /** The round currently in play (1-based). */
+  readonly round: number;
+  readonly leader_id: string | null;
+  /** Every event in fold order, scored — the timeline and the review list read this. */
+  readonly events: readonly ScoredEvent[];
+  readonly paused: boolean;
+  readonly complete: boolean;
+  /** More than one id means a genuine tie the tiebreaker could not split. */
+  readonly winner_ids: readonly string[];
+}
+
+// ---------------------------------------------------------------------------------
+// Eligibility and points for one catch
+// ---------------------------------------------------------------------------------
+
+/**
+ * Does `speciesId` match `ruleId`, where `ruleId` may name a group?
+ *
+ * Exact match first, then one hop up the roll-up chain. One hop is enough for the current
+ * ontology (a species rolls up to a group; groups do not nest), and the loop below is
+ * bounded anyway so a future nested group cannot spin.
+ */
+export function speciesMatches(
+  speciesId: string,
+  ruleId: string,
+  ctx: ScoringContext,
+): boolean {
+  if (speciesId === ruleId) return true;
+  let cursor: string | null = speciesId;
+  for (let hops = 0; hops < 4 && cursor !== null; hops += 1) {
+    cursor = ctx.rollsUpTo(cursor);
+    if (cursor === ruleId) return true;
+  }
+  return false;
+}
+
+function tierPointsFor(
+  speciesId: string,
+  rules: GameRules,
+  ctx: ScoringContext,
+): number {
+  // An exact species tier beats a group tier, so "Bluefin 8" wins over "Tuna 3".
+  const exact = rules.scoring.tiers.find((t) => t.species_id === speciesId);
+  if (exact) return exact.points;
+  const group = rules.scoring.tiers.find((t) => speciesMatches(speciesId, t.species_id, ctx));
+  if (group) return group.points;
+  return rules.scoring.default_points;
+}
+
+function isEligible(speciesId: string, rules: GameRules, ctx: ScoringContext): boolean {
+  const eligible = rules.scoring.eligible_species;
+  if (eligible === null) return true;
+  return eligible.some((id) => speciesMatches(speciesId, id, ctx));
+}
+
+/**
+ * The repeat rule, applied to the Nth scoring catch of a species by one participant.
+ * `priorCount` is how many already scored. Returns the base value this one earns.
+ */
+export function repeatValue(base: number, priorCount: number, rule: RepeatRule): number {
+  switch (rule.kind) {
+    case "unlimited":
+      return base;
+    case "unique_only":
+      return priorCount === 0 ? base : 0;
+    case "capped":
+      return priorCount < rule.count ? base : 0;
+    case "diminishing": {
+      // Full, half, quarter… floored at one point so a repeat is never worth nothing
+      // while the rule still says catches count. Zero is what `capped` is for.
+      const divided = Math.floor(base / 2 ** priorCount);
+      return Math.max(1, divided);
+    }
+  }
+}
+
+/** The single largest fish among a set of scored catches. Weight first, then length. */
+function largestOf(events: readonly ScoredEvent[]): readonly string[] {
+  let best: { weight: number; length: number } | null = null;
+  for (const scored of events) {
+    const weight = scored.event.weight_g ?? 0;
+    const length = scored.event.length_mm ?? 0;
+    if (weight === 0 && length === 0) continue;
+    if (
+      best === null ||
+      weight > best.weight ||
+      (weight === best.weight && length > best.length)
+    ) {
+      best = { weight, length };
+    }
+  }
+  if (best === null) return [];
+  const winner = best;
+  return events
+    .filter(
+      (s) =>
+        (s.event.weight_g ?? 0) === winner.weight &&
+        (s.event.length_mm ?? 0) === winner.length,
+    )
+    .map((s) => s.event.id);
+}
+
+// ---------------------------------------------------------------------------------
+// The fold
+// ---------------------------------------------------------------------------------
+
+interface WorkingRow {
+  points: number;
+  scoring_catches: number;
+  total_catches: number;
+  released: number;
+  species: Set<string>;
+  speciesScoringCount: Map<string, number>;
+  marks: Map<string, number>;
+  eliminated_round: number | null;
+}
+
+export function score(
+  rules: GameRules,
+  participants: readonly GameParticipant[],
+  events: readonly GameEvent[],
+  ctx: ScoringContext,
+): GameStandings {
+  const active = participants.filter((p) => p.removed_at === null);
+  const rows = new Map<string, WorkingRow>();
+  for (const p of active) {
+    rows.set(p.id, {
+      points: p.handicap_points,
+      scoring_catches: 0,
+      total_catches: 0,
+      released: 0,
+      species: new Set(),
+      speciesScoringCount: new Map(),
+      marks: new Map(),
+      eliminated_round: null,
+    });
+  }
+
+  /*
+    Fold order is `seq`, and each id folds exactly once.
+
+    The dedup is not belt-and-braces over IndexedDB's `put`. It is the guarantee itself:
+    the founder's criterion is "a catch cannot score twice", and the only way to mean that
+    is for the *scoring* to be idempotent, whatever the caller hands it. A retried write, a
+    double-tap that re-fires a handler, a Phase 2 sync that replays an event already
+    present — all of them arrive here as a duplicate id, and all of them score once.
+  */
+  const seen = new Set<string>();
+  const ordered = [...events]
+    .sort((a, b) => (a.seq === b.seq ? (a.id < b.id ? -1 : 1) : a.seq - b.seq))
+    .filter((e) => {
+      if (seen.has(e.id)) return false;
+      seen.add(e.id);
+      return true;
+    });
+  const voided = new Set<string>();
+  for (const e of ordered) {
+    if (e.kind === "void" && e.voids_event_id !== null) voided.add(e.voids_event_id);
+  }
+
+  const scored: ScoredEvent[] = [];
+  const roundCatches = new Map<number, ScoredEvent[]>();
+  let round = 1;
+  let paused = false;
+  let complete = false;
+  let firstBloodTaken = false;
+
+  const closedTargets = (): Map<string, Set<string>> => {
+    const out = new Map<string, Set<string>>();
+    for (const [id, row] of rows) {
+      const set = new Set<string>();
+      for (const [target, marks] of row.marks) {
+        if (marks >= (rules.cricket?.marks_to_close ?? 3)) set.add(target);
+      }
+      out.set(id, set);
+    }
+    return out;
+  };
+
+  for (const event of ordered) {
+    if (event.kind === "paused") {
+      paused = true;
+      continue;
+    }
+    if (event.kind === "resumed") {
+      paused = false;
+      continue;
+    }
+    if (event.kind === "void") {
+      scored.push(blank(event, "voided", null));
+      continue;
+    }
+    if (event.kind === "adjustment") {
+      const row = event.participant_id === null ? undefined : rows.get(event.participant_id);
+      const delta = event.adjustment_points ?? 0;
+      if (row) row.points += delta;
+      scored.push({ ...blank(event, "scored", event.note), points: delta });
+      continue;
+    }
+    if (event.kind === "round_advanced") {
+      applyRoundEnd(round);
+      round += 1;
+      if (round > rules.rounds.count) {
+        complete = true;
+        round = rules.rounds.count;
+      }
+      scored.push(blank(event, "scored", null));
+      continue;
+    }
+
+    // --- a catch ------------------------------------------------------------------
+    const row = event.participant_id === null ? undefined : rows.get(event.participant_id);
+    if (!row) {
+      scored.push(blank(event, "voided", "This player was removed from the game."));
+      continue;
+    }
+    if (voided.has(event.id)) {
+      row.total_catches += 1;
+      scored.push(blank(event, "voided", "Undone."));
+      continue;
+    }
+
+    row.total_catches += 1;
+    if (event.disposition === "released") row.released += 1;
+
+    const zero = (status: EventScoreStatus, reason: string): void => {
+      scored.push(blank(event, status, reason));
+    };
+
+    if (rules.host_approval && !event.approved) {
+      zero("pending_approval", "Waiting for the captain to confirm this one.");
+      continue;
+    }
+    if (row.eliminated_round !== null) {
+      zero("zero_eliminated", "Out of the running — this fish still counts on the trip.");
+      continue;
+    }
+    if (event.species_id === null) {
+      // An unresolved Quick Mark scores nothing until somebody says what it was.
+      zero("zero_unresolved", "No species yet — name the fish and it scores.");
+      continue;
+    }
+    const speciesId: string = event.species_id;
+    if (ctx.isProtected(speciesId) || event.legal?.protected_species === true) {
+      zero("zero_protected", "Protected species. No points, and none were ever available.");
+      continue;
+    }
+    if (event.legal !== null && event.legal.verdict === "release" && event.disposition === "kept") {
+      // The game never pays for a fish that should have gone back.
+      zero("zero_illegal_retention", `Kept against the rules — ${event.legal.reason}`);
+      continue;
+    }
+    if (!isEligible(speciesId, rules, ctx)) {
+      zero("zero_not_eligible", "Not a target in this game.");
+      continue;
+    }
+
+    const base = tierPointsFor(speciesId, rules, ctx);
+    const prior = row.speciesScoringCount.get(speciesId) ?? 0;
+    const earned = repeatValue(base, prior, rules.scoring.repeat);
+
+    if (earned === 0) {
+      row.species.add(speciesId);
+      zero("zero_repeat_cap", "Already scored the limit for this species.");
+      continue;
+    }
+
+    const bonuses: AppliedBonus[] = [];
+    const b = rules.scoring.bonuses;
+    if (!firstBloodTaken && b.first_blood > 0) {
+      bonuses.push({ kind: "first_blood", points: b.first_blood });
+      firstBloodTaken = true;
+    }
+    if (event.new_species && b.new_species > 0) {
+      bonuses.push({ kind: "new_species", points: b.new_species });
+    }
+    if (event.personal_best && b.personal_best > 0) {
+      bonuses.push({ kind: "personal_best", points: b.personal_best });
+    }
+    if (event.disposition === "released" && b.release > 0) {
+      bonuses.push({ kind: "release", points: b.release });
+    }
+
+    // Fish Cricket marks. A closed target keeps scoring points until everyone closes it.
+    let marks = 0;
+    let target: string | null = null;
+    let targetWasClosed = false;
+    if (rules.cricket !== null) {
+      const cricket = rules.cricket;
+      target = cricket.targets.find((t) => speciesMatches(speciesId, t, ctx)) ?? null;
+      if (target !== null) {
+        const held = row.marks.get(target) ?? 0;
+        // Read BEFORE the marks land. The catch that closes a target closes it and stops
+        // there; the next one scores. Same as the darts game this borrows from, and the
+        // reason the read is separated from the write rather than folded into it.
+        targetWasClosed = held >= cricket.marks_to_close;
+        if (!targetWasClosed) {
+          marks = event.personal_best && cricket.personal_best_marks
+            ? 3
+            : isSizeBonus(event) && cricket.size_bonus_marks
+              ? 2
+              : 1;
+          row.marks.set(target, Math.min(cricket.marks_to_close, held + marks));
+        }
+      }
+    }
+
+    const bonusTotal = bonuses.reduce((sum, x) => sum + x.points, 0);
+    // In Cricket a target that is not yet closed earns marks, not points; points only
+    // start once this player has closed it and an opponent has not.
+    const pointsFromCatch =
+      rules.cricket === null ? earned : cricketPoints(event, target, earned, targetWasClosed);
+    const total = pointsFromCatch + bonusTotal;
+
+    row.points += total;
+    row.scoring_catches += 1;
+    row.species.add(speciesId);
+    row.speciesScoringCount.set(speciesId, prior + 1);
+
+    const entry: ScoredEvent = {
+      event,
+      points: total,
+      base_points: pointsFromCatch,
+      bonuses,
+      status: "scored",
+      reason: null,
+      marks,
+      target,
+    };
+    scored.push(entry);
+    const bucket = roundCatches.get(round) ?? [];
+    bucket.push(entry);
+    roundCatches.set(round, bucket);
+  }
+
+  /**
+   * Cricket points: only a target this player had ALREADY closed pays, and only while at
+   * least one opponent still has it open. Once everybody has closed it the target is dead
+   * and catching it is worth nothing — that pressure to move on is the whole game.
+   */
+  function cricketPoints(
+    event: GameEvent,
+    target: string | null,
+    earned: number,
+    wasClosed: boolean,
+  ): number {
+    if (target === null || !wasClosed) return 0;
+    const closed = closedTargets();
+    const everyoneElseClosed = active
+      .filter((p) => p.id !== event.participant_id)
+      .every((p) => closed.get(p.id)?.has(target) === true);
+    return everyoneElseClosed ? 0 : earned;
+  }
+
+  /** Round boundary: the biggest-fish bonus, then elimination, then any score reset. */
+  function applyRoundEnd(finished: number): void {
+    const bonus = rules.scoring.bonuses.biggest_of_round;
+    if (bonus > 0) {
+      for (const id of largestOf(roundCatches.get(finished) ?? [])) {
+        const owner = scored.find((s) => s.event.id === id)?.event.participant_id;
+        const row = owner === null || owner === undefined ? undefined : rows.get(owner);
+        if (row) row.points += bonus;
+      }
+    }
+
+    if (rules.elimination !== null) {
+      const standing = [...rows.entries()]
+        .filter(([, r]) => r.eliminated_round === null)
+        .sort((a, b) => b[1].points - a[1].points);
+      const survivors = eliminate(standing, rules.elimination.rule);
+      for (const [id, row] of standing) {
+        if (!survivors.has(id)) row.eliminated_round = finished;
+      }
+    }
+
+    if (!rules.rounds.carry_scores) {
+      for (const [id, row] of rows) {
+        const handicap = active.find((p) => p.id === id)?.handicap_points ?? 0;
+        row.points = handicap;
+        row.speciesScoringCount.clear();
+      }
+    }
+  }
+
+  const finalRows = rankRows(rows, active, rules.tiebreaker, scored);
+  const teams = rankTeams(finalRows);
+  const leader = finalRows.find((r) => r.eliminated_round === null) ?? finalRows[0] ?? null;
+
+  return {
+    rows: finalRows,
+    teams,
+    round,
+    leader_id: leader ? leader.participant_id : null,
+    events: scored,
+    paused,
+    complete,
+    winner_ids: complete ? winnersOf(finalRows) : [],
+  };
+}
+
+/** A "qualifying size" is any fish the angler actually measured. */
+function isSizeBonus(event: GameEvent): boolean {
+  return (event.weight_g ?? 0) > 0 || (event.length_mm ?? 0) > 0;
+}
+
+function blank(event: GameEvent, status: EventScoreStatus, reason: string | null): ScoredEvent {
+  return {
+    event,
+    points: 0,
+    base_points: 0,
+    bonuses: [],
+    status,
+    reason,
+    marks: 0,
+    target: null,
+  };
+}
+
+/** Who survives one round boundary. Returns the ids that stay in. */
+function eliminate(
+  standing: readonly (readonly [string, WorkingRow])[],
+  rule: GameRules["elimination"] extends null ? never : NonNullable<GameRules["elimination"]>["rule"],
+): Set<string> {
+  const ids = standing.map(([id]) => id);
+  if (ids.length <= 1) return new Set(ids);
+
+  switch (rule.kind) {
+    case "lowest": {
+      // Everyone tied at the bottom goes. Two anglers on the same score both had the
+      // same day, and silently keeping one of them is the kind of arbitrary the founder
+      // would hear about on the drive home.
+      const lowest = standing[standing.length - 1][1].points;
+      return new Set(standing.filter(([, r]) => r.points > lowest).map(([id]) => id));
+    }
+    case "below_threshold":
+      return new Set(standing.filter(([, r]) => r.points >= rule.points).map(([id]) => id));
+    case "top_half": {
+      const keep = Math.max(1, Math.ceil(ids.length / 2));
+      return new Set(ids.slice(0, keep));
+    }
+  }
+}
+
+function rankRows(
+  rows: Map<string, WorkingRow>,
+  participants: readonly GameParticipant[],
+  tiebreaker: Tiebreaker,
+  scored: readonly ScoredEvent[],
+): readonly Standing[] {
+  const biggestBy = new Map<string, number>();
+  for (const s of scored) {
+    if (s.status !== "scored" || s.event.participant_id === null) continue;
+    const size = s.event.weight_g ?? s.event.length_mm ?? 0;
+    biggestBy.set(
+      s.event.participant_id,
+      Math.max(biggestBy.get(s.event.participant_id) ?? 0, size),
+    );
+  }
+
+  const built = participants.flatMap((p) => {
+    const row = rows.get(p.id);
+    if (!row) return [];
+    return [{
+      participant_id: p.id,
+      team_id: p.team_id,
+      points: row.points,
+      handicap: p.handicap_points,
+      scoring_catches: row.scoring_catches,
+      total_catches: row.total_catches,
+      released: row.released,
+      unique_species: [...row.species],
+      marks: Object.fromEntries(row.marks),
+      closed: [...row.marks.entries()].filter(([, m]) => m > 0).map(([t]) => t),
+      eliminated_round: row.eliminated_round,
+      rank: 0,
+    }];
+  });
+
+  const sorted = [...built].sort((a, b) => {
+    // An eliminated player never outranks one still fishing, whatever the score says.
+    if ((a.eliminated_round === null) !== (b.eliminated_round === null)) {
+      return a.eliminated_round === null ? -1 : 1;
+    }
+    if (b.points !== a.points) return b.points - a.points;
+    switch (tiebreaker) {
+      case "most_species":
+        return b.unique_species.length - a.unique_species.length;
+      case "biggest_fish":
+        return (biggestBy.get(b.participant_id) ?? 0) - (biggestBy.get(a.participant_id) ?? 0);
+      case "earliest_lead":
+      case "shared_win":
+        return 0;
+    }
+  });
+
+  // Equal scores share a rank. 1, 2, 2, 4 — never 1, 2, 3, 4 with two equal totals.
+  let lastPoints: number | null = null;
+  let lastRank = 0;
+  return sorted.map((r, i) => {
+    const rank = r.points === lastPoints ? lastRank : i + 1;
+    lastPoints = r.points;
+    lastRank = rank;
+    return { ...r, rank };
+  });
+}
+
+function rankTeams(rows: readonly Standing[]): readonly TeamStanding[] {
+  const byTeam = new Map<string, Standing[]>();
+  for (const r of rows) {
+    if (r.team_id === null) continue;
+    byTeam.set(r.team_id, [...(byTeam.get(r.team_id) ?? []), r]);
+  }
+  const built = [...byTeam.entries()].map(([team_id, members]) => ({
+    team_id,
+    points: members.reduce((sum, m) => sum + m.points, 0),
+    participant_ids: members.map((m) => m.participant_id),
+    eliminated_round: members.every((m) => m.eliminated_round !== null)
+      ? Math.max(...members.map((m) => m.eliminated_round ?? 0))
+      : null,
+    rank: 0,
+  }));
+  return built
+    .sort((a, b) => b.points - a.points)
+    .map((t, i) => ({ ...t, rank: i + 1 }));
+}
+
+function winnersOf(rows: readonly Standing[]): readonly string[] {
+  const standing = rows.filter((r) => r.eliminated_round === null);
+  const pool = standing.length > 0 ? standing : rows;
+  if (pool.length === 0) return [];
+  const top = pool[0].points;
+  return pool.filter((r) => r.points === top).map((r) => r.participant_id);
+}

--- a/src/core/rules/games/scoring.ts
+++ b/src/core/rules/games/scoring.ts
@@ -77,10 +77,14 @@ export interface Standing {
   readonly team_id: string | null;
   readonly points: number;
   readonly handicap: number;
+  /** This round, when scores reset between rounds. Otherwise the whole game. */
   readonly scoring_catches: number;
-  readonly total_catches: number;
   readonly released: number;
   readonly unique_species: readonly string[];
+  /** The whole game, always — these never reset at a round boundary. */
+  readonly total_catches: number;
+  readonly total_species: number;
+  readonly total_released: number;
   /** Fish Cricket: target -> marks accrued (capped at `marks_to_close`). */
   readonly marks: Readonly<Record<string, number>>;
   readonly closed: readonly string[];
@@ -208,10 +212,20 @@ function largestOf(events: readonly ScoredEvent[]): readonly string[] {
 
 interface WorkingRow {
   points: number;
+  /*
+    Two sets of counters, because a round reset makes them mean different things.
+
+    A Make the Cut board that reads "1 fish · 1 species" beside a score of 0 is a board
+    that contradicts itself: those were yesterday's fish and this is today's score. So the
+    displayed counters reset with the points, and a second set that never resets carries
+    the whole game to the results screen.
+  */
   scoring_catches: number;
-  total_catches: number;
   released: number;
   species: Set<string>;
+  total_catches: number;
+  total_species: Set<string>;
+  total_released: number;
   speciesScoringCount: Map<string, number>;
   marks: Map<string, number>;
   eliminated_round: number | null;
@@ -229,9 +243,11 @@ export function score(
     rows.set(p.id, {
       points: p.handicap_points,
       scoring_catches: 0,
-      total_catches: 0,
       released: 0,
       species: new Set(),
+      total_catches: 0,
+      total_species: new Set(),
+      total_released: 0,
       speciesScoringCount: new Map(),
       marks: new Map(),
       eliminated_round: null,
@@ -323,7 +339,10 @@ export function score(
     }
 
     row.total_catches += 1;
-    if (event.disposition === "released") row.released += 1;
+    if (event.disposition === "released") {
+      row.released += 1;
+      row.total_released += 1;
+    }
 
     const zero = (status: EventScoreStatus, reason: string): void => {
       scored.push(blank(event, status, reason));
@@ -363,6 +382,7 @@ export function score(
 
     if (earned === 0) {
       row.species.add(speciesId);
+      row.total_species.add(speciesId);
       zero("zero_repeat_cap", "Already scored the limit for this species.");
       continue;
     }
@@ -417,6 +437,7 @@ export function score(
     row.points += total;
     row.scoring_catches += 1;
     row.species.add(speciesId);
+    row.total_species.add(speciesId);
     row.speciesScoringCount.set(speciesId, prior + 1);
 
     const entry: ScoredEvent = {
@@ -480,6 +501,10 @@ export function score(
         const handicap = active.find((p) => p.id === id)?.handicap_points ?? 0;
         row.points = handicap;
         row.speciesScoringCount.clear();
+        // The displayed counters reset with the score they sit beside. `total_*` does not.
+        row.scoring_catches = 0;
+        row.released = 0;
+        row.species.clear();
       }
     }
   }
@@ -568,9 +593,11 @@ function rankRows(
       points: row.points,
       handicap: p.handicap_points,
       scoring_catches: row.scoring_catches,
-      total_catches: row.total_catches,
       released: row.released,
       unique_species: [...row.species],
+      total_catches: row.total_catches,
+      total_species: row.total_species.size,
+      total_released: row.total_released,
       marks: Object.fromEntries(row.marks),
       closed: [...row.marks.entries()].filter(([, m]) => m > 0).map(([t]) => t),
       eliminated_round: row.eliminated_round,

--- a/src/core/rules/games/types.ts
+++ b/src/core/rules/games/types.ts
@@ -1,0 +1,268 @@
+/**
+ * Boat Games domain types (ADR 009).
+ *
+ * The shape here carries the whole ownership decision, so it is worth stating once:
+ * a `GameEvent` is a first-class record of a fish, not a pointer to one. It holds its
+ * own species and measurements because a guest has no catch row and never will until
+ * they claim one. `catch_id` is set only when the host opted the fish into their own
+ * log, and then it *references* that catch rather than duplicating it.
+ *
+ * Pure data. No I/O, no React, no IndexedDB — `features/games/` stores these and
+ * `scoring.ts` folds them.
+ */
+
+export type GameMode = "captains_cup" | "fish_cricket" | "make_the_cut";
+
+export type GameStatus = "draft" | "active" | "paused" | "completed";
+
+/** Scoreboard colours, by token key. Never a hex — the tripwire and the palette both care. */
+export type ParticipantColor =
+  | "signal-orange"
+  | "tide-cyan"
+  | "moon-pale"
+  | "success-green"
+  | "amber-flag"
+  | "text-link";
+
+export const PARTICIPANT_COLORS: readonly ParticipantColor[] = [
+  "signal-orange",
+  "tide-cyan",
+  "moon-pale",
+  "success-green",
+  "amber-flag",
+  "text-link",
+];
+
+// ---------------------------------------------------------------------------------
+// Participants and teams
+// ---------------------------------------------------------------------------------
+
+/**
+ * A local player. The `id` is the stable local participant id the founder asked for:
+ * minted on this device, never reused, and the only thing a game event points at.
+ *
+ * `claimed_user_id` is Phase 2's hook. It stays null through the whole of Phase 1, and
+ * the fact that it is *here* rather than bolted on later is the point: when a guest
+ * claims their fish, their events already name them.
+ */
+export interface GameParticipant {
+  readonly id: string;
+  readonly session_id: string;
+  readonly display_name: string;
+  readonly color_key: ParticipantColor;
+  readonly team_id: string | null;
+  /**
+   * Founder's call: a flat number of points added once to the starting score, shown on
+   * the scoreboard. The only reading that means the same thing in all three modes.
+   */
+  readonly handicap_points: number;
+  /** True for the phone's owner. Only a host's catches may be offered to their own log. */
+  readonly is_host: boolean;
+  readonly claimed_user_id: string | null;
+  readonly joined_at: string;
+  /** Set when a player is removed before the game starts. Their events never counted. */
+  readonly removed_at: string | null;
+}
+
+export interface GameTeam {
+  readonly id: string;
+  readonly session_id: string;
+  readonly name: string;
+  readonly color_key: ParticipantColor;
+}
+
+/** A crew member saved across trips, so the same four people are two taps next time. */
+export interface CrewMember {
+  readonly id: string;
+  readonly display_name: string;
+  readonly color_key: ParticipantColor;
+  readonly default_handicap: number;
+  readonly created_at: string;
+  readonly last_played_at: string | null;
+}
+
+// ---------------------------------------------------------------------------------
+// Rules
+// ---------------------------------------------------------------------------------
+
+/**
+ * Points for one species or one species group. A group id (`rockfish`, `tuna`) matches
+ * any species that rolls up to it, which is how the founder's "categories when exact
+ * targets would be too restrictive" works without a second vocabulary.
+ */
+export interface SpeciesPointRule {
+  readonly species_id: string;
+  readonly points: number;
+}
+
+/** How repeats of the same species are handled, so one easy fish cannot win a day. */
+export type RepeatRule =
+  /** Every catch scores its full value. */
+  | { readonly kind: "unlimited" }
+  /** Only the first `count` catches of a species score. */
+  | { readonly kind: "capped"; readonly count: number }
+  /** Full, then half, then a quarter… floored at one point. */
+  | { readonly kind: "diminishing" }
+  /** Only the first catch of each species scores at all. */
+  | { readonly kind: "unique_only" };
+
+export interface BonusRules {
+  /** First scoring catch of the whole game. */
+  readonly first_blood: number;
+  /** A species this angler has never logged before. */
+  readonly new_species: number;
+  /** Beat their own best for the species. */
+  readonly personal_best: number;
+  /** A legal release. Never a penalty for keeping — an *incentive* not to. */
+  readonly release: number;
+  /** Biggest eligible fish of the round, awarded at the round boundary. */
+  readonly biggest_of_round: number;
+}
+
+export interface ScoringRules {
+  readonly tiers: readonly SpeciesPointRule[];
+  /** Points for an eligible species with no tier of its own. */
+  readonly default_points: number;
+  /** Null means every species is eligible. */
+  readonly eligible_species: readonly string[] | null;
+  readonly repeat: RepeatRule;
+  readonly bonuses: BonusRules;
+}
+
+export interface RoundRules {
+  /** 1 for a single-session game. */
+  readonly count: number;
+  /** Minutes per round, or null for a round the host closes by hand (a fishing day). */
+  readonly minutes: number | null;
+  /** True when a round is a day on a multi-day trip rather than a timer. */
+  readonly multi_day: boolean;
+  /** Do scores carry into the next round, or start clean? */
+  readonly carry_scores: boolean;
+}
+
+export interface CricketRules {
+  /** The species or groups that must be closed. */
+  readonly targets: readonly string[];
+  /** Marks needed to close one target. Default three, like darts. */
+  readonly marks_to_close: number;
+  /** A qualifying size gives two marks instead of one. */
+  readonly size_bonus_marks: boolean;
+  /** A personal best gives three marks — closes a target outright. */
+  readonly personal_best_marks: boolean;
+}
+
+export type EliminationKind =
+  | { readonly kind: "lowest" }
+  | { readonly kind: "below_threshold"; readonly points: number }
+  | { readonly kind: "top_half" };
+
+export interface EliminationRules {
+  readonly rule: EliminationKind;
+  /** Eliminate whole teams rather than individuals. */
+  readonly by_team: boolean;
+}
+
+export type Tiebreaker =
+  | "most_species"
+  | "biggest_fish"
+  | "earliest_lead"
+  | "shared_win";
+
+export interface GameRules {
+  readonly mode: GameMode;
+  readonly scoring: ScoringRules;
+  readonly rounds: RoundRules;
+  /** Present only for `fish_cricket`. */
+  readonly cricket: CricketRules | null;
+  /** Present only for `make_the_cut`. */
+  readonly elimination: EliminationRules | null;
+  readonly tiebreaker: Tiebreaker;
+  /** Honor system, or the host confirms each catch before it scores. */
+  readonly host_approval: boolean;
+  /** May a player be added after the first catch? */
+  readonly late_join: boolean;
+}
+
+// ---------------------------------------------------------------------------------
+// Session and events
+// ---------------------------------------------------------------------------------
+
+export interface GameSession {
+  readonly id: string;
+  readonly mode: GameMode;
+  readonly name: string;
+  readonly status: GameStatus;
+  readonly rules: GameRules;
+  readonly zone: string;
+  readonly region_id: string;
+  /** The trip this game belongs to, when one was open. Games do not require a trip. */
+  readonly trip_id: string | null;
+  readonly created_at: string;
+  readonly started_at: string | null;
+  readonly completed_at: string | null;
+  /** Next sequence number to hand an event. Ordering never depends on the clock. */
+  readonly next_seq: number;
+}
+
+export type GameEventKind =
+  | "catch"
+  | "void"
+  | "round_advanced"
+  | "paused"
+  | "resumed"
+  | "adjustment";
+
+export type EventDisposition = "kept" | "released";
+
+/**
+ * What Fish Legal said about this fish at the moment it was scored, frozen here so a
+ * pack update next season cannot rewrite a finished game — the same stance the catch
+ * log already takes with `regulation_snapshot`.
+ *
+ * `null` on the event means no verified pack covered the region. That is *unknown*, not
+ * *prohibited*: it scores normally. Silence is not proof, in either direction.
+ */
+export interface EventLegalSnapshot {
+  readonly verdict: "keep" | "release" | "conditional";
+  readonly reason: string;
+  readonly pack_id: string;
+  readonly pack_version: number;
+  /** From the ontology, independent of any regional pack. */
+  readonly protected_species: boolean;
+}
+
+export interface GameEvent {
+  /** uuidv7, minted at the tap. Doubles as the idempotency key — the fold folds it once. */
+  readonly id: string;
+  readonly session_id: string;
+  readonly kind: GameEventKind;
+  readonly participant_id: string | null;
+  readonly round: number;
+  /**
+   * Monotonic within the session. THIS is the order events fold in, not `created_at`:
+   * offline the device clock is the only clock and it is user-editable, and a game must
+   * not reorder itself because somebody fixed their timezone mid-trip.
+   */
+  readonly seq: number;
+  readonly created_at: string;
+
+  readonly species_id: string | null;
+  readonly species_other: string | null;
+  readonly length_mm: number | null;
+  readonly weight_g: number | null;
+  readonly disposition: EventDisposition | null;
+  readonly personal_best: boolean;
+  readonly new_species: boolean;
+
+  /** Set only when the host chose to log this fish to their own book (ADR 009 §1). */
+  readonly catch_id: string | null;
+  readonly legal: EventLegalSnapshot | null;
+
+  /** For `void`: the event being undone. Nothing is ever mutated or deleted. */
+  readonly voids_event_id: string | null;
+  /** For `adjustment`: a host correction, always with a note for the audit trail. */
+  readonly adjustment_points: number | null;
+  readonly note: string | null;
+  /** Set false while `host_approval` is on and the host has not confirmed yet. */
+  readonly approved: boolean;
+}

--- a/src/core/rules/vectors/games.json
+++ b/src/core/rules/vectors/games.json
@@ -1,0 +1,21 @@
+{
+  "_comment": "Boat Games scoring vectors (ADR 003 §4, ADR 009 §3). These are what let a future Swift client be checked against this engine rather than re-derived from it. Each case is a rules preset, a list of catches, and the expected points per participant.",
+  "repeatValue": [
+    { "why": "unlimited pays full every time", "base": 3, "prior": 0, "rule": { "kind": "unlimited" }, "expect": 3 },
+    { "why": "unlimited, tenth fish", "base": 3, "prior": 9, "rule": { "kind": "unlimited" }, "expect": 3 },
+    { "why": "unique_only pays the first", "base": 5, "prior": 0, "rule": { "kind": "unique_only" }, "expect": 5 },
+    { "why": "unique_only pays nothing after", "base": 5, "prior": 1, "rule": { "kind": "unique_only" }, "expect": 0 },
+    { "why": "capped at 3 pays the third", "base": 3, "prior": 2, "rule": { "kind": "capped", "count": 3 }, "expect": 3 },
+    { "why": "capped at 3 stops at the fourth", "base": 3, "prior": 3, "rule": { "kind": "capped", "count": 3 }, "expect": 0 },
+    { "why": "diminishing halves", "base": 8, "prior": 1, "rule": { "kind": "diminishing" }, "expect": 4 },
+    { "why": "diminishing quarters", "base": 8, "prior": 2, "rule": { "kind": "diminishing" }, "expect": 2 },
+    { "why": "diminishing floors at one, never zero", "base": 8, "prior": 9, "rule": { "kind": "diminishing" }, "expect": 1 },
+    { "why": "diminishing on a one-pointer stays one", "base": 1, "prior": 5, "rule": { "kind": "diminishing" }, "expect": 1 }
+  ],
+  "speciesMatches": [
+    { "why": "exact", "species": "kelp_bass", "rule": "kelp_bass", "expect": true },
+    { "why": "rolls up to its group", "species": "vermilion_rockfish", "rule": "rockfish", "expect": true },
+    { "why": "a different group does not match", "species": "vermilion_rockfish", "rule": "surfperch", "expect": false },
+    { "why": "a group does not match downward", "species": "rockfish", "rule": "vermilion_rockfish", "expect": false }
+  ]
+}

--- a/src/features/games/components/game-results.tsx
+++ b/src/features/games/components/game-results.tsx
@@ -2,11 +2,11 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
 
 import { speciesById } from "@/core/ontology/species";
 import { awards, biggestFish, winningTeams } from "@/core/rules/games/results";
 import { formatWhen, modeName, pointsLabel } from "../format";
+import { useGuardedAction } from "../use-guard";
 import { summaryFor } from "./scoreboard";
 import { gameView, rematch, useGames } from "../store";
 import { CARD_CLASS, PARTICIPANT_CLASSES, PRIMARY_BUTTON, SECONDARY_BUTTON } from "../ui-classes";
@@ -41,7 +41,7 @@ function NoSuchGame() {
 export function GameResults({ sessionId }: { sessionId: string }) {
   const games = useGames();
   const router = useRouter();
-  const [busy, setBusy] = useState(false);
+  const { busy, run } = useGuardedAction();
 
   const view = gameView(games, sessionId);
 
@@ -186,15 +186,10 @@ export function GameResults({ sessionId }: { sessionId: string }) {
           type="button"
           disabled={busy}
           onClick={() =>
-            void (async () => {
-              setBusy(true);
-              try {
-                const next = await rematch(sessionId);
-                if (next) router.push(`/games/new?resume=${next.id}`);
-              } finally {
-                setBusy(false);
-              }
-            })()
+            void run(async () => {
+              const next = await rematch(sessionId);
+              if (next) router.push(`/games/new?resume=${next.id}`);
+            })
           }
           className={`${PRIMARY_BUTTON} disabled:opacity-disabled`}
         >

--- a/src/features/games/components/game-results.tsx
+++ b/src/features/games/components/game-results.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import { speciesById } from "@/core/ontology/species";
 import { awards, biggestFish } from "@/core/rules/games/results";
 import { formatWhen, modeName, pointsLabel } from "../format";
+import { summaryFor } from "./scoreboard";
 import { gameView, rematch, useGames } from "../store";
 import { CARD_CLASS, PARTICIPANT_CLASSES, PRIMARY_BUTTON, SECONDARY_BUTTON } from "../ui-classes";
 
@@ -91,7 +92,7 @@ export function GameResults({ sessionId }: { sessionId: string }) {
                 <span className="flex min-w-0 flex-1 flex-col">
                   <span className="truncate text-body-strong text-text-primary">{player.display_name}</span>
                   <span className="text-caption text-text-muted">
-                    {row.scoring_catches} scoring · {row.unique_species.length} species
+                    {summaryFor(row)}
                     {row.eliminated_round !== null
                       ? ` · out after ${session.rules.rounds.multi_day ? "day" : "round"} ${row.eliminated_round}`
                       : ""}

--- a/src/features/games/components/game-results.tsx
+++ b/src/features/games/components/game-results.tsx
@@ -92,7 +92,13 @@ export function GameResults({ sessionId }: { sessionId: string }) {
                 <span className="flex min-w-0 flex-1 flex-col">
                   <span className="truncate text-body-strong text-text-primary">{player.display_name}</span>
                   <span className="text-caption text-text-muted">
-                    {summaryFor(row)}
+                    {/* The whole game here, not just the last round. */}
+                    {summaryFor({
+                      catches: row.total_catches,
+                      species: row.total_species,
+                      released: row.total_released,
+                      handicap: row.handicap,
+                    })}
                     {row.eliminated_round !== null
                       ? ` · out after ${session.rules.rounds.multi_day ? "day" : "round"} ${row.eliminated_round}`
                       : ""}

--- a/src/features/games/components/game-results.tsx
+++ b/src/features/games/components/game-results.tsx
@@ -5,7 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 
 import { speciesById } from "@/core/ontology/species";
-import { awards, biggestFish } from "@/core/rules/games/results";
+import { awards, biggestFish, winningTeams } from "@/core/rules/games/results";
 import { formatWhen, modeName, pointsLabel } from "../format";
 import { summaryFor } from "./scoreboard";
 import { gameView, rematch, useGames } from "../store";
@@ -56,6 +56,7 @@ export function GameResults({ sessionId }: { sessionId: string }) {
   const winners = standings.winner_ids.length > 0
     ? standings.winner_ids
     : standings.rows.slice(0, 1).map((r) => r.participant_id);
+  const teamWinners = winningTeams(standings);
   const biggest = biggestFish(standings);
   const scoredCatches = standings.events.filter(
     (e) => e.event.kind === "catch" && e.status === "scored",
@@ -68,17 +69,42 @@ export function GameResults({ sessionId }: { sessionId: string }) {
           {modeName(session.mode)} · {formatWhen(session.completed_at ?? session.created_at)}
         </p>
         <h1 className="text-h1 text-text-primary">
-          {winners.length === 0
-            ? "No winner"
-            : winners.length === 1
-              ? `${nameOf(winners[0])} wins`
-              : `${winners.map(nameOf).join(" and ")} share it`}
+          {/*
+            "take it" rather than "wins", because a team name can be plural or singular and
+            the app does not get to choose: "Adults wins" and "Port win" are both wrong, and
+            the captain types the name. This construction is right for either.
+          */}
+          {teamWinners.length === 1
+            ? `${teamWinners[0]} take it`
+            : teamWinners.length > 1
+              ? `${teamWinners.join(" and ")} share it`
+              : winners.length === 0
+                ? "No winner"
+                : winners.length === 1
+                  ? `${nameOf(winners[0])} wins`
+                  : `${winners.map(nameOf).join(" and ")} share it`}
         </h1>
       </header>
 
+      {standings.teams.length > 0 ? (
+        <section className="flex flex-col gap-space-3" aria-labelledby="teams-heading">
+          <h2 id="teams-heading" className="text-h3 text-text-primary">
+            Final team scores
+          </h2>
+          <ol className="flex flex-col gap-space-2">
+            {standings.teams.map((team) => (
+              <li key={team.team_id} className={`${CARD_CLASS} flex items-center justify-between gap-space-3 p-space-4`}>
+                <span className="min-w-0 truncate text-body-strong text-text-primary">{team.team_id}</span>
+                <span className="shrink-0 text-h2 tabular-nums text-text-primary">{team.points}</span>
+              </li>
+            ))}
+          </ol>
+        </section>
+      ) : null}
+
       <section className="flex flex-col gap-space-3" aria-labelledby="standings-heading">
         <h2 id="standings-heading" className="text-h3 text-text-primary">
-          Final standings
+          {standings.teams.length > 0 ? "Who caught what" : "Final standings"}
         </h2>
         <ol className="flex flex-col gap-space-2">
           {standings.rows.map((row) => {

--- a/src/features/games/components/game-results.tsx
+++ b/src/features/games/components/game-results.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+
+import { speciesById } from "@/core/ontology/species";
+import { awards, biggestFish } from "@/core/rules/games/results";
+import { formatWhen, modeName, pointsLabel } from "../format";
+import { gameView, rematch, useGames } from "../store";
+import { CARD_CLASS, PARTICIPANT_CLASSES, PRIMARY_BUTTON, SECONDARY_BUTTON } from "../ui-classes";
+
+/**
+ * /games/[id]/results — how it finished.
+ *
+ * Four awards, not ten. The founder's handoff listed biggest fish, most species, most
+ * valuable catch, best comeback, slams and a released total; comeback and most-valuable
+ * were held back deliberately (see `core/rules/games/results.ts`) because a results
+ * screen nobody reads to the bottom is worse than a short one they do. They are one
+ * function each away when a real game asks for them.
+ */
+/** Reads the game id from the query string. See `app/(app)/games/result/page.tsx`. */
+export function GameResultsRoute() {
+  const id = useSearchParams().get("id");
+  if (!id) return <NoSuchGame />;
+  return <GameResults sessionId={id} />;
+}
+
+function NoSuchGame() {
+  return (
+    <div className="mx-auto flex max-w-reading flex-col gap-space-4 p-space-5">
+      <p className="text-body text-text-primary">That game is not on this phone.</p>
+      <Link href="/games" className={SECONDARY_BUTTON}>
+        Back to Boat Games
+      </Link>
+    </div>
+  );
+}
+
+export function GameResults({ sessionId }: { sessionId: string }) {
+  const games = useGames();
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  const view = gameView(games, sessionId);
+
+  if (!games.hydrated) {
+    return <p className="p-space-5 text-body text-text-muted">Reading the scorecard…</p>;
+  }
+  if (!view) return <NoSuchGame />;
+
+  const { session, participants, standings } = view;
+  const nameOf = (id: string | null) =>
+    participants.find((p) => p.id === id)?.display_name ?? "Someone";
+  const winners = standings.winner_ids.length > 0
+    ? standings.winner_ids
+    : standings.rows.slice(0, 1).map((r) => r.participant_id);
+  const biggest = biggestFish(standings);
+  const scoredCatches = standings.events.filter(
+    (e) => e.event.kind === "catch" && e.status === "scored",
+  );
+
+  return (
+    <div className="mx-auto flex max-w-reading flex-col gap-space-6 px-space-4 py-space-5">
+      <header className="flex flex-col gap-space-2">
+        <p className="text-caption text-text-muted">
+          {modeName(session.mode)} · {formatWhen(session.completed_at ?? session.created_at)}
+        </p>
+        <h1 className="text-h1 text-text-primary">
+          {winners.length === 0
+            ? "No winner"
+            : winners.length === 1
+              ? `${nameOf(winners[0])} wins`
+              : `${winners.map(nameOf).join(" and ")} share it`}
+        </h1>
+      </header>
+
+      <section className="flex flex-col gap-space-3" aria-labelledby="standings-heading">
+        <h2 id="standings-heading" className="text-h3 text-text-primary">
+          Final standings
+        </h2>
+        <ol className="flex flex-col gap-space-2">
+          {standings.rows.map((row) => {
+            const player = participants.find((p) => p.id === row.participant_id);
+            if (!player) return null;
+            const colors = PARTICIPANT_CLASSES[player.color_key] ?? PARTICIPANT_CLASSES["text-link"];
+            return (
+              <li key={row.participant_id} className={`${CARD_CLASS} flex items-center gap-space-3 p-space-4`}>
+                <span className="w-space-6 shrink-0 text-h3 tabular-nums text-text-muted">{row.rank}</span>
+                <span aria-hidden="true" className={`size-space-3 shrink-0 rounded-full ${colors.dot}`} />
+                <span className="flex min-w-0 flex-1 flex-col">
+                  <span className="truncate text-body-strong text-text-primary">{player.display_name}</span>
+                  <span className="text-caption text-text-muted">
+                    {row.scoring_catches} scoring · {row.unique_species.length} species
+                    {row.eliminated_round !== null
+                      ? ` · out after ${session.rules.rounds.multi_day ? "day" : "round"} ${row.eliminated_round}`
+                      : ""}
+                  </span>
+                </span>
+                <span className="shrink-0 text-h2 tabular-nums text-text-primary">{row.points}</span>
+              </li>
+            );
+          })}
+        </ol>
+      </section>
+
+      <section className="flex flex-col gap-space-3" aria-labelledby="awards-heading">
+        <h2 id="awards-heading" className="text-h3 text-text-primary">
+          Worth mentioning
+        </h2>
+        <ul className="flex flex-col gap-space-2">
+          {awards(standings, participants).map((award) => (
+            <li key={award.kind} className={`${CARD_CLASS} flex items-baseline justify-between gap-space-3 p-space-3`}>
+              <span className="text-body text-text-muted">{award.label}</span>
+              <span className="text-body-strong text-text-primary">
+                {award.kind === "biggest_fish" && biggest
+                  ? `${award.detail} · ${speciesById(biggest.event.species_id)?.commonName ?? "a fish"}`
+                  : award.detail}
+              </span>
+            </li>
+          ))}
+          {awards(standings, participants).length === 0 ? (
+            <li className="text-body text-text-muted">Nothing measured, nothing released. Next time.</li>
+          ) : null}
+        </ul>
+      </section>
+
+      <section className="flex flex-col gap-space-3" aria-labelledby="timeline-heading">
+        <h2 id="timeline-heading" className="text-h3 text-text-primary">
+          How it went
+        </h2>
+        {scoredCatches.length === 0 ? (
+          <p className="text-body text-text-muted">No fish were scored in this one.</p>
+        ) : (
+          <ol className="flex flex-col gap-space-2">
+            {scoredCatches.map((scored) => (
+              <li key={scored.event.id} className="flex items-baseline justify-between gap-space-3">
+                <span className="min-w-0 flex-1 truncate text-body text-text-primary">
+                  {nameOf(scored.event.participant_id)} —{" "}
+                  {speciesById(scored.event.species_id)?.commonName ?? "a fish"}
+                </span>
+                <span className="shrink-0 text-caption tabular-nums text-text-muted">
+                  {pointsLabel(scored.points)}
+                </span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+
+      <div className="flex flex-col gap-space-3">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() =>
+            void (async () => {
+              setBusy(true);
+              try {
+                const next = await rematch(sessionId);
+                if (next) router.push(`/games/new?resume=${next.id}`);
+              } finally {
+                setBusy(false);
+              }
+            })()
+          }
+          className={`${PRIMARY_BUTTON} disabled:opacity-disabled`}
+        >
+          Rematch — same crew, same rules
+        </button>
+        <Link href="/games" className={SECONDARY_BUTTON}>
+          Back to Boat Games
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/features/games/components/game-settings.tsx
+++ b/src/features/games/components/game-settings.tsx
@@ -1,0 +1,510 @@
+"use client";
+
+import { SPECIES, speciesById } from "@/core/ontology/species";
+import { POINT_TEMPLATES } from "@/core/rules/games/modes";
+import type { GameRules, RepeatRule, Tiebreaker } from "@/core/rules/games/types";
+import { CARD_CLASS, CHIP_CLASS, CHIP_OFF, CHIP_ON, INPUT_CLASS, SELECT_CLASS } from "../ui-classes";
+
+/**
+ * Step 3 — the rules, and the sentence that explains them.
+ *
+ * Every control here writes into one `GameRules` value, which is the whole reason three
+ * games did not need three settings screens. The plain-language summary at the bottom is
+ * built from the same value, so it cannot drift from what the engine will actually do —
+ * a rules summary written by hand is a rules summary that lies within two sprints.
+ */
+
+const DURATIONS = [
+  { label: "2 hours", minutes: 120 },
+  { label: "4 hours", minutes: 240 },
+  { label: "All day", minutes: 600 },
+  { label: "No timer", minutes: null },
+];
+
+const REPEAT_OPTIONS: readonly { label: string; rule: RepeatRule; blurb: string }[] = [
+  {
+    label: "First three",
+    rule: { kind: "capped", count: 3 },
+    blurb: "Only your first three of any one species score.",
+  },
+  {
+    label: "One each",
+    rule: { kind: "unique_only" },
+    blurb: "Only the first of each species scores. Variety wins.",
+  },
+  {
+    label: "Worth less each time",
+    rule: { kind: "diminishing" },
+    blurb: "Full points, then half, then a quarter — never less than one.",
+  },
+  {
+    label: "Everything counts",
+    rule: { kind: "unlimited" },
+    blurb: "Every fish scores full value. Simplest, and easiest to run away with.",
+  },
+];
+
+const TIEBREAKERS: readonly { value: Tiebreaker; label: string }[] = [
+  { value: "most_species", label: "Most different species" },
+  { value: "biggest_fish", label: "Biggest fish" },
+  { value: "shared_win", label: "Share the win" },
+];
+
+/** Targets worth offering: the roll-up groups first, then the fish people name. */
+const TARGET_CHOICES = SPECIES.filter(
+  (s) => s.takeStatus !== "protected" && (s.isGroup || s.sortOrder < 500),
+).slice(0, 40);
+
+export function GameSettings({
+  rules,
+  onChange,
+}: {
+  rules: GameRules;
+  onChange: (next: GameRules) => void;
+}) {
+  const set = (patch: Partial<GameRules>) => onChange({ ...rules, ...patch });
+  const setScoring = (patch: Partial<GameRules["scoring"]>) =>
+    onChange({ ...rules, scoring: { ...rules.scoring, ...patch } });
+  const setBonus = (key: keyof GameRules["scoring"]["bonuses"], value: number) =>
+    setScoring({ bonuses: { ...rules.scoring.bonuses, [key]: value } });
+
+  return (
+    <div className="flex flex-col gap-space-6">
+      {rules.rounds.multi_day ? (
+        <Field label="Fishing days" hint="The captain closes each day by hand, so a long run offshore never ends a round early.">
+          <select
+            className={SELECT_CLASS}
+            value={rules.rounds.count}
+            onChange={(e) => set({ rounds: { ...rules.rounds, count: Number(e.target.value) } })}
+          >
+            {[2, 3, 4, 5].map((n) => (
+              <option key={n} value={n}>
+                {n} days
+              </option>
+            ))}
+          </select>
+        </Field>
+      ) : (
+        <Field label="How long" hint="The timer is a display. Nothing ends on its own — you close the game.">
+          <div className="flex flex-wrap gap-space-2">
+            {DURATIONS.map((d) => (
+              <button
+                key={d.label}
+                type="button"
+                aria-pressed={rules.rounds.minutes === d.minutes}
+                onClick={() => set({ rounds: { ...rules.rounds, minutes: d.minutes } })}
+                className={`${CHIP_CLASS} ${rules.rounds.minutes === d.minutes ? CHIP_ON : CHIP_OFF}`}
+              >
+                {d.label}
+              </button>
+            ))}
+          </div>
+        </Field>
+      )}
+
+      {rules.cricket === null ? (
+        <>
+          <Field label="What fish are worth" hint="A starting point, not a law. Southern California values are the app's own; edit any of them.">
+            <div className="flex flex-wrap gap-space-2">
+              {POINT_TEMPLATES.map((template) => {
+                const on = sameTiers(rules.scoring.tiers, template.tiers);
+                return (
+                  <button
+                    key={template.id}
+                    type="button"
+                    aria-pressed={on}
+                    onClick={() => setScoring({ tiers: template.tiers })}
+                    className={`${CHIP_CLASS} ${on ? CHIP_ON : CHIP_OFF}`}
+                  >
+                    {template.name}
+                  </button>
+                );
+              })}
+            </div>
+          </Field>
+
+          {rules.scoring.tiers.length > 0 ? (
+            <Field label="Point table" hint="Change any number. A group like Rockfish covers every fish that rolls up to it.">
+              <ul className="flex flex-col gap-space-2">
+                {rules.scoring.tiers.map((tier, index) => (
+                  <li key={tier.species_id} className="flex items-center gap-space-3">
+                    <label
+                      className="flex-1 text-body text-text-primary"
+                      htmlFor={`tier-${tier.species_id}`}
+                    >
+                      {speciesById(tier.species_id)?.commonName ?? tier.species_id}
+                    </label>
+                    <input
+                      id={`tier-${tier.species_id}`}
+                      type="number"
+                      inputMode="numeric"
+                      min={0}
+                      max={99}
+                      value={tier.points}
+                      onChange={(e) => {
+                        const next = [...rules.scoring.tiers];
+                        next[index] = { ...tier, points: clampPoints(e.target.value) };
+                        setScoring({ tiers: next });
+                      }}
+                      className={`${INPUT_CLASS} w-space-16 text-center`}
+                    />
+                  </li>
+                ))}
+              </ul>
+            </Field>
+          ) : null}
+
+          <Field label="Anything not on the table" hint="What an eligible fish with no listed value is worth.">
+            <input
+              type="number"
+              inputMode="numeric"
+              min={0}
+              max={99}
+              value={rules.scoring.default_points}
+              onChange={(e) => setScoring({ default_points: clampPoints(e.target.value) })}
+              className={`${INPUT_CLASS} w-space-16 text-center`}
+              aria-label="Points for an unlisted species"
+            />
+          </Field>
+
+          <Field label="Same fish again" hint="Stops one hot bite on an easy species winning the day.">
+            <div className="flex flex-col gap-space-2">
+              {REPEAT_OPTIONS.map((option) => {
+                const on = option.rule.kind === rules.scoring.repeat.kind;
+                return (
+                  <button
+                    key={option.label}
+                    type="button"
+                    aria-pressed={on}
+                    onClick={() => setScoring({ repeat: option.rule })}
+                    className={`${CARD_CLASS} min-h-touch-floor p-space-3 text-left ${
+                      on ? "border-signal-orange" : ""
+                    }`}
+                  >
+                    <span className="block text-body-strong text-text-primary">{option.label}</span>
+                    <span className="block text-caption text-text-muted">{option.blurb}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </Field>
+
+          <Field label="Bonuses" hint="Points on top of the fish's own value.">
+            <ul className="flex flex-col gap-space-3">
+              <BonusRow label="First fish of the game" value={rules.scoring.bonuses.first_blood} onChange={(v) => setBonus("first_blood", v)} />
+              <BonusRow label="A species new to that angler" value={rules.scoring.bonuses.new_species} onChange={(v) => setBonus("new_species", v)} />
+              <BonusRow label="A personal best" value={rules.scoring.bonuses.personal_best} onChange={(v) => setBonus("personal_best", v)} />
+              <BonusRow label="Released" value={rules.scoring.bonuses.release} onChange={(v) => setBonus("release", v)} />
+              <BonusRow label="Biggest of the round" value={rules.scoring.bonuses.biggest_of_round} onChange={(v) => setBonus("biggest_of_round", v)} />
+            </ul>
+          </Field>
+        </>
+      ) : (
+        <>
+          <Field label="Targets" hint="Pick a handful. Groups like Rockfish count any fish in them, which helps when nobody can name it to species.">
+            <div className="flex flex-wrap gap-space-2">
+              {TARGET_CHOICES.map((species) => {
+                const on = rules.cricket?.targets.includes(species.id) ?? false;
+                return (
+                  <button
+                    key={species.id}
+                    type="button"
+                    aria-pressed={on}
+                    onClick={() => {
+                      const cricket = rules.cricket;
+                      if (!cricket) return;
+                      const targets = on
+                        ? cricket.targets.filter((t) => t !== species.id)
+                        : [...cricket.targets, species.id];
+                      set({ cricket: { ...cricket, targets } });
+                    }}
+                    className={`${CHIP_CLASS} ${on ? CHIP_ON : CHIP_OFF}`}
+                  >
+                    {species.commonName}
+                  </button>
+                );
+              })}
+            </div>
+          </Field>
+
+          <Field label="Marks to close a target" hint="Three is the darts default and the one people expect.">
+            <select
+              className={SELECT_CLASS}
+              value={rules.cricket.marks_to_close}
+              onChange={(e) =>
+                rules.cricket &&
+                set({ cricket: { ...rules.cricket, marks_to_close: Number(e.target.value) } })
+              }
+            >
+              {[2, 3, 4, 5].map((n) => (
+                <option key={n} value={n}>
+                  {n} marks
+                </option>
+              ))}
+            </select>
+          </Field>
+
+          <Toggle
+            label="A measured fish counts double"
+            hint="Length or weight entered = two marks instead of one."
+            on={rules.cricket.size_bonus_marks}
+            onChange={(on) => rules.cricket && set({ cricket: { ...rules.cricket, size_bonus_marks: on } })}
+          />
+          <Toggle
+            label="A personal best closes it outright"
+            hint="Three marks in one fish."
+            on={rules.cricket.personal_best_marks}
+            onChange={(on) => rules.cricket && set({ cricket: { ...rules.cricket, personal_best_marks: on } })}
+          />
+        </>
+      )}
+
+      {rules.elimination !== null ? (
+        <>
+          <Field label="Who goes home" hint="Applied when the captain closes each day.">
+            <div className="flex flex-col gap-space-2">
+              {([
+                { kind: "lowest", label: "Lowest score", blurb: "Everyone tied at the bottom goes, rather than the app picking one." },
+                { kind: "top_half", label: "Keep the top half", blurb: "Halves the field each day. Short and brutal." },
+              ] as const).map((option) => {
+                const on = rules.elimination?.rule.kind === option.kind;
+                return (
+                  <button
+                    key={option.kind}
+                    type="button"
+                    aria-pressed={on}
+                    onClick={() =>
+                      rules.elimination &&
+                      set({ elimination: { ...rules.elimination, rule: { kind: option.kind } } })
+                    }
+                    className={`${CARD_CLASS} min-h-touch-floor p-space-3 text-left ${on ? "border-signal-orange" : ""}`}
+                  >
+                    <span className="block text-body-strong text-text-primary">{option.label}</span>
+                    <span className="block text-caption text-text-muted">{option.blurb}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </Field>
+          <Toggle
+            label="Carry scores between days"
+            hint="Off means every day starts level, so one bad morning is not the end of it."
+            on={rules.rounds.carry_scores}
+            onChange={(on) => set({ rounds: { ...rules.rounds, carry_scores: on } })}
+          />
+        </>
+      ) : null}
+
+      <Field label="If it ends level" hint="">
+        <select
+          className={SELECT_CLASS}
+          value={rules.tiebreaker}
+          onChange={(e) => set({ tiebreaker: e.target.value as Tiebreaker })}
+        >
+          {TIEBREAKERS.map((t) => (
+            <option key={t.value} value={t.value}>
+              {t.label}
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      <Toggle
+        label="Captain confirms each fish"
+        hint="Off is the honor system, which is what a family trip wants."
+        on={rules.host_approval}
+        onChange={(on) => set({ host_approval: on })}
+      />
+
+      <section className={`${CARD_CLASS} flex flex-col gap-space-2 p-space-4`} aria-live="polite">
+        <h3 className="text-body-strong text-text-primary">How this game will work</h3>
+        <ul className="flex flex-col gap-space-2">
+          {explainRules(rules).map((line) => (
+            <li key={line} className="text-body text-text-muted">
+              {line}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+/**
+ * The rules, in the words a captain would use telling the boat what they are playing.
+ *
+ * Derived from the same `GameRules` the engine folds, so this can only be wrong if the
+ * engine is wrong too. Exported for its test.
+ */
+export function explainRules(rules: GameRules): readonly string[] {
+  const lines: string[] = [];
+
+  if (rules.cricket !== null) {
+    const names = rules.cricket.targets
+      .map((t) => speciesById(t)?.commonName ?? t)
+      .join(", ");
+    lines.push(
+      `Close ${rules.cricket.targets.length} targets — ${names || "none picked yet"} — with ${rules.cricket.marks_to_close} of each.`,
+    );
+    if (rules.cricket.size_bonus_marks) lines.push("A fish you measure counts as two toward closing.");
+    if (rules.cricket.personal_best_marks) lines.push("A personal best closes a target on its own.");
+    lines.push("Once you have closed a target it scores points for you, until everyone else closes it too.");
+  } else {
+    lines.push(
+      rules.scoring.tiers.length > 0
+        ? `Fish are worth ${Math.min(...rules.scoring.tiers.map((t) => t.points))} to ${Math.max(...rules.scoring.tiers.map((t) => t.points))} points, and anything unlisted is worth ${rules.scoring.default_points}.`
+        : `Every fish is worth ${rules.scoring.default_points}.`,
+    );
+    switch (rules.scoring.repeat.kind) {
+      case "capped":
+        lines.push(`Only your first ${rules.scoring.repeat.count} of any one species score.`);
+        break;
+      case "unique_only":
+        lines.push("Only the first of each species scores — it is a hunt for variety.");
+        break;
+      case "diminishing":
+        lines.push("Each repeat of a species is worth half the last, down to one point.");
+        break;
+      case "unlimited":
+        lines.push("Every fish scores its full value, however many you catch.");
+        break;
+    }
+    const bonuses = Object.entries(rules.scoring.bonuses).filter(([, v]) => v > 0);
+    if (bonuses.length > 0) {
+      lines.push(
+        `Bonuses on top: ${bonuses.map(([k, v]) => `${BONUS_WORDS[k] ?? k} (+${v})`).join(", ")}.`,
+      );
+    }
+  }
+
+  if (rules.elimination !== null) {
+    lines.push(
+      rules.elimination.rule.kind === "top_half"
+        ? `${rules.rounds.count} days, and only the top half survive each one.`
+        : `${rules.rounds.count} days, and the lowest score goes out at the end of each one.`,
+    );
+    lines.push(
+      rules.rounds.carry_scores
+        ? "Scores carry from day to day."
+        : "Scores start level again every day.",
+    );
+    lines.push("Knocked out? Your fish still count on the trip — just not for the cup.");
+  } else if (rules.rounds.minutes !== null) {
+    lines.push(`Runs about ${rules.rounds.minutes >= 60 ? `${Math.round(rules.rounds.minutes / 60)} hours` : `${rules.rounds.minutes} minutes`}. Nothing ends by itself — you close the game.`);
+  } else {
+    lines.push("No timer. The game ends when you close it.");
+  }
+
+  lines.push(
+    rules.host_approval
+      ? "You confirm each fish before it scores."
+      : "Honor system — a fish scores the moment it is logged.",
+  );
+
+  // Not configurable, and stated every time, because it is the promise the game makes.
+  lines.push(
+    "Protected fish score nothing, and a fish kept when it should have gone back scores nothing. Releasing never costs you points.",
+  );
+
+  return lines;
+}
+
+const BONUS_WORDS: Record<string, string> = {
+  first_blood: "first fish of the game",
+  new_species: "a species new to you",
+  personal_best: "a personal best",
+  release: "releasing it",
+  biggest_of_round: "biggest of the round",
+};
+
+function sameTiers(
+  a: GameRules["scoring"]["tiers"],
+  b: GameRules["scoring"]["tiers"],
+): boolean {
+  return a.length === b.length && a.every((t, i) => t.species_id === b[i].species_id && t.points === b[i].points);
+}
+
+function clampPoints(raw: string): number {
+  const n = Number.parseInt(raw, 10);
+  if (Number.isNaN(n)) return 0;
+  return Math.max(0, Math.min(99, n));
+}
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-space-2">
+      <h3 className="text-body-strong text-text-primary">{label}</h3>
+      {hint ? <p className="text-caption text-text-muted">{hint}</p> : null}
+      {children}
+    </section>
+  );
+}
+
+function Toggle({
+  label,
+  hint,
+  on,
+  onChange,
+}: {
+  label: string;
+  hint: string;
+  on: boolean;
+  onChange: (on: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={on}
+      onClick={() => onChange(!on)}
+      className={`${CARD_CLASS} flex min-h-touch-floor items-center justify-between gap-space-3 p-space-3 text-left ${
+        on ? "border-signal-orange" : ""
+      }`}
+    >
+      <span className="flex flex-col">
+        <span className="text-body-strong text-text-primary">{label}</span>
+        <span className="text-caption text-text-muted">{hint}</span>
+      </span>
+      <span className={`text-label ${on ? "text-signal-orange" : "text-text-muted"}`}>
+        {on ? "On" : "Off"}
+      </span>
+    </button>
+  );
+}
+
+function BonusRow({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+}) {
+  const id = `bonus-${label.replace(/\W+/g, "-").toLowerCase()}`;
+  return (
+    <li className="flex items-center gap-space-3">
+      <label htmlFor={id} className="flex-1 text-body text-text-primary">
+        {label}
+      </label>
+      <input
+        id={id}
+        type="number"
+        inputMode="numeric"
+        min={0}
+        max={99}
+        value={value}
+        onChange={(e) => onChange(clampPoints(e.target.value))}
+        className={`${INPUT_CLASS} w-space-16 text-center`}
+      />
+    </li>
+  );
+}

--- a/src/features/games/components/games-entry.tsx
+++ b/src/features/games/components/games-entry.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import Link from "next/link";
+
+import { modeName } from "../format";
+import { gameView, unfinishedGames, useGames } from "../store";
+import { CARD_CLASS } from "../ui-classes";
+
+/**
+ * The way into Boat Games from the Fish Log.
+ *
+ * Lives here rather than inside `features/catches/` so the log screen only has to render
+ * one component and neither feature reaches into the other's internals (ADR 005 §3).
+ *
+ * Two shapes on purpose. With a game running it is an amber card that is hard to walk
+ * past, because the likeliest reason this angler opened the app at all is that a game is
+ * live and the phone went to sleep. With nothing running it is one quiet line — Boat
+ * Games must not shout at somebody who only came to log a fish.
+ */
+export function GamesEntry() {
+  const games = useGames();
+  if (!games.hydrated) return null;
+
+  const running = unfinishedGames(games).filter((s) => s.status !== "draft");
+  const active = running[0];
+
+  if (!active) {
+    return (
+      <Link
+        href="/games"
+        className="flex min-h-touch-floor items-center justify-between gap-space-3 px-space-4 text-body text-text-link"
+      >
+        <span>Boat Games — play against the crew</span>
+        <span aria-hidden="true">→</span>
+      </Link>
+    );
+  }
+
+  const view = gameView(games, active.id);
+  const leader = view?.standings.rows.find((r) => r.participant_id === view.standings.leader_id);
+  const leaderName = view?.participants.find((p) => p.id === leader?.participant_id)?.display_name;
+
+  return (
+    <div className="px-space-4">
+      <Link
+        href={`/games/play?id=${active.id}`}
+        className={`${CARD_CLASS} flex flex-col gap-space-1 border-amber-flag p-space-4`}
+      >
+        <span className="text-body-strong text-amber-flag">
+          {active.status === "paused" ? "A game is paused" : "A game is going"}
+        </span>
+        <span className="text-body text-text-primary">{active.name}</span>
+        <span className="text-caption text-text-muted">
+          {modeName(active.mode)}
+          {leaderName ? ` · ${leaderName} leading on ${leader?.points ?? 0}` : " · no fish yet"}
+        </span>
+      </Link>
+    </div>
+  );
+}

--- a/src/features/games/components/games-home.tsx
+++ b/src/features/games/components/games-home.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import Link from "next/link";
+
+import { MODES } from "@/core/rules/games/modes";
+import { formatWhen, modeName } from "../format";
+import {
+  finishedGames,
+  gameView,
+  unfinishedGames,
+  useGames,
+} from "../store";
+import { CARD_CLASS, PARTICIPANT_CLASSES, PRIMARY_BUTTON, SECONDARY_BUTTON } from "../ui-classes";
+
+/**
+ * /games — the Boat Games home.
+ *
+ * Ordered by what somebody standing on a boat actually came here for. An unfinished game
+ * is at the top and impossible to miss, because the single most likely reason this screen
+ * is open is that a game is already running and the phone went to sleep. "Start a game"
+ * comes second. The catalogue of modes — the thing a designer would put first — comes
+ * last, because it only matters the first two times.
+ *
+ * Reached from the Log screen rather than the nav bar: `shell-nav.tsx` documents the
+ * measured widths that make a seventh destination a two-row bar on every phone made, and
+ * `shell-nav.test.ts` pins the count so adding one is a decision rather than a patch.
+ */
+export function GamesHome() {
+  const games = useGames();
+  const unfinished = unfinishedGames(games);
+  const finished = finishedGames(games).slice(0, 5);
+
+  return (
+    <div className="mx-auto flex max-w-reading flex-col gap-space-6 px-space-4 py-space-5">
+      <header className="flex flex-col gap-space-2">
+        <h1 className="text-h1 text-text-primary">Boat Games</h1>
+        <p className="text-body text-text-muted">
+          Friendly competition for everyone on the boat. No accounts, no signal needed.
+        </p>
+      </header>
+
+      {!games.available ? (
+        <p className={`${CARD_CLASS} p-space-4 text-body text-error-red`}>
+          This browser will not let the app save anything, so a game could not be kept.
+          Games need on-device storage to survive the phone locking.
+        </p>
+      ) : null}
+
+      {games.hydrated && unfinished.length > 0 ? (
+        <section className="flex flex-col gap-space-3" aria-labelledby="unfinished-heading">
+          <h2 id="unfinished-heading" className="text-h3 text-amber-flag">
+            {unfinished.length === 1 ? "A game is still going" : `${unfinished.length} games still going`}
+          </h2>
+          <ul className="flex flex-col gap-space-3">
+            {unfinished.map((session) => {
+              const view = gameView(games, session.id);
+              const leader = view?.standings.rows.find(
+                (r) => r.participant_id === view.standings.leader_id,
+              );
+              const leaderName = view?.participants.find(
+                (p) => p.id === leader?.participant_id,
+              )?.display_name;
+              return (
+                <li key={session.id}>
+                  <Link
+                    href={session.status === "draft" ? `/games/new?resume=${session.id}` : `/games/play?id=${session.id}`}
+                    className={`${CARD_CLASS} flex flex-col gap-space-2 border-amber-flag p-space-4`}
+                  >
+                    <span className="flex flex-wrap items-baseline justify-between gap-space-2">
+                      <span className="text-h3 text-text-primary">{session.name}</span>
+                      <span className="text-caption text-text-muted">
+                        {formatWhen(session.created_at)}
+                      </span>
+                    </span>
+                    <span className="text-body text-text-muted">
+                      {modeName(session.mode)}
+                      {session.status === "draft"
+                        ? " · not started yet"
+                        : session.status === "paused"
+                          ? " · paused"
+                          : leaderName
+                            ? ` · ${leaderName} leading on ${leader?.points ?? 0}`
+                            : " · no fish yet"}
+                    </span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ) : null}
+
+      <Link href="/games/new" className={PRIMARY_BUTTON}>
+        Start a new game
+      </Link>
+
+      {finished.length > 0 ? (
+        <section className="flex flex-col gap-space-3" aria-labelledby="recent-heading">
+          <h2 id="recent-heading" className="text-h3 text-text-primary">
+            Recent results
+          </h2>
+          <ul className="flex flex-col gap-space-2">
+            {finished.map((session) => {
+              const view = gameView(games, session.id);
+              const winners = (view?.standings.winner_ids ?? [])
+                .map((id) => view?.participants.find((p) => p.id === id)?.display_name)
+                .filter((name): name is string => Boolean(name));
+              return (
+                <li key={session.id}>
+                  <Link
+                    href={`/games/result?id=${session.id}`}
+                    className={`${CARD_CLASS} flex flex-col gap-space-1 p-space-4`}
+                  >
+                    <span className="text-body-strong text-text-primary">{session.name}</span>
+                    <span className="text-caption text-text-muted">
+                      {winners.length > 0 ? `${winners.join(" and ")} won` : "No winner recorded"}
+                      {" · "}
+                      {formatWhen(session.completed_at ?? session.created_at)}
+                    </span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ) : null}
+
+      {games.crew.length > 0 ? (
+        <section className="flex flex-col gap-space-3" aria-labelledby="crew-heading">
+          <h2 id="crew-heading" className="text-h3 text-text-primary">
+            My crew
+          </h2>
+          <ul className="flex flex-wrap gap-space-2">
+            {games.crew.map((member) => (
+              <li
+                key={member.id}
+                className="flex min-h-touch-floor items-center gap-space-2 rounded-full border border-hairline bg-surface px-4"
+              >
+                <span
+                  aria-hidden="true"
+                  className={`size-space-3 rounded-full ${
+                    PARTICIPANT_CLASSES[member.color_key]?.dot ?? "bg-text-link"
+                  }`}
+                />
+                <span className="text-label text-text-primary">{member.display_name}</span>
+              </li>
+            ))}
+          </ul>
+          <p className="text-caption text-text-muted">
+            Saved on this phone so the same crew is two taps next trip.
+          </p>
+        </section>
+      ) : null}
+
+      <section className="flex flex-col gap-space-3" aria-labelledby="modes-heading">
+        <h2 id="modes-heading" className="text-h3 text-text-primary">
+          The games
+        </h2>
+        <ul className="flex flex-col gap-space-3">
+          {MODES.map((mode) => (
+            <li key={mode.mode} className={`${CARD_CLASS} flex flex-col gap-space-2 p-space-4`}>
+              <span className="flex flex-wrap items-baseline justify-between gap-space-2">
+                <h3 className="text-body-strong text-text-primary">{mode.name}</h3>
+                <span className="text-caption text-text-muted">{mode.duration}</span>
+              </span>
+              <p className="text-body text-text-muted">{mode.tagline}</p>
+              <ul className="flex flex-col gap-space-1">
+                {mode.how.map((line) => (
+                  <li key={line} className="text-caption text-text-muted">
+                    {line}
+                  </li>
+                ))}
+              </ul>
+              <Link href={`/games/new?mode=${mode.mode}`} className={`${SECONDARY_BUTTON} self-start`}>
+                Play {mode.name}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/src/features/games/components/log-catch-sheet.tsx
+++ b/src/features/games/components/log-catch-sheet.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from "react";
 import { SPECIES, speciesById } from "@/core/ontology/species";
 import { localDateOf } from "@/core/rules/catch/rules";
 import type { EventDisposition, GameParticipant, GameSession } from "@/core/rules/games/types";
+import { useGuardedAction } from "../use-guard";
 import { logHostCatch } from "../host-catch";
 import { legalForGameCatch, legalWarning } from "../legal";
 import { logGameCatch } from "../store";
@@ -49,7 +50,7 @@ export function LogCatchSheet({
   const [personalBest, setPersonalBest] = useState(false);
   const [newSpecies, setNewSpecies] = useState(false);
   const [alsoLog, setAlsoLog] = useState(false);
-  const [busy, setBusy] = useState(false);
+  const { busy, run } = useGuardedAction();
 
   const player = participants.find((p) => p.id === participantId) ?? null;
   const localDate = localDateOf(new Date().toISOString(), session.zone);
@@ -64,9 +65,8 @@ export function LogCatchSheet({
   }, [query]);
 
   async function save(): Promise<void> {
-    if (busy || participantId === "") return;
-    setBusy(true);
-    try {
+    if (participantId === "") return;
+    await run(async () => {
       /*
         The host's own fish, if they asked for it, goes to their real log first, and the
         game event then references that catch by id.
@@ -100,9 +100,7 @@ export function LogCatchSheet({
         catchId,
       });
       onDone();
-    } finally {
-      setBusy(false);
-    }
+    });
   }
 
   return (

--- a/src/features/games/components/log-catch-sheet.tsx
+++ b/src/features/games/components/log-catch-sheet.tsx
@@ -130,8 +130,16 @@ export function LogCatchSheet({
           autoComplete="off"
           className={INPUT_CLASS}
         />
+        {/*
+          Once a fish is chosen the list collapses to just that fish.
+
+          Leaving the twelve suggestions on screen pushed "Kept or released?" and the save
+          button most of a screen further down at 320px, which is the width this has to work
+          at — and every one of those chips was a way to change the answer by accident with a
+          wet thumb. Tapping the chosen fish reopens the list.
+        */}
         <ul className="flex flex-wrap gap-space-2">
-          {matches.map((s) => {
+          {(speciesId === null ? matches : SPECIES.filter((s) => s.id === speciesId)).map((s) => {
             const on = s.id === speciesId;
             return (
               <li key={s.id}>
@@ -139,12 +147,18 @@ export function LogCatchSheet({
                   type="button"
                   aria-pressed={on}
                   onClick={() => {
-                    setSpeciesId(s.id);
-                    setQuery("");
+                    if (on) {
+                      setSpeciesId(null);
+                      setQuery("");
+                    } else {
+                      setSpeciesId(s.id);
+                      setQuery("");
+                    }
                   }}
                   className={`${CHIP_CLASS} ${on ? CHIP_ON : CHIP_OFF}`}
                 >
                   {s.commonName}
+                  {on ? " ✕" : ""}
                 </button>
               </li>
             );

--- a/src/features/games/components/log-catch-sheet.tsx
+++ b/src/features/games/components/log-catch-sheet.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from "react";
 import { SPECIES, speciesById } from "@/core/ontology/species";
 import { localDateOf } from "@/core/rules/catch/rules";
 import type { EventDisposition, GameParticipant, GameSession } from "@/core/rules/games/types";
+import { logHostCatch } from "../host-catch";
 import { legalForGameCatch, legalWarning } from "../legal";
 import { logGameCatch } from "../store";
 import {
@@ -66,6 +67,25 @@ export function LogCatchSheet({
     if (busy || participantId === "") return;
     setBusy(true);
     try {
+      /*
+        The host's own fish, if they asked for it, goes to their real log first, and the
+        game event then references that catch by id.
+
+        Order matters and is the opposite of what you would guess. The catch is written
+        first so the event can carry its id, which is what ADR 009 means by "references
+        rather than duplicates" — one fish, one factual record. If minting the catch fails
+        the game event still lands with a null `catch_id`, because the game must never lose
+        a fish over a bookkeeping convenience.
+      */
+      const catchId =
+        alsoLog && player !== null ? await logHostCatch(player, {
+          speciesId,
+          speciesOther: speciesId === null && query.trim().length > 0 ? query.trim() : null,
+          lengthMm: inchesToMm(lengthIn),
+          weightG: poundsToGrams(weightLb),
+          disposition,
+        }) : null;
+
       await logGameCatch({
         sessionId: session.id,
         participantId,
@@ -77,10 +97,7 @@ export function LogCatchSheet({
         personalBest,
         newSpecies,
         legal,
-        // Phase 1 links nothing: the host's opt-in mints a real catch through the
-        // ordinary catch flow, and that work lands with the log integration. Until then
-        // the toggle records the intent without inventing a half-formed catch row.
-        catchId: null,
+        catchId,
       });
       onDone();
     } finally {

--- a/src/features/games/components/log-catch-sheet.tsx
+++ b/src/features/games/components/log-catch-sheet.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { SPECIES, speciesById } from "@/core/ontology/species";
+import { localDateOf } from "@/core/rules/catch/rules";
+import type { EventDisposition, GameParticipant, GameSession } from "@/core/rules/games/types";
+import { legalForGameCatch, legalWarning } from "../legal";
+import { logGameCatch } from "../store";
+import {
+  CARD_CLASS,
+  CHIP_CLASS,
+  CHIP_OFF,
+  CHIP_ON,
+  INPUT_CLASS,
+  PARTICIPANT_CLASSES,
+  PRIMARY_BUTTON,
+  SECONDARY_BUTTON,
+} from "../ui-classes";
+
+/**
+ * Logging a fish during a game.
+ *
+ * Deliberately shorter than the full catch form. Three people are hauling fish at once
+ * and the phone is being passed around wet — who, what, and back or in the box. Everything
+ * else is optional, and the host can send their own fish to their real log with one tap
+ * (ADR 009 §1), which is the only path by which a game catch ever becomes a `catch` row.
+ *
+ * The submit button disables itself for the duration of the write. That plus the event's
+ * client-minted id is the double-tap protection: the fold folds an id once, so even a
+ * duplicated write scores once.
+ */
+export function LogCatchSheet({
+  session,
+  participants,
+  onDone,
+}: {
+  session: GameSession;
+  participants: readonly GameParticipant[];
+  onDone: () => void;
+}) {
+  const [participantId, setParticipantId] = useState(participants[0]?.id ?? "");
+  const [speciesId, setSpeciesId] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [lengthIn, setLengthIn] = useState("");
+  const [weightLb, setWeightLb] = useState("");
+  const [disposition, setDisposition] = useState<EventDisposition>("released");
+  const [personalBest, setPersonalBest] = useState(false);
+  const [newSpecies, setNewSpecies] = useState(false);
+  const [alsoLog, setAlsoLog] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const player = participants.find((p) => p.id === participantId) ?? null;
+  const localDate = localDateOf(new Date().toISOString(), session.zone);
+  const legal = useMemo(() => legalForGameCatch(speciesId, localDate), [speciesId, localDate]);
+  const warning = legalWarning(legal);
+
+  const matches = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const pool = SPECIES.filter((s) => s.takeStatus !== "protected" || q.length > 0);
+    if (q.length === 0) return pool.slice(0, 12);
+    return pool.filter((s) => s.commonName.toLowerCase().includes(q)).slice(0, 12);
+  }, [query]);
+
+  async function save(): Promise<void> {
+    if (busy || participantId === "") return;
+    setBusy(true);
+    try {
+      await logGameCatch({
+        sessionId: session.id,
+        participantId,
+        speciesId,
+        speciesOther: speciesId === null && query.trim().length > 0 ? query.trim() : null,
+        lengthMm: inchesToMm(lengthIn),
+        weightG: poundsToGrams(weightLb),
+        disposition,
+        personalBest,
+        newSpecies,
+        legal,
+        // Phase 1 links nothing: the host's opt-in mints a real catch through the
+        // ordinary catch flow, and that work lands with the log integration. Until then
+        // the toggle records the intent without inventing a half-formed catch row.
+        catchId: null,
+      });
+      onDone();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-space-5">
+      <section className="flex flex-col gap-space-2">
+        <h3 className="text-body-strong text-text-primary">Who caught it?</h3>
+        <ul className="flex flex-wrap gap-space-2">
+          {participants.map((p) => {
+            const on = p.id === participantId;
+            return (
+              <li key={p.id}>
+                <button
+                  type="button"
+                  aria-pressed={on}
+                  onClick={() => setParticipantId(p.id)}
+                  className={`${CHIP_CLASS} flex items-center gap-space-2 ${on ? CHIP_ON : CHIP_OFF}`}
+                >
+                  <span
+                    aria-hidden="true"
+                    className={`size-space-3 rounded-full ${PARTICIPANT_CLASSES[p.color_key]?.dot ?? "bg-text-link"}`}
+                  />
+                  {p.display_name}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+
+      <section className="flex flex-col gap-space-2">
+        <label htmlFor="game-species" className="text-body-strong text-text-primary">
+          What was it?
+        </label>
+        <input
+          id="game-species"
+          value={speciesId ? (speciesById(speciesId)?.commonName ?? "") : query}
+          onChange={(e) => {
+            setSpeciesId(null);
+            setQuery(e.target.value);
+          }}
+          placeholder="Start typing, or leave it and name it later"
+          autoComplete="off"
+          className={INPUT_CLASS}
+        />
+        <ul className="flex flex-wrap gap-space-2">
+          {matches.map((s) => {
+            const on = s.id === speciesId;
+            return (
+              <li key={s.id}>
+                <button
+                  type="button"
+                  aria-pressed={on}
+                  onClick={() => {
+                    setSpeciesId(s.id);
+                    setQuery("");
+                  }}
+                  className={`${CHIP_CLASS} ${on ? CHIP_ON : CHIP_OFF}`}
+                >
+                  {s.commonName}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+        {speciesId === null ? (
+          <p className="text-caption text-text-muted">
+            No species yet means no points yet — log it now and name it when the boat settles.
+          </p>
+        ) : null}
+      </section>
+
+      {warning ? (
+        <p className={`${CARD_CLASS} border-amber-flag p-space-3 text-body text-amber-flag`} role="status">
+          {warning}
+        </p>
+      ) : null}
+
+      <section className="flex flex-col gap-space-2">
+        <h3 className="text-body-strong text-text-primary">Kept or released?</h3>
+        <div className="flex gap-space-2">
+          {(["released", "kept"] as const).map((value) => (
+            <button
+              key={value}
+              type="button"
+              aria-pressed={disposition === value}
+              onClick={() => setDisposition(value)}
+              className={`${CHIP_CLASS} flex-1 ${disposition === value ? CHIP_ON : CHIP_OFF}`}
+            >
+              {value === "released" ? "Released" : "Kept"}
+            </button>
+          ))}
+        </div>
+        <p className="text-caption text-text-muted">
+          Releasing never costs points. A fish never has to be killed to score.
+        </p>
+      </section>
+
+      <section className="flex gap-space-3">
+        <label className="flex flex-1 flex-col gap-space-1 text-body text-text-primary">
+          Length (in)
+          <input
+            type="number"
+            inputMode="decimal"
+            value={lengthIn}
+            onChange={(e) => setLengthIn(e.target.value)}
+            className={INPUT_CLASS}
+          />
+        </label>
+        <label className="flex flex-1 flex-col gap-space-1 text-body text-text-primary">
+          Weight (lb)
+          <input
+            type="number"
+            inputMode="decimal"
+            value={weightLb}
+            onChange={(e) => setWeightLb(e.target.value)}
+            className={INPUT_CLASS}
+          />
+        </label>
+      </section>
+
+      <section className="flex flex-wrap gap-space-2">
+        <Flag label="Personal best" on={personalBest} onChange={setPersonalBest} />
+        <Flag label="New species for them" on={newSpecies} onChange={setNewSpecies} />
+      </section>
+
+      {player?.is_host ? (
+        <button
+          type="button"
+          role="switch"
+          aria-checked={alsoLog}
+          onClick={() => setAlsoLog((on) => !on)}
+          className={`${CARD_CLASS} flex min-h-touch-floor items-center justify-between gap-space-3 p-space-3 text-left ${
+            alsoLog ? "border-signal-orange" : ""
+          }`}
+        >
+          <span className="flex flex-col">
+            <span className="text-body text-text-primary">Also add to my own log</span>
+            <span className="text-caption text-text-muted">
+              Only your fish. Everyone else&apos;s stays in the game and never touches your Passport.
+            </span>
+          </span>
+          <span className={`text-label ${alsoLog ? "text-signal-orange" : "text-text-muted"}`}>
+            {alsoLog ? "On" : "Off"}
+          </span>
+        </button>
+      ) : null}
+
+      <div className="flex flex-col gap-space-3">
+        <button type="button" disabled={busy || participantId === ""} onClick={() => void save()} className={`${PRIMARY_BUTTON} disabled:opacity-disabled`}>
+          {busy ? "Saving…" : "Save the fish"}
+        </button>
+        <button type="button" onClick={onDone} className={SECONDARY_BUTTON}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Flag({
+  label,
+  on,
+  onChange,
+}: {
+  label: string;
+  on: boolean;
+  onChange: (on: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={on}
+      onClick={() => onChange(!on)}
+      className={`${CHIP_CLASS} ${on ? CHIP_ON : CHIP_OFF}`}
+    >
+      {label}
+    </button>
+  );
+}
+
+/** Both return null for blank or nonsense, so an empty box never writes a zero-inch fish. */
+function inchesToMm(raw: string): number | null {
+  const n = Number.parseFloat(raw);
+  return Number.isFinite(n) && n > 0 ? Math.round(n * 25.4) : null;
+}
+
+function poundsToGrams(raw: string): number | null {
+  const n = Number.parseFloat(raw);
+  return Number.isFinite(n) && n > 0 ? Math.round(n * 453.592) : null;
+}

--- a/src/features/games/components/new-game.tsx
+++ b/src/features/games/components/new-game.tsx
@@ -1,0 +1,378 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+
+import { MODES } from "@/core/rules/games/modes";
+import { PARTICIPANT_COLORS, type GameMode, type GameRules, type ParticipantColor } from "@/core/rules/games/types";
+import { useRegionPreference } from "@/features/settings/region";
+import { GameSettings } from "./game-settings";
+import { modeName } from "../format";
+import {
+  addParticipant,
+  createGame,
+  discardGame,
+  participantsOf,
+  removeParticipant,
+  startGame,
+  updateRules,
+  useGames,
+} from "../store";
+import {
+  CARD_CLASS,
+  CHIP_CLASS,
+  CHIP_OFF,
+  CHIP_ON,
+  DANGER_BUTTON,
+  INPUT_CLASS,
+  PARTICIPANT_CLASSES,
+  PRIMARY_BUTTON,
+  SECONDARY_BUTTON,
+} from "../ui-classes";
+
+/**
+ * /games/new — pick a game, add the crew, set the rules.
+ *
+ * The session row is written the instant a mode is chosen, as a `draft`. That is
+ * deliberate: setting up a four-player game takes a couple of minutes, and a phone that
+ * locks or an app the OS decides to evict must not cost the captain that work. A draft
+ * shows on the home screen under "still going" and resumes exactly here.
+ */
+
+type Step = "mode" | "players" | "rules";
+
+export function NewGame() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const games = useGames();
+  const [regionId] = useRegionPreference();
+
+  const resumeId = params.get("resume");
+  const requestedMode = params.get("mode") as GameMode | null;
+
+  const [sessionId, setSessionId] = useState<string | null>(resumeId);
+  const [step, setStep] = useState<Step>(resumeId ? "players" : "mode");
+  const [busy, setBusy] = useState(false);
+
+  const session = games.sessions.find((s) => s.id === sessionId) ?? null;
+  const players = sessionId ? participantsOf(games, sessionId) : [];
+
+  async function chooseMode(mode: GameMode): Promise<void> {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const created = await createGame({
+        mode,
+        name: modeName(mode),
+        // The device's own zone. A game is scored on the boat's clock, like a catch is.
+        zone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        regionId,
+        tripId: null,
+      });
+      setSessionId(created.id);
+      setStep("players");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function begin(): Promise<void> {
+    if (!sessionId || busy) return;
+    setBusy(true);
+    try {
+      await startGame(sessionId);
+      router.push(`/games/play?id=${sessionId}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function abandon(): Promise<void> {
+    if (!sessionId) return;
+    await discardGame(sessionId);
+    router.push("/games");
+  }
+
+  if (step === "mode" || session === null) {
+    return (
+      <Frame title="Start a game" step={1}>
+        <ul className="flex flex-col gap-space-3">
+          {(requestedMode ? MODES.filter((m) => m.mode === requestedMode) : MODES).map((mode) => (
+            <li key={mode.mode}>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void chooseMode(mode.mode)}
+                className={`${CARD_CLASS} flex w-full flex-col gap-space-2 p-space-4 text-left disabled:opacity-disabled`}
+              >
+                <span className="flex flex-wrap items-baseline justify-between gap-space-2">
+                  <span className="text-h3 text-text-primary">{mode.name}</span>
+                  <span className="text-caption text-text-muted">{mode.duration}</span>
+                </span>
+                <span className="text-body text-text-muted">{mode.tagline}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+        {requestedMode ? (
+          <button type="button" onClick={() => router.push("/games/new")} className={SECONDARY_BUTTON}>
+            See the other games
+          </button>
+        ) : null}
+      </Frame>
+    );
+  }
+
+  if (step === "players") {
+    return (
+      <Frame title="Who is fishing?" step={2} subtitle={modeName(session.mode)}>
+        <PlayerSetup sessionId={session.id} />
+        <div className="flex flex-col gap-space-3">
+          <button
+            type="button"
+            disabled={players.length < 2}
+            onClick={() => setStep("rules")}
+            className={`${PRIMARY_BUTTON} disabled:opacity-disabled`}
+          >
+            {players.length < 2 ? "Add at least two players" : "Next — the rules"}
+          </button>
+          <button type="button" onClick={() => void abandon()} className={DANGER_BUTTON}>
+            Throw this game away
+          </button>
+        </div>
+      </Frame>
+    );
+  }
+
+  return (
+    <Frame title="The rules" step={3} subtitle={modeName(session.mode)}>
+      <GameSettings
+        rules={session.rules}
+        onChange={(next: GameRules) => void updateRules(session.id, next)}
+      />
+      <div className="flex flex-col gap-space-3">
+        <button type="button" disabled={busy} onClick={() => void begin()} className={`${PRIMARY_BUTTON} disabled:opacity-disabled`}>
+          Start the game
+        </button>
+        <button type="button" onClick={() => setStep("players")} className={SECONDARY_BUTTON}>
+          Back to the players
+        </button>
+      </div>
+    </Frame>
+  );
+}
+
+/**
+ * Step 2 — the local crew.
+ *
+ * Nobody needs an account. Every player minted here gets a stable local participant id,
+ * and that id is the only thing a game catch ever points at (ADR 009 §1) — which is what
+ * keeps a guest's fish out of the phone owner's Passport.
+ */
+function PlayerSetup({ sessionId }: { sessionId: string }) {
+  const games = useGames();
+  const players = participantsOf(games, sessionId);
+  const [name, setName] = useState("");
+  const [handicap, setHandicap] = useState("0");
+  const [saveToCrew, setSaveToCrew] = useState(true);
+  const [teams, setTeams] = useState(false);
+  const [teamNames, setTeamNames] = useState<[string, string]>(["Port", "Starboard"]);
+
+  const takenColors = new Set(players.map((p) => p.color_key));
+  const nextColor: ParticipantColor =
+    PARTICIPANT_COLORS.find((c) => !takenColors.has(c)) ?? PARTICIPANT_COLORS[0];
+
+  async function add(displayName: string, colorKey: ParticipantColor, handicapPoints: number): Promise<void> {
+    const trimmed = displayName.trim();
+    if (trimmed.length === 0) return;
+    await addParticipant({
+      sessionId,
+      displayName: trimmed,
+      colorKey,
+      teamId: teams ? teamNames[players.length % 2] : null,
+      handicap: handicapPoints,
+      // The first player added is the phone's owner. Only their fish may be offered to
+      // their own log; everyone else's stays a game record (ADR 009 §1).
+      isHost: players.length === 0,
+      saveToCrew,
+    });
+    setName("");
+    setHandicap("0");
+  }
+
+  const unadded = games.crew.filter(
+    (c) => !players.some((p) => p.display_name.toLowerCase() === c.display_name.toLowerCase()),
+  );
+
+  return (
+    <div className="flex flex-col gap-space-5">
+      <div className="flex gap-space-2">
+        {[
+          { on: !teams, label: "Single players" },
+          { on: teams, label: "Teams" },
+        ].map((option) => (
+          <button
+            key={option.label}
+            type="button"
+            aria-pressed={option.on}
+            onClick={() => setTeams(option.label === "Teams")}
+            className={`${CHIP_CLASS} flex-1 ${option.on ? CHIP_ON : CHIP_OFF}`}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+
+      {teams ? (
+        <div className="flex flex-col gap-space-2">
+          <p className="text-caption text-text-muted">
+            Players alternate between the two sides as you add them. Rename either one.
+          </p>
+          <div className="flex gap-space-2">
+            {teamNames.map((teamName, i) => (
+              <input
+                key={i}
+                value={teamName}
+                aria-label={`Team ${i + 1} name`}
+                onChange={(e) =>
+                  setTeamNames((prev) => (i === 0 ? [e.target.value, prev[1]] : [prev[0], e.target.value]))
+                }
+                className={INPUT_CLASS}
+              />
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {players.length > 0 ? (
+        <ul className="flex flex-col gap-space-2">
+          {players.map((player) => (
+            <li key={player.id} className={`${CARD_CLASS} flex items-center gap-space-3 p-space-3`}>
+              <span
+                aria-hidden="true"
+                className={`size-space-4 shrink-0 rounded-full ${PARTICIPANT_CLASSES[player.color_key]?.dot ?? "bg-text-link"}`}
+              />
+              <span className="flex min-w-0 flex-1 flex-col">
+                <span className="truncate text-body-strong text-text-primary">
+                  {player.display_name}
+                  {player.is_host ? " (you)" : ""}
+                </span>
+                <span className="text-caption text-text-muted">
+                  {[
+                    player.team_id,
+                    player.handicap_points !== 0 ? `${player.handicap_points > 0 ? "+" : ""}${player.handicap_points} start` : null,
+                  ]
+                    .filter(Boolean)
+                    .join(" · ") || "No handicap"}
+                </span>
+              </span>
+              <button
+                type="button"
+                onClick={() => void removeParticipant(player.id)}
+                className={`${SECONDARY_BUTTON} shrink-0`}
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {unadded.length > 0 ? (
+        <section className="flex flex-col gap-space-2">
+          <h3 className="text-body-strong text-text-primary">From my crew</h3>
+          <ul className="flex flex-wrap gap-space-2">
+            {unadded.map((member) => (
+              <li key={member.id}>
+                <button
+                  type="button"
+                  onClick={() => void add(member.display_name, nextColor, member.default_handicap)}
+                  className={`${CHIP_CLASS} ${CHIP_OFF}`}
+                >
+                  + {member.display_name}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <form
+        className="flex flex-col gap-space-3"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void add(name, nextColor, Number.parseInt(handicap, 10) || 0);
+        }}
+      >
+        <label htmlFor="player-name" className="text-body-strong text-text-primary">
+          Add a player
+        </label>
+        <input
+          id="player-name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder={players.length === 0 ? "Your name" : "Their name"}
+          autoComplete="off"
+          className={INPUT_CLASS}
+        />
+        <div className="flex items-center gap-space-3">
+          <label htmlFor="player-handicap" className="flex-1 text-body text-text-primary">
+            Head start
+            <span className="block text-caption text-text-muted">
+              Points on the board before the first fish. Leave at zero for an even game.
+            </span>
+          </label>
+          <input
+            id="player-handicap"
+            type="number"
+            inputMode="numeric"
+            value={handicap}
+            onChange={(e) => setHandicap(e.target.value)}
+            className={`${INPUT_CLASS} w-space-16 text-center`}
+          />
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={saveToCrew}
+          onClick={() => setSaveToCrew((on) => !on)}
+          className={`${CARD_CLASS} flex min-h-touch-floor items-center justify-between gap-space-3 p-space-3 text-left ${
+            saveToCrew ? "border-signal-orange" : ""
+          }`}
+        >
+          <span className="text-body text-text-primary">Remember them for next trip</span>
+          <span className={`text-label ${saveToCrew ? "text-signal-orange" : "text-text-muted"}`}>
+            {saveToCrew ? "On" : "Off"}
+          </span>
+        </button>
+        <button type="submit" disabled={name.trim().length === 0} className={`${SECONDARY_BUTTON} disabled:opacity-disabled`}>
+          Add player
+        </button>
+      </form>
+    </div>
+  );
+}
+
+function Frame({
+  title,
+  subtitle,
+  step,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  step: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="mx-auto flex max-w-reading flex-col gap-space-6 px-space-4 py-space-5">
+      <header className="flex flex-col gap-space-1">
+        <p className="text-caption text-text-muted">
+          Step {step} of 3{subtitle ? ` · ${subtitle}` : ""}
+        </p>
+        <h1 className="text-h1 text-text-primary">{title}</h1>
+      </header>
+      {children}
+    </div>
+  );
+}

--- a/src/features/games/components/new-game.tsx
+++ b/src/features/games/components/new-game.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { MODES } from "@/core/rules/games/modes";
 import { PARTICIPANT_COLORS, type GameMode, type GameRules, type ParticipantColor } from "@/core/rules/games/types";
 import { useRegionPreference } from "@/features/settings/region";
+import { useGuardedAction } from "../use-guard";
 import { GameSettings } from "./game-settings";
 import { modeName } from "../format";
 import {
@@ -52,15 +53,13 @@ export function NewGame() {
 
   const [sessionId, setSessionId] = useState<string | null>(resumeId);
   const [step, setStep] = useState<Step>(resumeId ? "players" : "mode");
-  const [busy, setBusy] = useState(false);
+  const { busy, run } = useGuardedAction();
 
   const session = games.sessions.find((s) => s.id === sessionId) ?? null;
   const players = sessionId ? participantsOf(games, sessionId) : [];
 
   async function chooseMode(mode: GameMode): Promise<void> {
-    if (busy) return;
-    setBusy(true);
-    try {
+    await run(async () => {
       const created = await createGame({
         mode,
         name: modeName(mode),
@@ -71,20 +70,15 @@ export function NewGame() {
       });
       setSessionId(created.id);
       setStep("players");
-    } finally {
-      setBusy(false);
-    }
+    });
   }
 
   async function begin(): Promise<void> {
-    if (!sessionId || busy) return;
-    setBusy(true);
-    try {
+    if (!sessionId) return;
+    await run(async () => {
       await startGame(sessionId);
       router.push(`/games/play?id=${sessionId}`);
-    } finally {
-      setBusy(false);
-    }
+    });
   }
 
   async function abandon(): Promise<void> {

--- a/src/features/games/components/scoreboard.tsx
+++ b/src/features/games/components/scoreboard.tsx
@@ -122,7 +122,12 @@ export function Scoreboard({ sessionId }: { sessionId: string }) {
                 <span className="text-caption text-text-muted">
                   {standing.eliminated_round !== null
                     ? `Out after ${session.rules.rounds.multi_day ? "day" : "round"} ${standing.eliminated_round}`
-                    : summaryFor(standing)}
+                    : summaryFor({
+                        catches: standing.scoring_catches,
+                        species: standing.unique_species.length,
+                        released: standing.released,
+                        handicap: standing.handicap,
+                      })}
                 </span>
                 {session.rules.cricket !== null ? (
                   <Marks
@@ -254,12 +259,12 @@ function NoSuchGame() {
  * a moving boat should provoke.
  */
 export function summaryFor(standing: {
-  scoring_catches: number;
-  unique_species: readonly string[];
+  catches: number;
+  species: number;
   released: number;
   handicap: number;
 }): string {
-  const parts = [`${standing.scoring_catches} fish`, `${standing.unique_species.length} species`];
+  const parts = [`${standing.catches} fish`, `${standing.species} species`];
   if (standing.released > 0) parts.push(`${standing.released} released`);
   if (standing.handicap !== 0) {
     parts.push(`${standing.handicap > 0 ? "+" : ""}${standing.handicap} head start`);

--- a/src/features/games/components/scoreboard.tsx
+++ b/src/features/games/components/scoreboard.tsx
@@ -88,9 +88,10 @@ export function Scoreboard({ sessionId }: { sessionId: string }) {
           <OfflineBadge />
         </div>
         <p className="text-caption text-text-muted">
-          {modeName(session.mode)}
+          {/* The game's default name IS the mode name, so printing both reads as a stutter. */}
+          {session.name === modeName(session.mode) ? "" : modeName(session.mode)}
           {session.rules.rounds.count > 1
-            ? ` · ${session.rules.rounds.multi_day ? "Day" : "Round"} ${standings.round} of ${session.rules.rounds.count}`
+            ? `${session.name === modeName(session.mode) ? "" : " · "}${session.rules.rounds.multi_day ? "Day" : "Round"} ${standings.round} of ${session.rules.rounds.count}`
             : ""}
           {paused ? " · Paused" : ""}
         </p>
@@ -121,7 +122,7 @@ export function Scoreboard({ sessionId }: { sessionId: string }) {
                 <span className="text-caption text-text-muted">
                   {standing.eliminated_round !== null
                     ? `Out after ${session.rules.rounds.multi_day ? "day" : "round"} ${standing.eliminated_round}`
-                    : summaryFor(standing.scoring_catches, standing.unique_species.length, standing.released)}
+                    : summaryFor(standing)}
                 </span>
                 {session.rules.cricket !== null ? (
                   <Marks
@@ -245,12 +246,24 @@ function NoSuchGame() {
   );
 }
 
-function summaryFor(catches: number, species: number, released: number): string {
-  const parts = [
-    `${catches} scoring ${catches === 1 ? "fish" : "fish"}`,
-    `${species} ${species === 1 ? "species" : "species"}`,
-  ];
-  if (released > 0) parts.push(`${released} released`);
+/**
+ * The line under a name on the scoreboard.
+ *
+ * The head start earns its place here: an angler sitting on 5 with no fish caught looks
+ * like a bug otherwise, and "where did that come from" is not a question a scoreboard on
+ * a moving boat should provoke.
+ */
+export function summaryFor(standing: {
+  scoring_catches: number;
+  unique_species: readonly string[];
+  released: number;
+  handicap: number;
+}): string {
+  const parts = [`${standing.scoring_catches} fish`, `${standing.unique_species.length} species`];
+  if (standing.released > 0) parts.push(`${standing.released} released`);
+  if (standing.handicap !== 0) {
+    parts.push(`${standing.handicap > 0 ? "+" : ""}${standing.handicap} head start`);
+  }
   return parts.join(" · ");
 }
 

--- a/src/features/games/components/scoreboard.tsx
+++ b/src/features/games/components/scoreboard.tsx
@@ -19,6 +19,7 @@ import {
   useGames,
 } from "../store";
 import { LogCatchSheet } from "./log-catch-sheet";
+import { useGuardedAction } from "../use-guard";
 import { useNow, useOnline } from "../use-now";
 import {
   BIG_ACTION,
@@ -54,7 +55,7 @@ export function Scoreboard({ sessionId }: { sessionId: string }) {
   const games = useGames();
   const router = useRouter();
   const [panel, setPanel] = useState<Panel>("none");
-  const [busy, setBusy] = useState(false);
+  const { busy, run } = useGuardedAction();
 
   const view = gameView(games, sessionId);
 
@@ -69,16 +70,6 @@ export function Scoreboard({ sessionId }: { sessionId: string }) {
   const lastScoring = [...standings.events].reverse().find((e) => e.status === "scored" && e.event.kind === "catch");
   const nameOf = (id: string | null) =>
     participants.find((p) => p.id === id)?.display_name ?? "Someone";
-
-  async function run(action: () => Promise<unknown>): Promise<void> {
-    if (busy) return;
-    setBusy(true);
-    try {
-      await action();
-    } finally {
-      setBusy(false);
-    }
-  }
 
   return (
     <div className="mx-auto flex max-w-reading flex-col gap-space-5 px-space-4 py-space-4">

--- a/src/features/games/components/scoreboard.tsx
+++ b/src/features/games/components/scoreboard.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+
+import { speciesById } from "@/core/ontology/species";
+import type { ScoredEvent } from "@/core/rules/games/scoring";
+import { explainRules } from "./game-settings";
+import { formatRemaining, modeName, pointsLabel } from "../format";
+import {
+  advanceRound,
+  finishGame,
+  gameView,
+  lastUndoableEvent,
+  pauseGame,
+  resumeGame,
+  undoEvent,
+  useGames,
+} from "../store";
+import { LogCatchSheet } from "./log-catch-sheet";
+import { useNow, useOnline } from "../use-now";
+import {
+  BIG_ACTION,
+  CARD_CLASS,
+  DANGER_BUTTON,
+  PARTICIPANT_CLASSES,
+  PRIMARY_BUTTON,
+  SECONDARY_BUTTON,
+} from "../ui-classes";
+
+type Panel = "none" | "log" | "review" | "rules";
+
+/**
+ * /games/[id] — the live game.
+ *
+ * Ordered by what has to be readable at arm's length on a moving boat: scores first and
+ * large, then the one action that matters, then everything else. Most fishing games do
+ * not take turns — everybody can hook up at once — so there is deliberately no turn
+ * indicator here; that belongs only to a mode built around turns, and none of the three
+ * are.
+ *
+ * Every number on this screen is folded from the event log on render (ADR 009 §3).
+ * Nothing is cached, so undo cannot leave a stale total behind.
+ */
+/** Reads the game id from the query string. See `app/(app)/games/play/page.tsx`. */
+export function ScoreboardRoute() {
+  const id = useSearchParams().get("id");
+  if (!id) return <NoSuchGame />;
+  return <Scoreboard sessionId={id} />;
+}
+
+export function Scoreboard({ sessionId }: { sessionId: string }) {
+  const games = useGames();
+  const router = useRouter();
+  const [panel, setPanel] = useState<Panel>("none");
+  const [busy, setBusy] = useState(false);
+
+  const view = gameView(games, sessionId);
+
+  if (!games.hydrated) {
+    return <p className="p-space-5 text-body text-text-muted">Opening the game…</p>;
+  }
+  if (!view) return <NoSuchGame />;
+
+  const { session, participants, standings } = view;
+  const paused = session.status === "paused";
+  const undoable = lastUndoableEvent(games, sessionId);
+  const lastScoring = [...standings.events].reverse().find((e) => e.status === "scored" && e.event.kind === "catch");
+  const nameOf = (id: string | null) =>
+    participants.find((p) => p.id === id)?.display_name ?? "Someone";
+
+  async function run(action: () => Promise<unknown>): Promise<void> {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await action();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto flex max-w-reading flex-col gap-space-5 px-space-4 py-space-4">
+      <header className="flex flex-col gap-space-1">
+        <div className="flex flex-wrap items-baseline justify-between gap-space-2">
+          <h1 className="text-h2 text-text-primary">{session.name}</h1>
+          <OfflineBadge />
+        </div>
+        <p className="text-caption text-text-muted">
+          {modeName(session.mode)}
+          {session.rules.rounds.count > 1
+            ? ` · ${session.rules.rounds.multi_day ? "Day" : "Round"} ${standings.round} of ${session.rules.rounds.count}`
+            : ""}
+          {paused ? " · Paused" : ""}
+        </p>
+        {!paused && session.rules.rounds.minutes !== null && session.started_at !== null ? (
+          <Countdown startedAt={session.started_at} minutes={session.rules.rounds.minutes} />
+        ) : null}
+      </header>
+
+      <ol className="flex flex-col gap-space-3">
+        {standings.rows.map((standing) => {
+          const player = participants.find((p) => p.id === standing.participant_id);
+          if (!player) return null;
+          const colors = PARTICIPANT_CLASSES[player.color_key] ?? PARTICIPANT_CLASSES["text-link"];
+          const leading = standing.participant_id === standings.leader_id && standing.eliminated_round === null;
+          return (
+            <li
+              key={standing.participant_id}
+              className={`${CARD_CLASS} flex items-center gap-space-4 p-space-4 ${
+                leading ? "border-signal-orange" : ""
+              } ${standing.eliminated_round !== null ? "opacity-disabled" : ""}`}
+            >
+              <span aria-hidden="true" className={`h-space-10 w-space-2 shrink-0 rounded-full ${colors.dot}`} />
+              <span className="flex min-w-0 flex-1 flex-col gap-space-1">
+                <span className="flex items-baseline gap-space-2">
+                  <span className="truncate text-h3 text-text-primary">{player.display_name}</span>
+                  {leading ? <span className="shrink-0 text-caption text-signal-orange">Leading</span> : null}
+                </span>
+                <span className="text-caption text-text-muted">
+                  {standing.eliminated_round !== null
+                    ? `Out after ${session.rules.rounds.multi_day ? "day" : "round"} ${standing.eliminated_round}`
+                    : summaryFor(standing.scoring_catches, standing.unique_species.length, standing.released)}
+                </span>
+                {session.rules.cricket !== null ? (
+                  <Marks
+                    targets={session.rules.cricket.targets}
+                    marks={standing.marks}
+                    toClose={session.rules.cricket.marks_to_close}
+                  />
+                ) : null}
+              </span>
+              <span className="shrink-0 text-display tabular-nums text-text-primary">{standing.points}</span>
+            </li>
+          );
+        })}
+      </ol>
+
+      {lastScoring ? (
+        <p className={`${CARD_CLASS} p-space-3 text-body text-text-muted`} aria-live="polite">
+          Last on the board: {nameOf(lastScoring.event.participant_id)} —{" "}
+          {speciesById(lastScoring.event.species_id)?.commonName ?? "a fish"},{" "}
+          {pointsLabel(lastScoring.points)}
+        </p>
+      ) : null}
+
+      {panel === "log" ? (
+        <section className={`${CARD_CLASS} p-space-4`} aria-label="Log a fish">
+          <LogCatchSheet
+            session={session}
+            participants={participants.filter((p) => p.removed_at === null)}
+            onDone={() => setPanel("none")}
+          />
+        </section>
+      ) : (
+        <button type="button" disabled={paused} onClick={() => setPanel("log")} className={`${BIG_ACTION} disabled:opacity-disabled`}>
+          {paused ? "Game is paused" : "Log a fish"}
+        </button>
+      )}
+
+      <div className="flex flex-wrap gap-space-2">
+        <button
+          type="button"
+          disabled={undoable === null || busy}
+          onClick={() => undoable && void run(() => undoEvent(sessionId, undoable.id))}
+          className={`${SECONDARY_BUTTON} flex-1 disabled:opacity-disabled`}
+        >
+          Undo last fish
+        </button>
+        <button
+          type="button"
+          onClick={() => setPanel(panel === "review" ? "none" : "review")}
+          className={`${SECONDARY_BUTTON} flex-1`}
+        >
+          Review catches
+        </button>
+        <button
+          type="button"
+          onClick={() => setPanel(panel === "rules" ? "none" : "rules")}
+          className={`${SECONDARY_BUTTON} flex-1`}
+        >
+          Game rules
+        </button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => void run(() => (paused ? resumeGame(sessionId) : pauseGame(sessionId)))}
+          className={`${SECONDARY_BUTTON} flex-1 disabled:opacity-disabled`}
+        >
+          {paused ? "Resume" : "Pause"}
+        </button>
+      </div>
+
+      {panel === "review" ? (
+        <ReviewList events={standings.events} nameOf={nameOf} onUndo={(id) => void run(() => undoEvent(sessionId, id))} />
+      ) : null}
+
+      {panel === "rules" ? (
+        <section className={`${CARD_CLASS} flex flex-col gap-space-2 p-space-4`} aria-label="Game rules">
+          <h2 className="text-body-strong text-text-primary">How this game works</h2>
+          <ul className="flex flex-col gap-space-2">
+            {explainRules(session.rules).map((line) => (
+              <li key={line} className="text-body text-text-muted">
+                {line}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <div className="flex flex-col gap-space-3 border-t border-hairline pt-space-4">
+        {standings.round < session.rules.rounds.count ? (
+          <button type="button" disabled={busy} onClick={() => void run(() => advanceRound(sessionId))} className={`${PRIMARY_BUTTON} disabled:opacity-disabled`}>
+            Close {session.rules.rounds.multi_day ? "day" : "round"} {standings.round}
+            {session.rules.elimination !== null ? " and make the cut" : ""}
+          </button>
+        ) : null}
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() =>
+            void run(async () => {
+              await finishGame(sessionId);
+              router.push(`/games/result?id=${sessionId}`);
+            })
+          }
+          className={`${DANGER_BUTTON} disabled:opacity-disabled`}
+        >
+          Finish the game
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function NoSuchGame() {
+  return (
+    <div className="mx-auto flex max-w-reading flex-col gap-space-4 p-space-5">
+      <p className="text-body text-text-primary">That game is not on this phone.</p>
+      <Link href="/games" className={SECONDARY_BUTTON}>
+        Back to Boat Games
+      </Link>
+    </div>
+  );
+}
+
+function summaryFor(catches: number, species: number, released: number): string {
+  const parts = [
+    `${catches} scoring ${catches === 1 ? "fish" : "fish"}`,
+    `${species} ${species === 1 ? "species" : "species"}`,
+  ];
+  if (released > 0) parts.push(`${released} released`);
+  return parts.join(" · ");
+}
+
+/** Cricket marks as the darts-style row: one slash, a cross, a circled cross. */
+function Marks({
+  targets,
+  marks,
+  toClose,
+}: {
+  targets: readonly string[];
+  marks: Readonly<Record<string, number>>;
+  toClose: number;
+}) {
+  return (
+    <ul className="flex flex-wrap gap-space-2">
+      {targets.map((target) => {
+        const held = marks[target] ?? 0;
+        const closed = held >= toClose;
+        return (
+          <li
+            key={target}
+            className={`text-caption ${closed ? "text-success-green" : "text-text-muted"}`}
+          >
+            {speciesById(target)?.commonName ?? target}{" "}
+            <span className="tabular-nums">
+              {closed ? "closed" : `${held}/${toClose}`}
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+/**
+ * The timer. A display and nothing more — it never ends a round (ADR 009 §3).
+ */
+function Countdown({ startedAt, minutes }: { startedAt: string; minutes: number }) {
+  const now = useNow();
+  // Zero until the store has ticked once, so the server and first client paint agree.
+  if (now === 0) return null;
+  const endsAt = new Date(startedAt).getTime() + minutes * 60_000;
+  return (
+    <p className="text-body text-tide-cyan" aria-live="off">
+      {formatRemaining(endsAt - now)}
+    </p>
+  );
+}
+
+function OfflineBadge() {
+  const online = useOnline();
+  if (online) return null;
+  return (
+    <span className="text-caption text-success-green">
+      Offline — the game is saved on this phone
+    </span>
+  );
+}
+
+function ReviewList({
+  events,
+  nameOf,
+  onUndo,
+}: {
+  events: readonly ScoredEvent[];
+  nameOf: (id: string | null) => string;
+  onUndo: (eventId: string) => void;
+}) {
+  const catches = [...events].reverse().filter((e) => e.event.kind === "catch");
+  if (catches.length === 0) {
+    return <p className="text-body text-text-muted">No fish yet.</p>;
+  }
+  return (
+    <ul className="flex flex-col gap-space-2" aria-label="Every fish in this game">
+      {catches.map((scored) => (
+        <li key={scored.event.id} className={`${CARD_CLASS} flex items-center gap-space-3 p-space-3`}>
+          <span className="flex min-w-0 flex-1 flex-col">
+            <span className="truncate text-body text-text-primary">
+              {nameOf(scored.event.participant_id)} —{" "}
+              {speciesById(scored.event.species_id)?.commonName ??
+                scored.event.species_other ??
+                "Not named yet"}
+            </span>
+            <span
+              className={`text-caption ${
+                scored.status === "scored"
+                  ? "text-text-muted"
+                  : scored.status === "voided"
+                    ? "text-text-muted"
+                    : "text-amber-flag"
+              }`}
+            >
+              {scored.status === "scored"
+                ? pointsLabel(scored.points) +
+                  (scored.bonuses.length > 0
+                    ? ` · ${scored.bonuses.map((b) => b.kind.replace(/_/g, " ")).join(", ")}`
+                    : "")
+                : (scored.reason ?? "No points")}
+            </span>
+          </span>
+          {scored.status !== "voided" ? (
+            <button type="button" onClick={() => onUndo(scored.event.id)} className={`${SECONDARY_BUTTON} shrink-0`}>
+              Undo
+            </button>
+          ) : (
+            <span className="shrink-0 text-caption text-text-muted">Undone</span>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/features/games/components/scoreboard.tsx
+++ b/src/features/games/components/scoreboard.tsx
@@ -100,12 +100,50 @@ export function Scoreboard({ sessionId }: { sessionId: string }) {
         ) : null}
       </header>
 
+      {/*
+        Team totals lead when the game has sides. Without this the board reads as four
+        individuals and the teams the captain set up have no visible effect on anything,
+        which is half a feature — the sides are the thing being played for.
+      */}
+      {standings.teams.length > 0 ? (
+        <>
+          <h2 className="text-label text-text-muted">Teams</h2>
+          <ol className="flex flex-col gap-space-2" aria-label="Team scores">
+          {standings.teams.map((team) => (
+            <li
+              key={team.team_id}
+              className={`${CARD_CLASS} flex items-center justify-between gap-space-3 p-space-4 ${
+                team.rank === 1 ? "border-signal-orange" : ""
+              }`}
+            >
+              <span className="flex min-w-0 flex-col">
+                <span className="truncate text-h3 text-text-primary">{team.team_id}</span>
+                <span className="text-caption text-text-muted">
+                  {team.participant_ids
+                    .map((id) => participants.find((p) => p.id === id)?.display_name)
+                    .filter(Boolean)
+                    .join(", ")}
+                </span>
+              </span>
+              <span className="shrink-0 text-display tabular-nums text-text-primary">{team.points}</span>
+            </li>
+          ))}
+          </ol>
+          <h2 className="text-label text-text-muted">Who caught what</h2>
+        </>
+      ) : null}
+
       <ol className="flex flex-col gap-space-3">
         {standings.rows.map((standing) => {
           const player = participants.find((p) => p.id === standing.participant_id);
           if (!player) return null;
           const colors = PARTICIPANT_CLASSES[player.color_key] ?? PARTICIPANT_CLASSES["text-link"];
-          const leading = standing.participant_id === standings.leader_id && standing.eliminated_round === null;
+          // In a team game nobody is "leading" — the side is. Highlighting a person there
+          // tells the boat the wrong thing about what is being played for.
+          const leading =
+            standings.teams.length === 0 &&
+            standing.participant_id === standings.leader_id &&
+            standing.eliminated_round === null;
           return (
             <li
               key={standing.participant_id}

--- a/src/features/games/flag.ts
+++ b/src/features/games/flag.ts
@@ -1,0 +1,10 @@
+/**
+ * `boat_games_v1`.
+ *
+ * A build-time constant, not a runtime lookup, so the routes stay static and a cold load
+ * on a boat still paints without the network (ADR 005 §5) — the same shape as
+ * `features/passport/flag.ts`. Setting `NEXT_PUBLIC_BOAT_GAMES_V1=off` hides the screens
+ * while the engine, its tests and the database migration all still ship.
+ */
+export const BOAT_GAMES_V1 =
+  (process.env.NEXT_PUBLIC_BOAT_GAMES_V1 ?? "on").toLowerCase() !== "off";

--- a/src/features/games/format.test.ts
+++ b/src/features/games/format.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { formatElapsed, formatRemaining, formatWhen, pointsLabel } from "./format";
+
+describe("formatElapsed", () => {
+  it("drops the hour until there is one", () => {
+    expect(formatElapsed(65_000)).toBe("1:05");
+    expect(formatElapsed(3_723_000)).toBe("1:02:03");
+  });
+  it("never renders a negative clock", () => {
+    expect(formatElapsed(-5_000)).toBe("0:00");
+  });
+});
+
+describe("formatRemaining", () => {
+  it("says the time is up rather than counting past zero", () => {
+    expect(formatRemaining(0)).toBe("Time's up");
+    expect(formatRemaining(-60_000)).toBe("Time's up");
+  });
+  it("uses minutes under the hour and hours over it", () => {
+    expect(formatRemaining(8 * 60_000)).toBe("8 min left");
+    expect(formatRemaining(120 * 60_000)).toBe("2 hr left");
+    expect(formatRemaining(95 * 60_000)).toBe("1 hr 35 min left");
+  });
+});
+
+describe("formatWhen", () => {
+  const now = new Date(2026, 8, 4, 12, 0, 0);
+  it("speaks in days near the present", () => {
+    expect(formatWhen(new Date(2026, 8, 4, 6).toISOString(), now)).toBe("Today");
+    expect(formatWhen(new Date(2026, 8, 3, 22).toISOString(), now)).toBe("Yesterday");
+    expect(formatWhen(new Date(2026, 8, 1).toISOString(), now)).toBe("3 days ago");
+  });
+  it("crosses midnight by calendar day, not by elapsed hours", () => {
+    // 14 hours earlier, but a different day — an angler calls that yesterday.
+    expect(formatWhen(new Date(2026, 8, 3, 22).toISOString(), new Date(2026, 8, 4, 12))).toBe("Yesterday");
+  });
+});
+
+describe("pointsLabel", () => {
+  it("gets the singular right", () => {
+    expect(pointsLabel(1)).toBe("+1 pt");
+    expect(pointsLabel(5)).toBe("+5 pts");
+    expect(pointsLabel(-1)).toBe("-1 pt");
+  });
+});

--- a/src/features/games/format.ts
+++ b/src/features/games/format.ts
@@ -1,0 +1,48 @@
+/** Small formatters the game screens share. Pure, so they are trivially testable. */
+
+import { MODES } from "@/core/rules/games/modes";
+import type { GameMode } from "@/core/rules/games/types";
+
+export function modeName(mode: GameMode): string {
+  return MODES.find((m) => m.mode === mode)?.name ?? "Game";
+}
+
+/** "1:24:03" while a game runs. Hours only appear once there are some. */
+export function formatElapsed(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const seconds = total % 60;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return hours > 0 ? `${hours}:${pad(minutes)}:${pad(seconds)}` : `${minutes}:${pad(seconds)}`;
+}
+
+/** "2 hours left", "8 minutes left", "Time's up". Words, not a bare countdown. */
+export function formatRemaining(ms: number): string {
+  if (ms <= 0) return "Time's up";
+  const minutes = Math.round(ms / 60000);
+  if (minutes < 60) return `${minutes} min left`;
+  const hours = Math.floor(minutes / 60);
+  const rest = minutes % 60;
+  if (rest === 0) return `${hours} hr left`;
+  return `${hours} hr ${rest} min left`;
+}
+
+/** "Today", "Yesterday", or a plain date. Never a raw ISO string in front of an angler. */
+export function formatWhen(iso: string, now: Date = new Date()): string {
+  const then = new Date(iso);
+  const days = Math.floor((startOfDay(now) - startOfDay(then)) / 86_400_000);
+  if (days === 0) return "Today";
+  if (days === 1) return "Yesterday";
+  if (days < 7) return `${days} days ago`;
+  return then.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function startOfDay(d: Date): number {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+}
+
+/** "Kelp bass · 4 lb 2 oz" style summary line for a scoring catch. */
+export function pointsLabel(points: number): string {
+  return `${points > 0 ? "+" : ""}${points} ${Math.abs(points) === 1 ? "pt" : "pts"}`;
+}

--- a/src/features/games/host-catch.ts
+++ b/src/features/games/host-catch.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import type { GameParticipant } from "@/core/rules/games/types";
+import { EMPTY_DRAFT, logCatch } from "@/features/catches/create";
+import { currentLog } from "@/features/catches/store";
+
+/**
+ * The one place a game catch may become a real catch (ADR 009 §1).
+ *
+ * This file is deliberately the *only* module in `features/games/` that imports the Fish
+ * Log's write path, and `ownership.test.ts` enforces that by name. The rule it protects is
+ * the founder's first requirement: if Mike catches a fish and Elliott records it on
+ * Elliott's phone, Mike's fish must never appear in Elliott's Passport, history, personal
+ * bests or statistics. Every other path in Boat Games writes a `game_event` and stops.
+ *
+ * So the host check below is not a formality. It is the rule, in code, at the only door
+ * that opens — and it is checked here rather than trusted from the caller, because a UI
+ * that only shows the toggle to the host is a UI, and a UI is one refactor from being
+ * wrong.
+ *
+ * The catch is minted through the ordinary `logCatch`, not by writing a row directly, so
+ * a fish caught during a game arrives in the log with the same rig, trip, conditions and
+ * regulation snapshot as any other fish. A game must not create second-class catches.
+ */
+
+export interface HostCatchInput {
+  readonly speciesId: string | null;
+  readonly speciesOther: string | null;
+  readonly lengthMm: number | null;
+  readonly weightG: number | null;
+  readonly disposition: "kept" | "released" | null;
+}
+
+/**
+ * Returns the new catch's id, or null if nothing was written.
+ *
+ * Null is not an error the caller has to handle loudly: the game event is already durable
+ * by the time this runs, and a failure here costs the angler a row in their own log, never
+ * the fish in the game. The game is the thing that must not break.
+ */
+export async function logHostCatch(
+  participant: GameParticipant,
+  input: HostCatchInput,
+): Promise<string | null> {
+  if (!participant.is_host) return null;
+
+  try {
+    const result = await logCatch(
+      currentLog(),
+      {
+        ...EMPTY_DRAFT,
+        speciesId: input.speciesId,
+        speciesOther: input.speciesOther,
+        lengthMm: input.lengthMm,
+        weightG: input.weightG,
+        // `n/a` rather than a guess: the game asks kept-or-released, but if it somehow
+        // arrives unset, inventing "released" would be a claim about a real fish in a
+        // real log, and the log's job is to be true rather than complete.
+        disposition: input.disposition ?? "n/a",
+        outcome: "landed",
+      },
+      // No GPS. Asking for a fix mid-game would put a permission prompt between the
+      // angler and the next fish; the catch flow attaches a position later if it can.
+      null,
+    );
+    return result.catchId;
+  } catch {
+    return null;
+  }
+}

--- a/src/features/games/legal.ts
+++ b/src/features/games/legal.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { speciesById } from "@/core/ontology/species";
+import type { EventLegalSnapshot } from "@/core/rules/games/types";
+import { snapshotForNewCatch } from "@/features/fish-legal/regulation-snapshot";
+
+/**
+ * What Fish Legal said about this fish, frozen onto the game event (ADR 009 §4).
+ *
+ * Reuses the same `snapshotForNewCatch` the catch flow uses, so a game and a log entry
+ * cannot disagree about the law. Frozen rather than looked up at render time for the
+ * reason the catch log already froze it: a pack update next season must not rewrite a
+ * finished game.
+ *
+ * A null return means no verified pack covers the region. That is *unknown*, not
+ * *prohibited* — the fold scores it normally. `protected_species` still travels, because
+ * it comes from the ontology and holds everywhere regardless of which packs have shipped.
+ */
+export function legalForGameCatch(
+  speciesId: string | null,
+  localDate: string,
+): EventLegalSnapshot | null {
+  if (speciesId === null) return null;
+  const isProtected = speciesById(speciesId)?.takeStatus === "protected";
+  const snapshot = snapshotForNewCatch(speciesId, localDate);
+  if (!snapshot) {
+    // No pack, but a protected species is still protected. Carry that much.
+    return isProtected
+      ? {
+          verdict: "release",
+          reason: "Protected species.",
+          pack_id: "none",
+          pack_version: 0,
+          protected_species: true,
+        }
+      : null;
+  }
+  return {
+    verdict: snapshot.verdict,
+    reason: snapshot.verdict_reason,
+    pack_id: snapshot.pack_id,
+    pack_version: snapshot.pack_version,
+    protected_species: isProtected,
+  };
+}
+
+/** The warning to show while a fish is being entered, if there is one worth showing. */
+export function legalWarning(legal: EventLegalSnapshot | null): string | null {
+  if (legal === null) return null;
+  if (legal.protected_species) return "Protected species — this one has to go back, and it scores nothing.";
+  if (legal.verdict === "release") return `${legal.reason} Release it and it still scores in full.`;
+  if (legal.verdict === "conditional") return legal.reason;
+  return null;
+}

--- a/src/features/games/ownership.test.ts
+++ b/src/features/games/ownership.test.ts
@@ -20,6 +20,13 @@ import { ENTITY_STORES, LOCAL_STORES } from "@/lib/offline/db";
 
 const GAMES_DIR = "src/features/games";
 
+/**
+ * The single sanctioned door between a game and the real Fish Log (ADR 009 §1). It exists
+ * so the host's own fish can reach their own log; it checks `is_host` itself, and it is
+ * named here so that any *other* file growing the same import fails this suite.
+ */
+const HOST_BRIDGE = join("src", "features", "games", "host-catch.ts");
+
 function sourceFiles(dir: string): readonly string[] {
   const out: string[] = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -51,13 +58,16 @@ describe("guest catches never become catch rows (ADR 009 §1)", () => {
     }
   });
 
-  it("never imports the Fish Log's write actions", () => {
-    for (const file of files) {
-      const text = readFileSync(file, "utf8");
-      expect(text, `${file} reaches into the catch store`).not.toMatch(
-        /from\s*["']@\/features\/catches\/(store|create)["']/,
-      );
-    }
+  it("imports the Fish Log's write actions from the host bridge and nowhere else", () => {
+    const importers = files.filter((file) =>
+      /from\s*["']@\/features\/catches\/(store|create)["']/.test(readFileSync(file, "utf8")),
+    );
+    expect(importers).toEqual([HOST_BRIDGE]);
+  });
+
+  it("keeps the host check inside the bridge rather than trusting its caller", () => {
+    const text = readFileSync(HOST_BRIDGE, "utf8");
+    expect(text).toMatch(/if\s*\(!participant\.is_host\)\s*return null;/);
   });
 });
 

--- a/src/features/games/ownership.test.ts
+++ b/src/features/games/ownership.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ENTITY_STORES, LOCAL_STORES } from "@/lib/offline/db";
+
+/**
+ * The architectural invariants from ADR 009, pinned at the level where a regression would
+ * actually be introduced — someone reaching for the catch store because it is right there
+ * and already has a species field.
+ *
+ * These are source-level assertions rather than behavioural ones on purpose. The behaviour
+ * was verified in a real browser (Chromium at 320px: after a guest logs a bluefin, the
+ * `catch` store holds 0 rows, the outbox holds 0, and `game_event` holds 1). But that check
+ * needs a browser and this suite has no DOM, and the invariant is too important to rest on
+ * a test somebody has to remember to run by hand. What is checked here is the thing that
+ * would break it.
+ */
+
+const GAMES_DIR = "src/features/games";
+
+function sourceFiles(dir: string): readonly string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...sourceFiles(path));
+    else if (/\.tsx?$/.test(entry.name) && !entry.name.endsWith(".test.ts")) out.push(path);
+  }
+  return out;
+}
+
+describe("guest catches never become catch rows (ADR 009 §1)", () => {
+  const files = sourceFiles(GAMES_DIR);
+
+  it("has source files to check, so a rename cannot silently pass this suite", () => {
+    expect(files.length).toBeGreaterThan(5);
+  });
+
+  it("never writes to the catch store from anywhere in Boat Games", () => {
+    for (const file of files) {
+      const text = readFileSync(file, "utf8");
+      // `commit` is the row-plus-outbox write path for syncable entities. Boat Games uses
+      // `commitLocal`. Importing the other one is how a game catch would become a catch.
+      expect(text, `${file} imports the syncable write path`).not.toMatch(
+        /\bimport\s*\{[^}]*\bcommit\b[^}]*\}\s*from\s*["']@\/lib\/offline\/db["']/,
+      );
+      expect(text, `${file} names the catch store in a write`).not.toMatch(
+        /store:\s*["']catch["']/,
+      );
+    }
+  });
+
+  it("never imports the Fish Log's write actions", () => {
+    for (const file of files) {
+      const text = readFileSync(file, "utf8");
+      expect(text, `${file} reaches into the catch store`).not.toMatch(
+        /from\s*["']@\/features\/catches\/(store|create)["']/,
+      );
+    }
+  });
+});
+
+describe("game stores stay out of the outbox (ADR 009 §2)", () => {
+  it("shares no store between the syncable set and the device-local set", () => {
+    const syncable = new Set<string>(ENTITY_STORES);
+    for (const local of LOCAL_STORES) {
+      // A store in both lists would be queued for a Supabase table that does not exist,
+      // and every mutation would come back 4xx and sit in `rejected` — a permanent
+      // "needs attention" badge on the angler's phone for a feature working perfectly.
+      expect(syncable.has(local), `${local} is in both sets`).toBe(false);
+    }
+  });
+
+  it("covers every store Boat Games writes to", () => {
+    expect([...LOCAL_STORES].sort()).toEqual([
+      "crew_member",
+      "game_event",
+      "game_participant",
+      "game_session",
+    ]);
+  });
+});

--- a/src/features/games/store.ts
+++ b/src/features/games/store.ts
@@ -322,8 +322,15 @@ export async function deleteCrewMember(id: string): Promise<void> {
  * Append one event and advance the session's sequence counter, in one transaction.
  *
  * The pairing is the point: `next_seq` and the event that consumed it are written
- * together or not at all, so two catches can never share a sequence number and the fold's
- * ordering stays total.
+ * together or not at all.
+ *
+ * The counter is nonetheless taken as the HIGHER of the session's `next_seq` and one past
+ * the largest sequence already on an event. `next_seq` is read from the in-memory
+ * snapshot, and two appends started before either has persisted would both read the same
+ * value and mint two events sharing a sequence number. Deriving it from the events as well
+ * makes that self-healing: the counter cannot go backwards even if the snapshot is stale,
+ * and a session whose counter is somehow wrong repairs itself on the next event rather
+ * than silently interleaving a game's history.
  */
 async function appendEvent(
   sessionId: string,
@@ -332,13 +339,17 @@ async function appendEvent(
   const session = snapshot.sessions.find((s) => s.id === sessionId);
   if (!session) return null;
   const standings = gameView(snapshot, sessionId)?.standings;
+  const highestSoFar = snapshot.events
+    .filter((e) => e.session_id === sessionId)
+    .reduce((max, e) => Math.max(max, e.seq), 0);
+  const seq = Math.max(session.next_seq, highestSoFar + 1);
   const event: GameEvent = {
     id: uuidv7(),
     session_id: sessionId,
     kind: fields.kind,
     participant_id: fields.participant_id ?? null,
     round: standings?.round ?? 1,
-    seq: session.next_seq,
+    seq,
     created_at: new Date().toISOString(),
     species_id: fields.species_id ?? null,
     species_other: fields.species_other ?? null,
@@ -356,7 +367,7 @@ async function appendEvent(
   };
   await persist([
     { store: "game_event", row: row(event) },
-    { store: "game_session", row: row({ ...session, next_seq: session.next_seq + 1 }) },
+    { store: "game_session", row: row({ ...session, next_seq: seq + 1 }) },
   ]);
   return event;
 }

--- a/src/features/games/store.ts
+++ b/src/features/games/store.ts
@@ -1,0 +1,513 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+import { speciesById } from "@/core/ontology/species";
+import { defaultsFor } from "@/core/rules/games/modes";
+import { score, type GameStandings, type ScoringContext } from "@/core/rules/games/scoring";
+import type {
+  CrewMember,
+  EventDisposition,
+  EventLegalSnapshot,
+  GameEvent,
+  GameEventKind,
+  GameMode,
+  GameParticipant,
+  GameRules,
+  GameSession,
+  GameTeam,
+  ParticipantColor,
+} from "@/core/rules/games/types";
+import { uuidv7 } from "@/core/sync/uuid";
+import {
+  allLocalRows,
+  commitLocal,
+  deleteLocalRow,
+  isIndexedDbAvailable,
+  type LocalStore,
+  type StoredRow,
+} from "@/lib/offline/db";
+
+/**
+ * Boat Games' read model and write path (ADR 009).
+ *
+ * The same shape as `features/catches/store.ts` — one in-memory snapshot hydrated from
+ * IndexedDB and republished on every write, read through `useSyncExternalStore` with an
+ * empty server snapshot so SSR and the first client paint agree.
+ *
+ * What is deliberately different: nothing here touches the outbox. A Phase 1 game is
+ * device-local, and queuing it for a table that does not exist would light up the backup
+ * warning for a game that is working perfectly (ADR 009 §2).
+ *
+ * The scoreboard is never stored. Every read folds the events (ADR 009 §3), which is why
+ * undo is an appended row rather than a recalculation somebody has to remember to run.
+ */
+
+export interface GamesSnapshot {
+  readonly hydrated: boolean;
+  readonly available: boolean;
+  readonly sessions: readonly GameSession[];
+  readonly participants: readonly GameParticipant[];
+  readonly events: readonly GameEvent[];
+  readonly teams: readonly GameTeam[];
+  readonly crew: readonly CrewMember[];
+}
+
+const EMPTY: GamesSnapshot = {
+  hydrated: false,
+  available: true,
+  sessions: [],
+  participants: [],
+  events: [],
+  teams: [],
+  crew: [],
+};
+
+let snapshot: GamesSnapshot = EMPTY;
+const listeners = new Set<() => void>();
+
+function publish(next: GamesSnapshot): void {
+  snapshot = next;
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  // Hydration is triggered by the first subscriber, matching `features/catches/store.ts`:
+  // idempotent, so every screen can mount without coordinating who loads the database.
+  void hydrateGames();
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+const getSnapshot = (): GamesSnapshot => snapshot;
+const SERVER: GamesSnapshot = EMPTY;
+const getServerSnapshot = (): GamesSnapshot => SERVER;
+
+let hydrating: Promise<void> | null = null;
+
+export function hydrateGames(): Promise<void> {
+  if (hydrating) return hydrating;
+  hydrating = (async () => {
+    if (!isIndexedDbAvailable()) {
+      publish({ ...EMPTY, hydrated: true, available: false });
+      return;
+    }
+    try {
+      await refresh();
+    } catch {
+      // A browser with IndexedDB blocked still renders, and says plainly that nothing
+      // can be saved, rather than throwing at somebody standing on a boat.
+      publish({ ...EMPTY, hydrated: true, available: false });
+    }
+  })();
+  return hydrating;
+}
+
+async function refresh(): Promise<void> {
+  const [sessions, participants, events, crew] = await Promise.all([
+    allLocalRows("game_session"),
+    allLocalRows("game_participant"),
+    allLocalRows("game_event"),
+    allLocalRows("crew_member"),
+  ]);
+  publish({
+    hydrated: true,
+    available: true,
+    sessions: sessions as unknown as GameSession[],
+    participants: participants as unknown as GameParticipant[],
+    events: events as unknown as GameEvent[],
+    teams: [],
+    crew: crew as unknown as CrewMember[],
+  });
+}
+
+export function useGames(): GamesSnapshot {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+export function currentGames(): GamesSnapshot {
+  return snapshot;
+}
+
+// --- Selectors ---------------------------------------------------------------------
+
+/** The ontology facts the fold needs, bound to the real species table. */
+export const SCORING_CONTEXT: ScoringContext = {
+  rollsUpTo: (id) => speciesById(id)?.rollsUpTo ?? null,
+  isProtected: (id) => speciesById(id)?.takeStatus === "protected",
+};
+
+export interface GameView {
+  readonly session: GameSession;
+  readonly participants: readonly GameParticipant[];
+  readonly events: readonly GameEvent[];
+  readonly standings: GameStandings;
+}
+
+export function gameView(state: GamesSnapshot, sessionId: string): GameView | null {
+  const session = state.sessions.find((s) => s.id === sessionId);
+  if (!session) return null;
+  const participants = state.participants.filter((p) => p.session_id === sessionId);
+  const events = state.events.filter((e) => e.session_id === sessionId);
+  return {
+    session,
+    participants,
+    events,
+    standings: score(session.rules, participants, events, SCORING_CONTEXT),
+  };
+}
+
+/** Games the angler can pick back up. The home screen leads with these. */
+export function unfinishedGames(state: GamesSnapshot): readonly GameSession[] {
+  return state.sessions
+    .filter((s) => s.status === "active" || s.status === "paused" || s.status === "draft")
+    .slice()
+    .sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+}
+
+export function finishedGames(state: GamesSnapshot): readonly GameSession[] {
+  return state.sessions
+    .filter((s) => s.status === "completed")
+    .slice()
+    .sort((a, b) => ((a.completed_at ?? "") < (b.completed_at ?? "") ? 1 : -1));
+}
+
+export function participantsOf(
+  state: GamesSnapshot,
+  sessionId: string,
+): readonly GameParticipant[] {
+  return state.participants.filter((p) => p.session_id === sessionId && p.removed_at === null);
+}
+
+// --- Write path --------------------------------------------------------------------
+
+async function persist(writes: readonly { store: LocalStore; row: StoredRow }[]): Promise<void> {
+  await commitLocal(writes);
+  await refresh();
+}
+
+const row = (value: unknown): StoredRow => value as unknown as StoredRow;
+
+export async function createGame(input: {
+  mode: GameMode;
+  name: string;
+  zone: string;
+  regionId: string;
+  tripId: string | null;
+  rules?: GameRules;
+}): Promise<GameSession> {
+  const session: GameSession = {
+    id: uuidv7(),
+    mode: input.mode,
+    name: input.name,
+    status: "draft",
+    rules: input.rules ?? defaultsFor(input.mode),
+    zone: input.zone,
+    region_id: input.regionId,
+    trip_id: input.tripId,
+    created_at: new Date().toISOString(),
+    started_at: null,
+    completed_at: null,
+    next_seq: 1,
+  };
+  await persist([{ store: "game_session", row: row(session) }]);
+  return session;
+}
+
+export async function updateRules(sessionId: string, rules: GameRules): Promise<void> {
+  const session = snapshot.sessions.find((s) => s.id === sessionId);
+  if (!session) return;
+  await persist([{ store: "game_session", row: row({ ...session, rules }) }]);
+}
+
+export async function renameGame(sessionId: string, name: string): Promise<void> {
+  const session = snapshot.sessions.find((s) => s.id === sessionId);
+  if (!session) return;
+  await persist([{ store: "game_session", row: row({ ...session, name }) }]);
+}
+
+export async function addParticipant(input: {
+  sessionId: string;
+  displayName: string;
+  colorKey: ParticipantColor;
+  teamId: string | null;
+  handicap: number;
+  isHost: boolean;
+  saveToCrew: boolean;
+}): Promise<GameParticipant> {
+  const now = new Date().toISOString();
+  const participant: GameParticipant = {
+    id: uuidv7(),
+    session_id: input.sessionId,
+    display_name: input.displayName,
+    color_key: input.colorKey,
+    team_id: input.teamId,
+    handicap_points: input.handicap,
+    is_host: input.isHost,
+    claimed_user_id: null,
+    joined_at: now,
+    removed_at: null,
+  };
+  const writes: { store: LocalStore; row: StoredRow }[] = [
+    { store: "game_participant", row: row(participant) },
+  ];
+  if (input.saveToCrew) {
+    const existing = snapshot.crew.find(
+      (c) => c.display_name.toLowerCase() === input.displayName.toLowerCase(),
+    );
+    const member: CrewMember = existing
+      ? { ...existing, last_played_at: now, color_key: input.colorKey, default_handicap: input.handicap }
+      : {
+          id: uuidv7(),
+          display_name: input.displayName,
+          color_key: input.colorKey,
+          default_handicap: input.handicap,
+          created_at: now,
+          last_played_at: now,
+        };
+    writes.push({ store: "crew_member", row: row(member) });
+  }
+  await persist(writes);
+  return participant;
+}
+
+/**
+ * Remove a player. Before the game starts they are deleted outright; once it is running
+ * they are tombstoned instead, because their events are part of the record and the fold
+ * needs to be able to say "this player was removed" rather than find an orphan.
+ */
+export async function removeParticipant(participantId: string): Promise<void> {
+  const participant = snapshot.participants.find((p) => p.id === participantId);
+  if (!participant) return;
+  const session = snapshot.sessions.find((s) => s.id === participant.session_id);
+  if (session?.status === "draft") {
+    await deleteLocalRow("game_participant", participantId);
+    await refresh();
+    return;
+  }
+  await persist([
+    { store: "game_participant", row: row({ ...participant, removed_at: new Date().toISOString() }) },
+  ]);
+}
+
+export async function saveCrewMember(input: {
+  displayName: string;
+  colorKey: ParticipantColor;
+  handicap: number;
+}): Promise<void> {
+  const now = new Date().toISOString();
+  await persist([
+    {
+      store: "crew_member",
+      row: row({
+        id: uuidv7(),
+        display_name: input.displayName,
+        color_key: input.colorKey,
+        default_handicap: input.handicap,
+        created_at: now,
+        last_played_at: null,
+      } satisfies CrewMember),
+    },
+  ]);
+}
+
+export async function deleteCrewMember(id: string): Promise<void> {
+  await deleteLocalRow("crew_member", id);
+  await refresh();
+}
+
+/**
+ * Append one event and advance the session's sequence counter, in one transaction.
+ *
+ * The pairing is the point: `next_seq` and the event that consumed it are written
+ * together or not at all, so two catches can never share a sequence number and the fold's
+ * ordering stays total.
+ */
+async function appendEvent(
+  sessionId: string,
+  fields: Partial<GameEvent> & { kind: GameEventKind },
+): Promise<GameEvent | null> {
+  const session = snapshot.sessions.find((s) => s.id === sessionId);
+  if (!session) return null;
+  const standings = gameView(snapshot, sessionId)?.standings;
+  const event: GameEvent = {
+    id: uuidv7(),
+    session_id: sessionId,
+    kind: fields.kind,
+    participant_id: fields.participant_id ?? null,
+    round: standings?.round ?? 1,
+    seq: session.next_seq,
+    created_at: new Date().toISOString(),
+    species_id: fields.species_id ?? null,
+    species_other: fields.species_other ?? null,
+    length_mm: fields.length_mm ?? null,
+    weight_g: fields.weight_g ?? null,
+    disposition: fields.disposition ?? null,
+    personal_best: fields.personal_best ?? false,
+    new_species: fields.new_species ?? false,
+    catch_id: fields.catch_id ?? null,
+    legal: fields.legal ?? null,
+    voids_event_id: fields.voids_event_id ?? null,
+    adjustment_points: fields.adjustment_points ?? null,
+    note: fields.note ?? null,
+    approved: fields.approved ?? !session.rules.host_approval,
+  };
+  await persist([
+    { store: "game_event", row: row(event) },
+    { store: "game_session", row: row({ ...session, next_seq: session.next_seq + 1 }) },
+  ]);
+  return event;
+}
+
+export async function startGame(sessionId: string): Promise<void> {
+  const session = snapshot.sessions.find((s) => s.id === sessionId);
+  if (!session) return;
+  await persist([
+    {
+      store: "game_session",
+      row: row({ ...session, status: "active", started_at: new Date().toISOString() }),
+    },
+  ]);
+}
+
+export interface GameCatchInput {
+  readonly sessionId: string;
+  readonly participantId: string;
+  readonly speciesId: string | null;
+  readonly speciesOther: string | null;
+  readonly lengthMm: number | null;
+  readonly weightG: number | null;
+  readonly disposition: EventDisposition | null;
+  readonly personalBest: boolean;
+  readonly newSpecies: boolean;
+  readonly legal: EventLegalSnapshot | null;
+  /** Set when the host opted this fish into their own log (ADR 009 §1). */
+  readonly catchId: string | null;
+}
+
+export async function logGameCatch(input: GameCatchInput): Promise<GameEvent | null> {
+  return appendEvent(input.sessionId, {
+    kind: "catch",
+    participant_id: input.participantId,
+    species_id: input.speciesId,
+    species_other: input.speciesOther,
+    length_mm: input.lengthMm,
+    weight_g: input.weightG,
+    disposition: input.disposition,
+    personal_best: input.personalBest,
+    new_species: input.newSpecies,
+    legal: input.legal,
+    catch_id: input.catchId,
+  });
+}
+
+/**
+ * Undo. Appends a `void` naming the event it takes back — never a delete, so the game's
+ * history stays whole and a mis-tap is visible as a correction rather than a gap.
+ */
+export async function undoEvent(sessionId: string, eventId: string): Promise<void> {
+  await appendEvent(sessionId, { kind: "void", voids_event_id: eventId, approved: true });
+}
+
+/** The most recent catch that has not already been undone. What "Undo last" undoes. */
+export function lastUndoableEvent(state: GamesSnapshot, sessionId: string): GameEvent | null {
+  const events = state.events.filter((e) => e.session_id === sessionId);
+  const voided = new Set(
+    events.filter((e) => e.kind === "void").map((e) => e.voids_event_id ?? ""),
+  );
+  const candidates = events
+    .filter((e) => e.kind === "catch" && !voided.has(e.id))
+    .sort((a, b) => b.seq - a.seq);
+  return candidates[0] ?? null;
+}
+
+export async function approveEvent(sessionId: string, eventId: string): Promise<void> {
+  const event = snapshot.events.find((e) => e.id === eventId);
+  if (!event) return;
+  await persist([{ store: "game_event", row: row({ ...event, approved: true }) }]);
+}
+
+export async function adjustPoints(
+  sessionId: string,
+  participantId: string,
+  points: number,
+  note: string,
+): Promise<void> {
+  await appendEvent(sessionId, {
+    kind: "adjustment",
+    participant_id: participantId,
+    adjustment_points: points,
+    note,
+    approved: true,
+  });
+}
+
+export async function advanceRound(sessionId: string): Promise<void> {
+  await appendEvent(sessionId, { kind: "round_advanced", approved: true });
+}
+
+export async function pauseGame(sessionId: string): Promise<void> {
+  const session = snapshot.sessions.find((s) => s.id === sessionId);
+  if (!session) return;
+  await appendEvent(sessionId, { kind: "paused", approved: true });
+  const latest = currentGames().sessions.find((s) => s.id === sessionId);
+  if (latest) await persist([{ store: "game_session", row: row({ ...latest, status: "paused" }) }]);
+}
+
+export async function resumeGame(sessionId: string): Promise<void> {
+  const session = snapshot.sessions.find((s) => s.id === sessionId);
+  if (!session) return;
+  await appendEvent(sessionId, { kind: "resumed", approved: true });
+  const latest = currentGames().sessions.find((s) => s.id === sessionId);
+  if (latest) await persist([{ store: "game_session", row: row({ ...latest, status: "active" }) }]);
+}
+
+export async function finishGame(sessionId: string): Promise<void> {
+  const session = snapshot.sessions.find((s) => s.id === sessionId);
+  if (!session) return;
+  await persist([
+    {
+      store: "game_session",
+      row: row({ ...session, status: "completed", completed_at: new Date().toISOString() }),
+    },
+  ]);
+}
+
+export async function discardGame(sessionId: string): Promise<void> {
+  for (const event of snapshot.events.filter((e) => e.session_id === sessionId)) {
+    await deleteLocalRow("game_event", event.id);
+  }
+  for (const p of snapshot.participants.filter((p) => p.session_id === sessionId)) {
+    await deleteLocalRow("game_participant", p.id);
+  }
+  await deleteLocalRow("game_session", sessionId);
+  await refresh();
+}
+
+/** A rematch: the same rules and the same crew, a clean slate of events. */
+export async function rematch(sessionId: string): Promise<GameSession | null> {
+  const previous = snapshot.sessions.find((s) => s.id === sessionId);
+  if (!previous) return null;
+  const created = await createGame({
+    mode: previous.mode,
+    name: previous.name,
+    zone: previous.zone,
+    regionId: previous.region_id,
+    tripId: previous.trip_id,
+    rules: previous.rules,
+  });
+  for (const p of snapshot.participants.filter((p) => p.session_id === sessionId && p.removed_at === null)) {
+    await addParticipant({
+      sessionId: created.id,
+      displayName: p.display_name,
+      colorKey: p.color_key,
+      teamId: p.team_id,
+      handicap: p.handicap_points,
+      isHost: p.is_host,
+      saveToCrew: false,
+    });
+  }
+  return created;
+}

--- a/src/features/games/ui-classes.ts
+++ b/src/features/games/ui-classes.ts
@@ -1,0 +1,48 @@
+/**
+ * Boat Games' repeated controls.
+ *
+ * Copied value-for-value from `features/catches/ui-classes.ts` for the reason stated
+ * there: ADR 005 §3 forbids reaching into another feature's internals, and a handful of
+ * class strings is a cheaper duplication than a cross-feature import.
+ *
+ * The two additions below are the ones a scoreboard needs and a log does not.
+ */
+
+export const FOCUS_RING =
+  "focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring";
+
+export const CHIP_CLASS = `min-h-touch-floor rounded-full border px-4 text-label transition-colors ${FOCUS_RING} active:scale-95 motion-reduce:transition-none`;
+export const CHIP_ON = "border-signal-orange bg-signal-orange text-ink-on-orange";
+export const CHIP_OFF = "border-border-interactive bg-surface text-text-link";
+
+export const PRIMARY_BUTTON = `inline-flex min-h-touch-floor items-center justify-center rounded-md bg-signal-orange px-4 text-label font-semibold text-ink-on-orange transition-colors hover:bg-signal-orange-pressed ${FOCUS_RING} active:scale-95 motion-reduce:transition-none`;
+
+export const SECONDARY_BUTTON = `inline-flex min-h-touch-floor items-center justify-center rounded-md border border-border-interactive px-4 text-label text-text-link transition-colors ${FOCUS_RING} active:scale-95 motion-reduce:transition-none`;
+
+export const DANGER_BUTTON = `inline-flex min-h-touch-floor items-center justify-center rounded-md border border-border-interactive px-4 text-label text-error-red transition-colors ${FOCUS_RING} active:scale-95 motion-reduce:transition-none`;
+
+export const INPUT_CLASS = `min-h-touch-floor w-full rounded-md border border-border-interactive bg-background px-4 text-body text-text-primary placeholder:text-text-muted ${FOCUS_RING}`;
+
+export const SELECT_CLASS = `min-h-touch-floor w-full rounded-md border border-border-interactive bg-background px-3 text-body text-text-primary ${FOCUS_RING}`;
+
+export const CARD_CLASS = "rounded-lg border border-hairline bg-surface";
+
+/**
+ * The one action that has to be findable with wet hands while the boat is moving, so it
+ * is taller than the touch floor rather than merely meeting it (design 03 §2).
+ */
+export const BIG_ACTION = `flex min-h-touch-primary-standard w-full items-center justify-center rounded-lg bg-signal-orange px-4 text-h3 font-semibold text-ink-on-orange transition-colors hover:bg-signal-orange-pressed ${FOCUS_RING} active:scale-95 motion-reduce:transition-none`;
+
+/**
+ * A participant's colour, as a full class pair. Written out rather than interpolated
+ * because Tailwind only ships classes it can see in the source — `bg-${key}` compiles to
+ * nothing at all and the scoreboard would render every player grey.
+ */
+export const PARTICIPANT_CLASSES: Record<string, { readonly dot: string; readonly text: string }> = {
+  "signal-orange": { dot: "bg-signal-orange", text: "text-signal-orange" },
+  "tide-cyan": { dot: "bg-tide-cyan", text: "text-tide-cyan" },
+  "moon-pale": { dot: "bg-moon-pale", text: "text-moon-pale" },
+  "success-green": { dot: "bg-success-green", text: "text-success-green" },
+  "amber-flag": { dot: "bg-amber-flag", text: "text-amber-flag" },
+  "text-link": { dot: "bg-text-link", text: "text-text-link" },
+};

--- a/src/features/games/use-guard.ts
+++ b/src/features/games/use-guard.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+/**
+ * Run an action at most once at a time, and report whether it is running.
+ *
+ * The `busy` flag alone is not enough, and the difference matters here more than in most
+ * apps. React state is read from a render closure, so two taps arriving before the
+ * re-render both see `busy === false` and both actions run. On this screen that is not a
+ * cosmetic bug: a double-tap on "Close day and make the cut" would close two days and
+ * eliminate two anglers, and the founder's handoff names duplicate button taps as a case
+ * the game has to survive on a wet phone.
+ *
+ * The ref is checked and set synchronously in the same turn, so the second tap loses
+ * whatever React has or has not re-rendered. The state exists only so the button can
+ * disable itself and say "Saving…".
+ *
+ * This is measured, not assumed. Five clicks dispatched in one synchronous task against a
+ * state-only guard wrote FIVE catches for one fish, all sharing sequence number 1; the
+ * same test against this guard writes one. (Playwright's ordinary `click()` cannot show
+ * the difference — the browser spaces those far enough apart that React always re-renders
+ * in between, so both versions pass. It takes clicks inside a single task to reproduce
+ * what a laggy phone does on its own.)
+ */
+export function useGuardedAction(): {
+  readonly busy: boolean;
+  readonly run: (action: () => Promise<unknown>) => Promise<void>;
+} {
+  const running = useRef(false);
+  const [busy, setBusy] = useState(false);
+
+  const run = useCallback(async (action: () => Promise<unknown>): Promise<void> => {
+    if (running.current) return;
+    running.current = true;
+    setBusy(true);
+    try {
+      await action();
+    } finally {
+      running.current = false;
+      setBusy(false);
+    }
+  }, []);
+
+  return { busy, run };
+}

--- a/src/features/games/use-now.ts
+++ b/src/features/games/use-now.ts
@@ -1,0 +1,75 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+/**
+ * A ticking clock and the online flag, as external stores rather than `useEffect` +
+ * `setState`.
+ *
+ * Both were written the obvious way first and both tripped `react-hooks/set-state-in-effect`,
+ * which is the correct call: setting state synchronously in an effect body is a cascading
+ * render, and with the React Compiler on it is exactly the shape that behaves differently
+ * from what the code appears to say. `useSyncExternalStore` is what these are for — an
+ * outside source of truth (the wall clock, the radio) that React subscribes to.
+ *
+ * The cached `nowMs` matters: `getSnapshot` must return a value that is `Object.is`-equal
+ * between renders or React re-renders forever, so it returns the last tick rather than
+ * calling `Date.now()` itself.
+ */
+
+let nowMs = 0;
+const listeners = new Set<() => void>();
+let timer: number | null = null;
+
+function emit(): void {
+  const next = Date.now();
+  if (next === nowMs) return;
+  nowMs = next;
+  for (const listener of listeners) listener();
+}
+
+function subscribeNow(listener: () => void): () => void {
+  listeners.add(listener);
+  if (timer === null) {
+    nowMs = Date.now();
+    // Only while the tab is visible. A countdown burning battery in a pocket for six
+    // hours is a real cost on a boat with no charger.
+    timer = window.setInterval(() => {
+      if (document.visibilityState === "visible") emit();
+    }, 1000);
+    document.addEventListener("visibilitychange", emit);
+  }
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0 && timer !== null) {
+      window.clearInterval(timer);
+      document.removeEventListener("visibilitychange", emit);
+      timer = null;
+    }
+  };
+}
+
+const getNow = (): number => nowMs;
+/** Zero on the server, so the first client paint matches and the timer simply hides. */
+const getServerNow = (): number => 0;
+
+export function useNow(): number {
+  return useSyncExternalStore(subscribeNow, getNow, getServerNow);
+}
+
+function subscribeOnline(listener: () => void): () => void {
+  window.addEventListener("online", listener);
+  window.addEventListener("offline", listener);
+  return () => {
+    window.removeEventListener("online", listener);
+    window.removeEventListener("offline", listener);
+  };
+}
+
+/** A boolean, so it is stable between renders without any caching of its own. */
+const getOnline = (): boolean => navigator.onLine;
+const getServerOnline = (): boolean => true;
+
+export function useOnline(): boolean {
+  return useSyncExternalStore(subscribeOnline, getOnline, getServerOnline);
+}

--- a/src/lib/offline/db.ts
+++ b/src/lib/offline/db.ts
@@ -21,7 +21,7 @@ import { openDB, type DBSchema, type IDBPDatabase, type IDBPTransaction, type St
 import type { Mutation, SyncEntity } from "@/core/sync/outbox";
 
 /** Bump only with a migration in `upgrade` below. */
-const DB_VERSION = 3;
+const DB_VERSION = 4;
 const DB_NAME = "fish-log-book";
 
 export const ENTITY_STORES = [
@@ -34,6 +34,24 @@ export const ENTITY_STORES = [
 ] as const;
 
 export type EntityStore = (typeof ENTITY_STORES)[number];
+
+/**
+ * Stores that live only on this device and are NEVER queued for sync (ADR 009 §2).
+ *
+ * Boat Games in Phase 1 is one host phone with no server behind it. Adding these to
+ * `ENTITY_STORES` would queue a mutation per row for Supabase tables that do not exist:
+ * every one comes back 4xx, lands in `rejected`, and puts a permanent "needs attention"
+ * badge on the angler's phone for a feature that is working perfectly. Phase 2 moves
+ * them across at the same moment it adds the tables — not before.
+ */
+export const LOCAL_STORES = [
+  "game_session",
+  "game_participant",
+  "game_event",
+  "crew_member",
+] as const;
+
+export type LocalStore = (typeof LOCAL_STORES)[number];
 
 /** Every syncable row carries at least these. Domain types live in `core/`. */
 export interface StoredRow {
@@ -52,6 +70,12 @@ interface FishLogDB extends DBSchema {
   meta: { key: string; value: unknown };
   /** Photo blobs, kept out of the row so a list query never drags megabytes with it. */
   media: { key: string; value: { id: string; catch_id: string; blob: Blob; created_at: string } };
+
+  /* Boat Games, device-local (ADR 009). Not syncable in Phase 1 — see LOCAL_STORES. */
+  game_session: { key: string; value: StoredRow };
+  game_participant: { key: string; value: StoredRow; indexes: { by_session: string } };
+  game_event: { key: string; value: StoredRow; indexes: { by_session: string } };
+  crew_member: { key: string; value: StoredRow };
 }
 
 let dbPromise: Promise<IDBPDatabase<FishLogDB>> | null = null;
@@ -87,6 +111,25 @@ export function getDb(): Promise<IDBPDatabase<FishLogDB>> {
 
         if (oldVersion > 0 && oldVersion < 3) {
           void backfillQuiverIds(tx);
+        }
+
+        // v4: Boat Games (ADR 009). Purely additive — four new stores, nothing existing
+        // is touched, so an angler mid-trip gains the feature without risking the log.
+        if (oldVersion < 4) {
+          if (!db.objectStoreNames.contains("game_session")) {
+            db.createObjectStore("game_session", { keyPath: "id" });
+          }
+          if (!db.objectStoreNames.contains("game_participant")) {
+            db.createObjectStore("game_participant", { keyPath: "id" })
+              .createIndex("by_session", "session_id");
+          }
+          if (!db.objectStoreNames.contains("game_event")) {
+            db.createObjectStore("game_event", { keyPath: "id" })
+              .createIndex("by_session", "session_id");
+          }
+          if (!db.objectStoreNames.contains("crew_member")) {
+            db.createObjectStore("crew_member", { keyPath: "id" });
+          }
         }
       },
     });
@@ -176,6 +219,35 @@ export async function commit(
 export async function allRows(store: EntityStore): Promise<readonly StoredRow[]> {
   const db = await getDb();
   return db.getAll(store);
+}
+
+/**
+ * Write device-local rows in ONE transaction. No outbox, by design (ADR 009 §2).
+ *
+ * The same durability contract as `commit` minus the sync intent: when this resolves the
+ * rows are on the device, and a game half-written across two transactions — a scoring
+ * event saved but its session left at the old round — is not a state this can produce.
+ */
+export async function commitLocal(
+  writes: readonly { store: LocalStore; row: StoredRow }[],
+): Promise<void> {
+  if (writes.length === 0) return;
+  const db = await getDb();
+  const stores = [...new Set(writes.map((w) => w.store))];
+  const tx = db.transaction(stores, "readwrite");
+  await Promise.all(writes.map((w) => tx.objectStore(w.store).put(w.row)));
+  await tx.done;
+}
+
+export async function allLocalRows(store: LocalStore): Promise<readonly StoredRow[]> {
+  const db = await getDb();
+  return db.getAll(store);
+}
+
+/** Remove one device-local row. Used for crew members and for discarding a draft game. */
+export async function deleteLocalRow(store: LocalStore, id: string): Promise<void> {
+  const db = await getDb();
+  await db.delete(store, id);
 }
 
 export async function rowsByIndex(

--- a/supabase/migrations/20260904130000_v2_de_ma_digest.sql
+++ b/supabase/migrations/20260904130000_v2_de_ma_digest.sql
@@ -10,7 +10,7 @@ values
    null, null, 15, 15, 14, null, 'total_length', null, null, true, 60),
   ('scup', null, 'de-tidal', 'salt', 'bag_limit', 'Scup: Season Open Year-Round. Size Limit 9 inch minimum (total length). Daily Limit / Person 30.', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=160', 'Delaware DNREC Fish Facts — Scup', '2026-01-01', '2026-09-04', 2,
    null, null, 30, 30, 9, null, 'total_length', null, null, true, 60),
-  ('bluefish', null, 'de-tidal', 'salt', 'bag_limit', 'Bluefish: Season Open Year Round. Size Limit No Size Limit. Daily Limit / Person 5 per shore or private boat anglers. 7 per anglers on for-hire vessels (Headboats and Charter boats).', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=100', 'Delaware DNREC Fish Facts — Bluefish', '2026-01-01', '2026-09-04', 2,
+  ('bluefish', null, 'de-tidal', 'salt', 'bag_limit', 'Bluefish: Season Open Year Round. Size Limit No Size Limit. Daily Limit / Person 5 per shore or private boat anglers. 7 per anglers on ''for-hire'' vessels (Headboats and Charter boats).', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=100', 'Delaware DNREC Fish Facts — Bluefish', '2026-01-01', '2026-09-04', 2,
    null, null, 5, 5, null, null, null, null, 'For-hire 7.', true, 60),
   ('weakfish', null, 'de-tidal', 'salt', 'bag_limit', 'Weakfish: Season Open Year-Round. Size Limit 13 inch minimum (total length). Daily Limit / Person 1.', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=192', 'Delaware DNREC Fish Facts — Weakfish', '2026-01-01', '2026-09-04', 2,
    null, null, 1, 1, 13, null, 'total_length', null, null, true, 60);


### PR DESCRIPTION
Phase 1 of the founder's Boat Games handoff: a game four anglers can play on one phone, with no accounts and no signal. Connected play, photos, verification and tournaments are deliberately out.

## What changed

- **One engine, three games.** `src/core/rules/games/` — a pure fold over an event log. Captain's Cup, Fish Cricket and Make the Cut are three `GameRules` values, not three scoring systems. The future modes in the spec are more of the same.
- **Guest catches are game events, never catch rows** (`ADR 009`). Four device-local IndexedDB stores at `DB_VERSION = 4`, outside the outbox. Only the host is offered "also add to my own log", and that path goes through the ordinary catch flow so the fish arrives with its trip, rig and regulation snapshot.
- **Screens.** `/games` home (unfinished games first), `/games/new` (mode → players → rules), `/games/play` live scoreboard, `/games/result`. Entry point on the Log screen. Fish Log Book's own tokens throughout — the DartCounter screenshots were a benchmark for clarity, not a visual reference.

## Why it's shaped this way

**The Passport reads every catch on the phone.** `usePassport` hands the whole catch store to species summaries, badges and slams, and nothing filters by `angler_id` — that column is written in four places and read in none. A guest's fish saved as a catch would silently have become a new species in the host's grid, progress on their badges and a leg of their slam. That forced the ownership model rather than being a preference; it's written up in `docs/architecture/decisions/009-boat-games-participant-ownership.md`.

**Game routes are `/games/play?id=` rather than `/games/[id]`.** A dynamic segment builds as `ƒ`, and ADR 005 §5 forbids a dynamic product route because it puts a network round trip in front of first paint. For most screens that's a slow load; here it's the feature failing at the only moment it matters. Game ids are minted on-device so they can never be listed in `generateStaticParams`. All four routes build `○`.

**Safeguards live in the engine, not the UI**, each with a named reason on the zero: protected species score nothing, a fish kept against a release verdict scores nothing and says why, an unresolved Quick Mark waits for its species, and a legal release scores exactly what keeping it would have. A region with no verified pack scores normally — unknown is not prohibited, and treating it as such would break the game everywhere we lack data.

## How it was checked

`npm run verify` green and `npm run build` clean. Driven in Chromium at 320px — all three modes, teams, undo, review, results, rematch — with no horizontal overflow on any screen and no console errors.

Three things checked against the database rather than the screen:

- After a guest logs a fish: **0** catch rows, **0** outbox mutations, 1 game event. The host opting in writes exactly 1 catch and the event carries its id; leaving the toggle off writes 0.
- A full game played with the network switched off, and resumed in a fresh tab after closing.
- **Five clicks dispatched in one synchronous task wrote five copies of the same fish** under a state-only guard, all sharing sequence number 1. That's the founder's "duplicate button taps" case, and ordinary Playwright clicking could not reproduce it — the browser spaces those far enough apart that React always re-renders between them. Fixed with a synchronous ref guard; the same test now writes one. The worst case wasn't the catch sheet but the close-the-day button, where two taps would have eliminated two anglers from a three-day tournament.

Two bugs came out of looking at real screens rather than tests: a day-2 board reading "1 fish · 1 species" beside a score of 0 (yesterday's fish, today's score), and a species picker that left twelve unrelated chips on screen pushing Save most of a screen down.

## Before you merge

**`main` is currently red, and it is not this branch.** `reg-data-parity` fails on `origin/main` at `8b273f6` on its own — verified on a clean worktree. The Delaware bluefish rule says `on 'for-hire' vessels` in the pack and `on for-hire vessels` in the migration, because the apostrophes were dropped rather than doubled for SQL. It's the fish-legal lane's file so I have not touched it; details and a one-line proposed patch are in `docs/team/channel/2026-09-04-01-head-dev-to-coo.md`. Everything else passes: 775 of 776.

Also worth someone owning separately: every existing detail route (`/catch/[id]`, `/trip/[id]`, `/spots/[id]`, both passport detail routes) is already dynamic, the same ADR 005 §5 violation this PR avoided. It predates this work.

## Not done

The founder's Phase 1 list is complete, but nobody has used this on a boat — four people passing a wet phone around while fish come over the rail is untested, and I'd expect the first real trip to change the catch-entry screen more than anything else here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SibpfrTGgxFEB99aUg7dVP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SibpfrTGgxFEB99aUg7dVP)_