### PR TITLE
Fix red main: escape the apostrophes in Delaware's bluefish verbatim

### DIFF
--- a/supabase/migrations/20260904130000_v2_de_ma_digest.sql
+++ b/supabase/migrations/20260904130000_v2_de_ma_digest.sql
@@ -10,7 +10,7 @@ values
    null, null, 15, 15, 14, null, 'total_length', null, null, true, 60),
   ('scup', null, 'de-tidal', 'salt', 'bag_limit', 'Scup: Season Open Year-Round. Size Limit 9 inch minimum (total length). Daily Limit / Person 30.', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=160', 'Delaware DNREC Fish Facts — Scup', '2026-01-01', '2026-09-04', 2,
    null, null, 30, 30, 9, null, 'total_length', null, null, true, 60),
-  ('bluefish', null, 'de-tidal', 'salt', 'bag_limit', 'Bluefish: Season Open Year Round. Size Limit No Size Limit. Daily Limit / Person 5 per shore or private boat anglers. 7 per anglers on for-hire vessels (Headboats and Charter boats).', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=100', 'Delaware DNREC Fish Facts — Bluefish', '2026-01-01', '2026-09-04', 2,
+  ('bluefish', null, 'de-tidal', 'salt', 'bag_limit', 'Bluefish: Season Open Year Round. Size Limit No Size Limit. Daily Limit / Person 5 per shore or private boat anglers. 7 per anglers on ''for-hire'' vessels (Headboats and Charter boats).', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=100', 'Delaware DNREC Fish Facts — Bluefish', '2026-01-01', '2026-09-04', 2,
    null, null, 5, 5, null, null, null, null, 'For-hire 7.', true, 60),
   ('weakfish', null, 'de-tidal', 'salt', 'bag_limit', 'Weakfish: Season Open Year-Round. Size Limit 13 inch minimum (total length). Daily Limit / Person 1.', 'https://fishspecies.dnrec.delaware.gov/FishSpecies.aspx?habitat=2&species=192', 'Delaware DNREC Fish Facts — Weakfish', '2026-01-01', '2026-09-04', 2,
    null, null, 1, 1, 13, null, 'total_length', null, null, true, 60);


### PR DESCRIPTION
One character class, two characters. `main` has been red since #60 merged.

## What was wrong

`reg-data-parity` fails on `de-bluefish` because the pack and its migration disagree. The DNREC source writes the phrase in quotes and the pack keeps it verbatim:

```
7 per anglers on 'for-hire' vessels
```

A single quote inside a SQL string literal has to be doubled. Here the quotes were **deleted** rather than escaped, so the migration reads `on for-hire vessels` and the two sentences no longer match.

The test was right to fail — a migration that doesn't say what the pack says is exactly the drift it exists to catch.

## The fix

Double them rather than drop them, which keeps the sentence faithful to the source. `reg-data-parity.test.ts:50` already normalises `''` back to `'` before comparing, so an escaped migration compares equal.

## Is it systemic?

No — I checked. Four other pack rules contain an apostrophe: Hawaii's `'Ama'ama`, `'O'io` and `'Ahi`, and Washington's `120'` fathom note. All four escaped correctly and are present in their migrations. This is a single slip, not a problem with how the SQL is being generated.

Worth noting separately: Hawaii and Washington aren't in the test's `LATER_BUNDLES` list, so those four are passing unchecked. Not changing that here — adding packs to the parity list could surface more failures and this PR should stay one line.

## How it was checked

Reproduced the failure on this exact base first, then confirmed green. `npm run verify` exits 0 — tripwires clean, 0 lint errors, tsc clean, 697 tests pass. `npm run build` clean.

## Why I touched another lane's file

The founder asked me to, explicitly. I'd flagged this from the Boat Games branch (#61) in `docs/team/channel/2026-09-04-01-head-dev-to-coo.md` with this patch proposed but not applied, since fish-legal isn't my lane. Kept it off the Boat Games branch so it stays one concern per PR and can merge on its own.

## Related, and the reason this went unnoticed

There is no CI in this repo — no `.github/workflows/`. The only PR check is Vercel, which runs `npm run build` and therefore never runs tests, lint, tripwires, or the type checker. #60 built fine, so it merged red. Happy to add a workflow that runs `npm run verify` on every PR as its own change if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SibpfrTGgxFEB99aUg7dVP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SibpfrTGgxFEB99aUg7dVP)_