### PR TITLE
Make the Log screen's Boat Games entry actually visible

### DIFF
--- a/src/features/games/components/games-entry.tsx
+++ b/src/features/games/components/games-entry.tsx
@@ -14,8 +14,16 @@ import { CARD_CLASS } from "../ui-classes";
  *
  * Two shapes on purpose. With a game running it is an amber card that is hard to walk
  * past, because the likeliest reason this angler opened the app at all is that a game is
- * live and the phone went to sleep. With nothing running it is one quiet line — Boat
- * Games must not shout at somebody who only came to log a fish.
+ * live and the phone went to sleep. With nothing running it is a plain card — present,
+ * tappable, and not competing with the catch button.
+ *
+ * The resting state was a single line of muted text until 2026-09-04, on the reasoning
+ * that Boat Games must not shout at somebody who only came to log a fish. That was wrong
+ * in a way worth recording: sitting above the "Fish Log" heading with no border and no
+ * background, it read as a page subtitle rather than a destination, and the founder — who
+ * had just watched the feature being built — went looking for it twice and could not find
+ * it. Restraint is right; invisibility is not the same thing. A bordered card with the
+ * name on its own line is still quiet, and can actually be seen.
  */
 export function GamesEntry() {
   const games = useGames();
@@ -26,13 +34,22 @@ export function GamesEntry() {
 
   if (!active) {
     return (
-      <Link
-        href="/games"
-        className="flex min-h-touch-floor items-center justify-between gap-space-3 px-space-4 text-body text-text-link"
-      >
-        <span>Boat Games — play against the crew</span>
-        <span aria-hidden="true">→</span>
-      </Link>
+      <div className="px-space-4">
+        <Link
+          href="/games"
+          className={`${CARD_CLASS} flex min-h-touch-floor items-center justify-between gap-space-3 p-space-4`}
+        >
+          <span className="flex flex-col">
+            <span className="text-body-strong text-text-primary">Boat Games</span>
+            <span className="text-caption text-text-muted">
+              Play against the crew — no signal needed
+            </span>
+          </span>
+          <span aria-hidden="true" className="shrink-0 text-body text-signal-orange">
+            →
+          </span>
+        </Link>
+      </div>
     );
   }
 


### PR DESCRIPTION
The founder went looking for Boat Games twice after it merged and couldn't find it. That's the whole bug report, and it's a good one.

## What was wrong

The resting-state entry was a single line of muted text — no border, no background — sitting *above* the "Fish Log" heading. So it read as a page subtitle or a breadcrumb rather than a destination.

It was reachable the entire time. It just didn't look like anything.

I aimed for unobtrusive, on the reasoning that Boat Games shouldn't shout at someone who only opened the app to log a fish. That reasoning is still right; the execution overshot into invisible.

## What it is now

A bordered card: the name on its own line in primary text, the explanation beneath it in muted, an orange arrow. Still quiet, still not competing with `+ Log catch` — which stays above the fold at 320px, checked.

The amber running-game state is unchanged. That one was never hard to see.

The component's docstring now records why the quiet version failed, rather than repeating the reasoning that produced the bug.

## How it was checked

Chromium at 320px, before and after. `npm run verify` exits 0 — 781 tests, tripwires clean, 0 lint errors. `npm run build` clean.

## Still open, and it's the founder's call

They asked for the *navigation* link specifically. This PR doesn't add one — the nav is measured-full at six items and a seventh puts every phone on two rows, which was declined earlier for good reasons. This fix might be enough on its own. If it isn't, the nav decision is worth revisiting with the new evidence, and `shell-nav.test.ts` pins the count so that stays a deliberate decision rather than a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SibpfrTGgxFEB99aUg7dVP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SibpfrTGgxFEB99aUg7dVP)_