### PR TITLE
Security: row-level security on the four regulation tables

### DIFF
--- a/docs/team/PRE-SHIP-CHECKLIST.md
+++ b/docs/team/PRE-SHIP-CHECKLIST.md
@@ -51,6 +51,17 @@ questions before the product ships. This file is what they should be handed.
       the same as migrations applied, and this is the check the privacy notice's "we do not
       share your log" claim rests on.
 
+      **Amended 2026-09-04.** That description was true of the angler-owned tables and
+      missed the reference ones. `reg_area`, `reg_group`, `reg_pack` and `reg_rule` were
+      created on 1 September, three days after the blanket
+      `revoke all on all tables in schema public from anon` ran — and that statement only
+      affects tables that exist when it runs. They had no RLS, no policy and no revoke.
+      Closed by `20260904220000_v1_regulations_rls.sql`, and
+      `src/core/rules/rls-coverage.test.ts` now fails if any future table is created
+      without them. **This makes the production check more urgent, not less:** if the
+      earlier migrations were applied and these four tables have been live and writable,
+      that wants looking at directly rather than assuming.
+
 - [ ] **Account deletion actually deletes.** The privacy notice commits to removal from the
       active database within 30 days on request. Confirm the auth cascade covers every
       angler-owned table, and that there is a path for someone to ask.

