### PR TITLE
CI: run npm run verify on every pull request

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,51 @@
+# Runs what a contributor runs before pushing, on every pull request.
+#
+# This exists because `main` sat red for three days and nothing said a word. The only
+# check on a PR was Vercel, which runs `next build` — a build passes happily while tests
+# fail, and that is exactly what happened: a migration and its TypeScript pack drifted
+# apart by two characters, the parity test caught it, and the PR merged anyway.
+#
+# `npm run verify` is deliberately the same command a person types locally
+# (docs/team/HOUSE-RULES.md §4), not a CI-only variant. A separate list here would drift
+# from the local one, and then "it passes on my machine" becomes true and useless.
+name: verify
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# A second push to the same PR makes the first run pointless. Cancel it rather than pay
+# for both — but never cancel a run on main, where the history of what passed matters.
+concurrency:
+  group: verify-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          # Matches the version the project is developed on. `npm cache` here needs the
+          # lockfile, which is committed.
+          node-version: '22'
+          cache: npm
+
+      # `npm ci` rather than `npm install`: it installs exactly the lockfile and fails if
+      # package.json and the lockfile disagree, which is itself worth catching.
+      - run: npm ci
+
+      # tokens:check, tripwires, lint, tsc, and the test suite — the whole gate.
+      - run: npm run verify
+
+      # The build is not part of `verify` and Vercel already runs it, but Vercel only
+      # builds the branches it is wired to. Running it here means a red build is caught
+      # on the PR by the same check as everything else.
+      - run: npm run build

--- a/docs/team/worklog/2026-09-04-12-head-dev.md
+++ b/docs/team/worklog/2026-09-04-12-head-dev.md
@@ -1,0 +1,44 @@
+### 2026-09-04 | head-dev | Two holes found while looking for what to do next
+
+Boat Games had just merged and I went looking for the next piece of work. Found two
+things that mattered more than anything on the list.
+
+- **Four database tables had no lock on them.** The regulation tables — the ones holding
+  bag limits and size limits — were the only tables in the whole database with no access
+  rules at all. Reading them was never a worry; that data is public law and the app ships
+  it anyway. Writing them was. The key the app uses is public by design, it sits in every
+  browser that loads the site, and a table with no rules is reachable with it. Someone
+  could have edited what Fish Legal tells an angler the law is.
+- **How it happened is worth understanding, because it will happen again otherwise.** The
+  original security migration locked every table that existed in August and finished with
+  a blanket "revoke everything from the public role". That statement only affects tables
+  that exist at the moment it runs. The regulation tables were created four days later and
+  inherited none of it. Three other tables created after the cutoff each remembered to
+  lock themselves — so this was not carelessness, it was a trap in the shape of the system,
+  where the protection lives in one file and new tables arrive in others.
+- **So the fix is a test, not just a migration.** The migration closes the hole. The test
+  reads every migration file and fails if any table is ever created without a lock, or if
+  a reference table ever loses its write protection. I broke it two different ways on
+  purpose to prove it fails — including one way that an earlier, sloppier version of my own
+  assertion would have passed, which is why I rewrote that assertion.
+- **What I could not check:** whether the missing rules ever mattered in production. That
+  needs database credentials I do not have. Amended the pre-ship checklist to say this
+  makes the "has security actually been switched on in production" question *more* urgent
+  rather than less — if those earlier migrations did run, those four tables have been open.
+- **The repo had no automated checking at all.** No CI. The only thing looking at a pull
+  request was the deployment service, which builds the app but never runs the tests. That
+  is exactly why `main` sat broken for three days earlier today: the test that catches the
+  problem existed, and nothing was running it. Added a workflow that runs the same command
+  a person runs before pushing — deliberately the same command, because a separate list
+  drifts and then "it works on my machine" becomes both true and useless.
+- Two pull requests, one concern each: #63 for the database locks, #64 for the checking.
+  #64 is its own proof — it runs on itself, so if it goes green the thing works.
+- Checks: verify exits 0 on both, 781 tests, build clean.
+- Files: `supabase/migrations/20260904220000_v1_regulations_rls.sql`,
+  `src/core/rules/rls-coverage.test.ts`, `docs/team/PRE-SHIP-CHECKLIST.md`,
+  `.github/workflows/verify.yml`.
+- **Next, and honestly:** the database question above is the one that needs a human with
+  production access, and it should not wait. After that, the pre-ship checklist still has
+  the tide data never being confirmed against the live service, and account deletion never
+  being tested against what the privacy notice promises. And Boat Games still has not been
+  used on a boat.


### PR DESCRIPTION
There is no CI in this repository. `.github/` doesn't exist.

The only check on a pull request is Vercel, which runs `next build` — and a build passes happily while tests fail. That isn't hypothetical: `main` went red when #60 merged, because a migration and its TypeScript pack had drifted apart by two characters. The parity test caught it. Nothing was running the parity test, so it merged, and it sat red for three days until I tripped over it.

## What this adds

One workflow running `npm run verify` on every PR and every push to `main` — the same command `HOUSE-RULES.md` §4 already defines as the bar, not a CI-specific list of steps. A separate list would drift from the local one, and then "it passes on my machine" becomes both true and useless.

That gate is: `tokens:check` → `tripwires` → `lint` → `tsc --noEmit` → `vitest run`.

It also runs `npm run build`, because Vercel only builds the branches it's wired to, and a red build should be caught by the same check as everything else.

## Details worth a sentence

- **`npm ci`, not `npm install`** — installs exactly the lockfile and fails if `package.json` and the lockfile disagree, which is itself worth catching.
- **Concurrency cancels superseded PR runs but never cancels on `main`**, where the record of what actually passed is the whole point.
- **`permissions: contents: read`** — it needs nothing else.
- **Node 22**, matching what the project is developed on. There's no `engines` field in `package.json`; adding one is a reasonable follow-up but not this PR.

## How it was checked

The YAML parses and resolves to the five expected steps. Beyond that, this PR is its own test: the workflow runs `on: pull_request`, so opening it triggers the first run. If that run is green, the thing works; if it's red, it has already earned its place.

I haven't verified GitHub Actions is enabled for the repo — if it is disabled at the org or repo level, no check will appear and that's a settings toggle rather than a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SibpfrTGgxFEB99aUg7dVP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SibpfrTGgxFEB99aUg7dVP)_