--- a/src/core/rules/rls-coverage.test.ts
+++ b/src/core/rules/rls-coverage.test.ts
@@ -1,0 +1,146 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Every table in the public schema has row-level security. No exceptions, forever.
+ *
+ * This exists because the rule was already broken once and nothing noticed for three
+ * days. `20260828120100_v1_rls.sql` covered every table that existed on 28 August and
+ * ended with `revoke all on all tables in schema public from anon` — a statement that
+ * only affects tables existing at the moment it runs. The regulation tables were created
+ * on 1 September and inherited none of it.
+ *
+ * That is not a mistake somebody makes through carelessness; it is a mistake the shape of
+ * the migration system invites, because the protection lives in one file and new tables
+ * arrive in others. `catch_gear` and `location_condition` remembered. `reg_rule` did not.
+ * The only durable fix is a test that reads the migrations and refuses to let the next one
+ * forget.
+ *
+ * Static analysis of SQL text, deliberately. Running these migrations against a real
+ * Postgres in CI would be a stronger check and is worth doing later; it is not a reason to
+ * ship nothing today, and this catches the exact class of omission that occurred.
+ */
+
+const migrationsDir = fileURLToPath(new URL("../../../supabase/migrations/", import.meta.url));
+
+const files = readdirSync(migrationsDir)
+  .filter((name) => name.endsWith(".sql"))
+  .sort();
+
+const sql = files.map((name) => readFileSync(migrationsDir + name, "utf8")).join("\n");
+
+/** Tables the migrations create, in the public schema. */
+function createdTables(text: string): readonly string[] {
+  const found = new Set<string>();
+  const re = /create\s+table\s+(?:if\s+not\s+exists\s+)?(?:public\.)?([a-z_][a-z0-9_]*)/gi;
+  for (const m of text.matchAll(re)) found.add(m[1].toLowerCase());
+  return [...found];
+}
+
+/**
+ * Tables RLS is switched on for — both spellings.
+ *
+ * The original migration turns it on inside `do $$ … foreach t in array array[…]` loops
+ * via `format()`, so a plain search for `alter table public.catch` finds nothing and would
+ * report seventeen false failures. Any `do` block that mentions RLS has its array literals
+ * harvested instead.
+ */
+function rlsEnabledTables(text: string): readonly string[] {
+  const found = new Set<string>();
+
+  for (const m of text.matchAll(
+    /alter\s+table\s+(?:public\.)?([a-z_][a-z0-9_]*)\s+enable\s+row\s+level\s+security/gi,
+  )) {
+    found.add(m[1].toLowerCase());
+  }
+
+  for (const block of text.matchAll(/do\s+\$\$([\s\S]*?)\$\$\s*;/gi)) {
+    const body = block[1];
+    if (!/enable\s+row\s+level\s+security/i.test(body)) continue;
+    for (const arr of body.matchAll(/array\s*\[([^\]]*)\]/gi)) {
+      for (const name of arr[1].matchAll(/'([a-z_][a-z0-9_]*)'/gi)) {
+        found.add(name[1].toLowerCase());
+      }
+    }
+  }
+
+  return [...found];
+}
+
+/**
+ * Tables whose write verbs are revoked, harvested the same two ways as RLS above.
+ *
+ * Needed because the revokes also live inside `format()` loops, so a per-table literal
+ * search finds nothing. An earlier version of this file asserted with a regex that had
+ * `|'table_name'` as an alternation — which matched the table's own CREATE statement and
+ * would have passed with every revoke deleted.
+ */
+function writeRevokedTables(text: string): readonly string[] {
+  const found = new Set<string>();
+
+  for (const m of text.matchAll(
+    /revoke\s+[^;]*?\bon\s+(?:public\.)?([a-z_][a-z0-9_]*)\s+from\s+[^;]*;/gi,
+  )) {
+    found.add(m[1].toLowerCase());
+  }
+
+  for (const block of text.matchAll(/do\s+\$\$([\s\S]*?)\$\$\s*;/gi)) {
+    const body = block[1];
+    if (!/revoke\s+[^']*(insert|update|delete|all)/i.test(body)) continue;
+    for (const arr of body.matchAll(/array\s*\[([^\]]*)\]/gi)) {
+      for (const name of arr[1].matchAll(/'([a-z_][a-z0-9_]*)'/gi)) {
+        found.add(name[1].toLowerCase());
+      }
+    }
+  }
+
+  return [...found];
+}
+
+describe("row-level security covers every table (ontology §6)", () => {
+  const created = createdTables(sql);
+  const protectedTables = new Set(rlsEnabledTables(sql));
+
+  it("finds the migrations, so a moved directory cannot make this suite vacuous", () => {
+    expect(files.length).toBeGreaterThan(5);
+    expect(created.length).toBeGreaterThan(15);
+  });
+
+  it("parses the tables that are protected inside do-blocks, not just literal statements", () => {
+    // `catch` is switched on through a format() loop. If the harvesting above regresses,
+    // this fails loudly rather than the suite quietly passing everything.
+    expect(protectedTables.has("catch")).toBe(true);
+    expect(protectedTables.has("species")).toBe(true);
+  });
+
+  it("has row-level security on every table it creates", () => {
+    const unprotected = created.filter((t) => !protectedTables.has(t)).sort();
+    expect(
+      unprotected,
+      `These tables are created by a migration but never get RLS. A table without it is ` +
+        `reachable through PostgREST with the anon key, which ships in every browser. Add ` +
+        `RLS in the migration that creates the table — the blanket revoke in the 28 August ` +
+        `migration does NOT cover tables created after it.`,
+    ).toEqual([]);
+  });
+
+  it("keeps the regulation tables locked to read-only", () => {
+    // Their content is what Fish Legal tells an angler the law is. Nobody writes it
+    // through the API; rows arrive by migration.
+    const revoked = new Set(writeRevokedTables(sql));
+    for (const table of ["reg_area", "reg_group", "reg_pack", "reg_rule"]) {
+      expect(protectedTables.has(table), `${table} has no RLS`).toBe(true);
+      expect(revoked.has(table), `${table} never has its write verbs revoked`).toBe(true);
+    }
+  });
+
+  it("revokes writes on every reference table, not only the regulation ones", () => {
+    // The vocabularies are the same kind of data and the same rule applies to them.
+    const revoked = new Set(writeRevokedTables(sql));
+    for (const table of ["species", "lure_class", "bait_type", "water_color"]) {
+      expect(revoked.has(table), `${table} never has its write verbs revoked`).toBe(true);
+    }
+  });
+});

--- a/supabase/migrations/20260904220000_v1_regulations_rls.sql
+++ b/supabase/migrations/20260904220000_v1_regulations_rls.sql
@@ -1,0 +1,44 @@
+-- =============================================================================
+-- Row-level security for the regulation tables
+--
+-- `20260828120100_v1_rls.sql` put RLS on every table that existed on 28 August and
+-- closed with `revoke all on all tables in schema public from anon`. The four
+-- regulation tables were created on 1 September, four days later, and that statement
+-- only ever affected tables that existed when it ran — there is no
+-- `alter default privileges ... for anon` in the public schema to catch later ones.
+-- So `reg_area`, `reg_group`, `reg_pack` and `reg_rule` have been the only tables in
+-- the schema with no RLS, no policy, and no revoke.
+--
+-- Reading them was never the risk: regulations are public law and the app ships them
+-- in the client bundle anyway. WRITING them is. The anon key is public by design (it
+-- is in every browser that loads the app), and a table with no RLS and no revoke is
+-- reachable through PostgREST with whatever the role's default grants allow. A stranger
+-- editing a bag limit or a size limit would be changing what Fish Legal tells an angler
+-- the law is — the one thing in this product that must not be wrong.
+--
+-- These are reference data with no `angler_id`, so they take the vocabulary pattern
+-- from the original migration rather than the angler-owned one: any signed-in angler
+-- may read, nobody may write through the API, rows arrive by migration.
+--
+-- Idempotent: safe whether or not it has already been applied, because the state of
+-- production is exactly what was unverified when this was written
+-- (docs/team/PRE-SHIP-CHECKLIST.md, "Confirm RLS is actually applied").
+-- =============================================================================
+
+do $$
+declare t text;
+begin
+  foreach t in array array['reg_area','reg_group','reg_pack','reg_rule']
+  loop
+    execute format('alter table public.%I enable row level security', t);
+
+    -- `if not exists` is not available for policies on every supported version, so
+    -- drop-then-create keeps this re-runnable without depending on it.
+    execute format('drop policy if exists %1$s_read on public.%1$s', t);
+    execute format(
+      'create policy %1$s_read on public.%1$s for select to authenticated using (true)', t);
+
+    execute format('revoke insert, update, delete on public.%I from authenticated, anon', t);
+    execute format('revoke all on public.%I from anon', t);
+  end loop;
+end $$;


### PR DESCRIPTION
`reg_area`, `reg_group`, `reg_pack` and `reg_rule` are the only tables in the public schema with **no RLS, no policy, and no revoke from `anon`**.

## How it happened

`20260828120100_v1_rls.sql` covers every table that existed on 28 August and closes with:

```sql
revoke all on all tables in schema public from anon;
```

That only affects tables existing at the moment it runs, and there's no `alter default privileges` for `anon` on the public schema to catch later ones. The regulation tables were created on **1 September**.

It wasn't a general lapse — `catch_gear`, `location_condition` and `trip_rig_gear` were all created after the cutoff and each carries its own revoke. The pattern was known and followed everywhere except here. Full audit:

| migration | tables | RLS | revoke |
|---|---|---|---|
| `…120000_v1_core_schema` | 18 tables | — | covered by the RLS migration 100s later |
| `…120000_v1_catch_gear` | `catch_gear` | ✅ | ✅ |
| `…180000_v1_rod_setups_and_locations` | `location_condition`, `trip_rig_gear` | ✅ | ✅ |
| `…230000_v1_regulations_socal_starter` | `reg_area`, `reg_group`, `reg_pack`, `reg_rule` | ❌ | ❌ |

## Why it matters

Reading these was never the risk — regulations are public law and ship in the client bundle anyway. **Writing** them is. The anon key is public by design (it's in every browser that loads the app), and a table with no RLS and no revoke is reachable through PostgREST with whatever the role's default grants allow. Someone editing a bag limit or a size limit would be changing what Fish Legal tells an angler the law is.

**What I can't tell you from here:** whether writes actually succeed against production. That needs credentials I don't have. What's certain is that the defence every other table has is absent on these four.

## The fix

They're reference data with no `angler_id`, so they take the vocabulary pattern from the original migration: any signed-in angler reads, nobody writes through the API, rows arrive by migration. Idempotent, because whether production has had the earlier migrations applied is exactly what the checklist says is unverified.

## The durable part

`src/core/rules/rls-coverage.test.ts` reads every migration and fails if a created table never gets RLS, or a reference table never gets its writes revoked. It parses the `format()` loops as well as literal statements — without that it would report seventeen false failures and be deleted within a week.

Confirmed it fails in **both** directions, because a test that can't fail is decoration:

- with the new migration removed → 2 tests fail, naming all four tables
- with the migration present but its revokes deleted → the revoke test fails

The second case matters: an earlier, sloppier assertion I wrote in this file had `|'table_name'` as a regex alternation, which matched the table's own `CREATE` statement and would have passed with every revoke gone.

## One thing to act on separately

I amended `PRE-SHIP-CHECKLIST.md`: this makes the "is RLS actually applied to production" item **more** urgent, not less. If the earlier migrations did run, these four tables have been live and writable, and that wants looking at directly rather than assumed.

## How it was checked

`npm run verify` exits 0 — tripwires clean, 0 lint errors, tsc clean, 781 tests. `npm run build` clean. The migration itself has not been run against a database; static analysis of the SQL is what this suite can do, and running migrations against a real Postgres in CI would be a stronger check worth adding later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SibpfrTGgxFEB99aUg7dVP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SibpfrTGgxFEB99aUg7dVP)_