### PR TITLE
Navigation drawer: every screen reachable from every screen

### DIFF
--- a/src/features/shell/components/nav-drawer.tsx
+++ b/src/features/shell/components/nav-drawer.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+
+import { destinationGroups } from "../destinations";
+
+/**
+ * "Everything" — the drawer that makes the whole app reachable from any screen.
+ *
+ * A native `<dialog>` opened with `showModal()`, deliberately. It gives Escape-to-close,
+ * a focus trap, inertness of the page behind it, and a backdrop, all correct, for free —
+ * every one of which is a thing a hand-rolled panel gets subtly wrong and nobody notices
+ * until somebody navigates with a keyboard or a screen reader.
+ *
+ * It slides from the left because that is where the button is and where a drawer is
+ * expected. The trigger sits in the header rather than the bottom bar: the bar is full at
+ * six and this is a find-something action rather than a do-something one — occasional,
+ * often two-handed, and not competing for the thumb's home position with "Log catch".
+ *
+ * Every item is a full-width row with the name on one line and a plain sentence beneath,
+ * because the persona this app is designed for (docs/design/README.md) should not have to
+ * infer what "Passport" means from the word alone.
+ */
+export function NavDrawer() {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (open && !dialog.open) dialog.showModal();
+    if (!open && dialog.open) dialog.close();
+  }, [open]);
+
+  const groups = destinationGroups();
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className="flex min-h-touch-floor items-center gap-space-2 rounded-md px-space-2 text-label text-text-link transition-colors hover:bg-surface-raised focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring active:scale-95 motion-reduce:transition-none"
+      >
+        {/* Icon and word together. Design 01 §1.3: a symbol is never the only signal. */}
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 20 20"
+          className="size-space-5"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+        >
+          <path d="M3 5h14M3 10h14M3 15h14" />
+        </svg>
+        Menu
+      </button>
+
+      <dialog
+        ref={dialogRef}
+        aria-label="Everywhere you can go"
+        onClose={() => setOpen(false)}
+        /*
+          `onClick` on the dialog itself catches the backdrop: a click whose target IS the
+          dialog element (rather than anything inside it) happened on the ::backdrop.
+        */
+        onClick={(event) => {
+          if (event.target === dialogRef.current) setOpen(false);
+        }}
+        className="m-0 h-dvh max-h-dvh w-[min(20rem,85vw)] max-w-none border-r border-hairline bg-background p-0 text-text-primary backdrop:bg-background/70"
+      >
+        <div className="flex h-full flex-col">
+          <div className="flex items-center justify-between border-b border-hairline px-space-4 py-space-3">
+            <h2 className="text-h3 text-text-primary">Go to</h2>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              className="flex min-h-touch-floor items-center rounded-md px-space-3 text-label text-text-link transition-colors hover:bg-surface-raised focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring"
+            >
+              Close
+            </button>
+          </div>
+
+          <nav aria-label="All destinations" className="flex-1 overflow-y-auto px-space-3 py-space-3">
+            {groups.map((group) => (
+              <section key={group.heading} className="mb-space-5 last:mb-0">
+                <h3 className="px-space-2 pb-space-2 text-caption text-text-muted">
+                  {group.heading}
+                </h3>
+                <ul className="flex flex-col gap-space-1">
+                  {group.items.map((item) => {
+                    const active =
+                      item.href === "/" ? pathname === "/" : pathname.startsWith(item.href);
+                    return (
+                      <li key={item.href}>
+                        <Link
+                          href={item.href}
+                          aria-current={active ? "page" : undefined}
+                          /*
+                            Closing happens here rather than in an effect on `pathname`.
+                            That effect was the obvious way to write it and it tripped
+                            react-hooks/set-state-in-effect — correctly: setting state
+                            synchronously in an effect body is a cascading render, and
+                            with the React Compiler on it is the shape that behaves
+                            differently from what the code appears to say. Tapping a link
+                            IS the event; there is no need to observe its consequence.
+                          */
+                          onClick={() => setOpen(false)}
+                          className={`flex min-h-touch-floor flex-col justify-center rounded-md border-l-2 px-space-3 py-space-2 transition-colors hover:bg-surface focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring ${
+                            active
+                              ? "border-signal-orange bg-surface"
+                              : "border-transparent"
+                          }`}
+                        >
+                          <span className="text-body-strong text-text-primary">{item.label}</span>
+                          <span className="text-caption text-text-muted">{item.blurb}</span>
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </section>
+            ))}
+          </nav>
+        </div>
+      </dialog>
+    </>
+  );
+}

--- a/src/features/shell/components/shell-frame.tsx
+++ b/src/features/shell/components/shell-frame.tsx
@@ -4,6 +4,7 @@ import { usePathname } from "next/navigation";
 
 import { useQuickMarkEnabled } from "@/features/settings/shortcuts";
 import { BackupBadge } from "./backup-badge";
+import { NavDrawer } from "./nav-drawer";
 import { QuickMarkAction } from "./quick-mark-action";
 import { ShellNav } from "./shell-nav";
 
@@ -16,8 +17,11 @@ import { ShellNav } from "./shell-nav";
  * shortcuts (default off) and, when on, renders bottom-right above the nav where the
  * thumb already is. See `quick-mark-action.tsx` for why there rather than anywhere else.
  *
- * With it gone the header carries only the backup badge, so it collapses to a single
- * quiet status line rather than leaving a hole where the button was.
+ * The header carries the backup badge and, since 2026-09-04, the Menu button that opens
+ * the navigation drawer. Six bottom-bar slots could never hold fourteen destinations, and
+ * the overflow had been landing inside other screens — the Passport behind Settings, Boat
+ * Games behind the Fish Log — which is why the founder could not find his own feature the
+ * day after it shipped. The drawer is the answer; the bar is unchanged.
  *
  * **One route is immersive.** The tide screen is a single-screen instrument — the brief
  * for it is explicit that nothing else may consume its vertical room and that the page
@@ -52,7 +56,13 @@ export function ShellFrame({ children }: { children: React.ReactNode }) {
 
   return (
     <div className="flex min-h-dvh flex-col">
-      <header className="flex items-center border-b border-hairline px-4 py-3">
+      {/*
+        The header carries the way into everything (`nav-drawer.tsx`) on the left and the
+        backup status on the right. The bottom bar stays at six for the everyday
+        destinations; the drawer is how the other eight stop being a treasure hunt.
+      */}
+      <header className="flex items-center justify-between gap-space-3 border-b border-hairline px-4 py-2">
+        <NavDrawer />
         <BackupBadge />
       </header>
 

--- a/src/features/shell/destinations.test.ts
+++ b/src/features/shell/destinations.test.ts
@@ -1,0 +1,123 @@
+import { existsSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { allDestinations, destinationGroups } from "./destinations";
+
+/**
+ * Nothing in this app is reachable only by knowing where it is.
+ *
+ * The failure this prevents already happened: Boat Games shipped, and the day after, the
+ * person who commissioned it went looking twice and could not find it. It had a link — on
+ * the Fish Log, a screen he opens daily — and that still was not enough, because the six
+ * bottom-bar slots were full and everything past six had been quietly filed inside
+ * whatever screen seemed related. The Passport lived behind Settings. So did the Tackle
+ * Box. Fish ID was linked from nowhere at all.
+ *
+ * Every one of those was a defensible local decision. Together they made a product you
+ * have to already know your way around. So this test treats findability as a property of
+ * the routing table rather than a thing everyone remembers: add a top-level route and you
+ * either put it in the drawer or you say here, in writing, why it is not a destination.
+ */
+
+const appDir = fileURLToPath(new URL("../../app/", import.meta.url));
+
+/**
+ * Routes that exist but are deliberately not places you "go" — they are things you open
+ * from somewhere else, and a drawer entry for them would be noise.
+ *
+ * Every entry needs a reason. "It felt cluttered" is not one; if a real feature ends up
+ * here, that is the bug this file exists to catch.
+ */
+const NOT_DESTINATIONS: Readonly<Record<string, string>> = {
+  catch: "One catch, opened from the Fish Log or the Calendar. Has no meaning without an id.",
+  day: "One calendar day, opened from the Calendar.",
+  trip: "One trip, opened from the Calendar or the Fish Log.",
+  spots:
+    "Unfinished. shell-nav.test.ts already pins that it must not be advertised; when it " +
+    "ships, it belongs in the drawer and this line should be deleted.",
+};
+
+/** Top-level route segments, from both the (app) group and the routes outside it. */
+function routeSegments(): readonly string[] {
+  const found = new Set<string>();
+  for (const dir of [`${appDir}(app)/`, appDir]) {
+    if (!existsSync(dir)) continue;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      // Route groups `(app)`, private folders `_x`, and dynamic segments are not
+      // top-level destinations in their own right.
+      if (/^[([_]/.test(entry.name)) continue;
+      if (!existsSync(`${dir}${entry.name}/page.tsx`)) continue;
+      found.add(entry.name);
+    }
+  }
+  return [...found].sort();
+}
+
+describe("every destination is findable from anywhere", () => {
+  const segments = routeSegments();
+  const hrefs = new Set(allDestinations().map((d) => d.href));
+
+  it("finds the route directories, so a moved app dir cannot make this vacuous", () => {
+    expect(segments.length).toBeGreaterThan(8);
+    expect(segments).toContain("log");
+  });
+
+  it("lists every top-level route in the drawer, or names why it is not a destination", () => {
+    const missing = segments.filter(
+      (segment) => !hrefs.has(`/${segment}`) && !(segment in NOT_DESTINATIONS),
+    );
+    expect(
+      missing,
+      `These routes exist but cannot be reached from the navigation drawer. Add them to ` +
+        `destinations.ts, or add them to NOT_DESTINATIONS with a reason. A feature nobody ` +
+        `can find is a feature nobody built.`,
+    ).toEqual([]);
+  });
+
+  it("includes the Calendar, which has no directory of its own", () => {
+    expect(hrefs.has("/")).toBe(true);
+  });
+
+  it("points only at routes that exist", () => {
+    for (const destination of allDestinations()) {
+      if (destination.href === "/") continue;
+      const segment = destination.href.replace(/^\//, "");
+      expect(
+        segments,
+        `${destination.href} is in the drawer but has no page`,
+      ).toContain(segment);
+    }
+  });
+
+  it("names the things that were previously buried", () => {
+    // The three that prompted this work. If any is dropped, that is a regression.
+    for (const href of ["/games", "/passport", "/tackle"]) {
+      expect(hrefs.has(href), `${href} is not in the drawer`).toBe(true);
+    }
+  });
+});
+
+describe("the drawer reads like something a person wrote", () => {
+  it("gives every destination a label and a plain-language line", () => {
+    for (const destination of allDestinations()) {
+      expect(destination.label.length).toBeGreaterThan(2);
+      expect(destination.blurb.length).toBeGreaterThan(10);
+      // A blurb that just repeats the label teaches nothing.
+      expect(destination.blurb.toLowerCase()).not.toBe(destination.label.toLowerCase());
+    }
+  });
+
+  it("has no duplicate destinations", () => {
+    const hrefs = allDestinations().map((d) => d.href);
+    expect(new Set(hrefs).size).toBe(hrefs.length);
+  });
+
+  it("renders no empty group when a feature flag is off", () => {
+    for (const group of destinationGroups()) {
+      expect(group.items.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/features/shell/destinations.ts
+++ b/src/features/shell/destinations.ts
@@ -1,0 +1,106 @@
+import { BOAT_GAMES_V1 } from "@/features/games/flag";
+import { PASSPORT_V1 } from "@/features/passport/flag";
+import { FIN_ID } from "@/features/wildlife/flag";
+
+/**
+ * Every place in the app you can go, in one list.
+ *
+ * The bottom bar holds six destinations and cannot hold more — six labels already wrap to
+ * two rows below 384px, and `shell-nav.tsx` records the measurement. So everything else
+ * has been reachable only from inside another screen: the Passport and the Tackle Box
+ * from Settings, Boat Games from the Fish Log, Fish ID from nowhere at all.
+ *
+ * That worked as an argument and failed as a product. The founder went looking for Boat
+ * Games the day after it shipped, twice, and could not find it — and Boat Games at least
+ * had a link on a screen he visits daily. "It is in Settings" is not findability; it is a
+ * treasure hunt with a map only the person who hid it can read.
+ *
+ * This list is the map. The drawer renders it, and `destinations.test.ts` fails if a new
+ * top-level route appears without either being added here or being named in the test's
+ * exclusion list with a reason. A feature nobody can find is a feature nobody built.
+ *
+ * Pure data, no React, so the test can read it without a DOM.
+ */
+
+export interface Destination {
+  readonly href: string;
+  readonly label: string;
+  /** One line, plain. What an angler would call the thing, not what the code calls it. */
+  readonly blurb: string;
+}
+
+export interface DestinationGroup {
+  readonly heading: string;
+  readonly items: readonly Destination[];
+}
+
+/**
+ * Grouped by when in a trip you want them, not by how the code is organised.
+ *
+ * Order inside each group is by how often it gets opened, so the common thing is nearest
+ * the top of a scrolling panel rather than alphabetised into the middle.
+ */
+export function destinationGroups(): readonly DestinationGroup[] {
+  const groups: DestinationGroup[] = [
+    {
+      heading: "Your fishing",
+      items: [
+        { href: "/", label: "Calendar", blurb: "Your days on the water, and what you caught" },
+        { href: "/log", label: "Fish Log", blurb: "Every catch, searchable" },
+        ...(PASSPORT_V1
+          ? [
+              {
+                href: "/passport",
+                label: "Fish Passport",
+                blurb: "Species you have caught, personal bests, and slams",
+              },
+            ]
+          : []),
+      ],
+    },
+    {
+      heading: "On the water",
+      items: [
+        { href: "/tides", label: "Tide", blurb: "Today's tide, and the days ahead" },
+        { href: "/fish-legal", label: "Fish Legal", blurb: "Size and bag limits where you are" },
+        ...(BOAT_GAMES_V1
+          ? [
+              {
+                href: "/games",
+                label: "Boat Games",
+                blurb: "Friendly competition with the crew, no signal needed",
+              },
+            ]
+          : []),
+        ...(FIN_ID
+          ? [
+              { href: "/fish-id", label: "Fish ID", blurb: "Work out what you just caught" },
+              { href: "/fin-id", label: "Whale & dolphin ID", blurb: "What that fin belonged to" },
+            ]
+          : []),
+      ],
+    },
+    {
+      heading: "Your gear",
+      items: [
+        { href: "/setup", label: "Setup", blurb: "Rods, region, and the day's conditions" },
+        { href: "/tackle", label: "Tackle Box", blurb: "The lures and baits you actually use" },
+      ],
+    },
+    {
+      heading: "The app",
+      items: [
+        { href: "/settings", label: "Settings", blurb: "Units, region, shortcuts, and your account" },
+        { href: "/legal", label: "Notices", blurb: "Privacy, terms, and how your data is handled" },
+      ],
+    },
+  ];
+
+  // A group whose every item is behind an off flag would render as an empty heading.
+  return groups.filter((group) => group.items.length > 0);
+}
+
+/** Flat, for the test and for anything that needs to ask "is this reachable?". */
+export function allDestinations(): readonly Destination[] {
+  return destinationGroups().flatMap((group) => group.items);
+}


### PR DESCRIPTION
The founder couldn't find Boat Games the day after it shipped. He looked twice. It had a link on the Fish Log — a screen he opens daily — and that still wasn't enough.

## The cause is bigger than Boat Games

The bottom bar holds six and can't hold more (six labels already wrap to two rows below 384px; `shell-nav.tsx` has the measurement). So everything past six got filed inside whatever screen seemed related:

| Destination | How you reach it today |
|---|---|
| Fish Passport | Settings |
| Tackle Box | Settings |
| Notices | Settings |
| Boat Games | Fish Log |
| Fish ID | nowhere at all |
| Whale & dolphin ID | a link inside Fish ID |

Every one of those was a defensible local decision. Together they made a product you have to already know your way around. "It's in Settings" isn't findability — it's a treasure hunt with a map only the person who hid it can read.

## What this adds

A **Menu** button in the header, opening a drawer listing all twelve destinations, grouped by when in a trip you want them, each with a plain sentence under the name — because "Passport" tells a first-time angler nothing.

**The bottom bar is untouched.** Muscle memory for the everyday six is worth keeping, and this is a find-something action, not a do-something one — occasional, often two-handed, not competing for the thumb's home position with "Log catch". `shell-nav.test.ts` still passes unchanged.

Native `<dialog>` with `showModal()`, deliberately: Escape, focus trapping, page inertness and a backdrop, all correct, for free. Every one of those is a thing a hand-rolled panel gets subtly wrong and nobody notices until someone navigates with a keyboard.

## The durable part

`destinations.test.ts` reads the route directories and fails if a top-level route is neither in the drawer nor named in an exclusion list **with a written reason**. Findability becomes a property of the routing table rather than something everyone has to remember. Confirmed it fails by removing Boat Games from the list.

The exclusions today are `catch`, `day`, `trip` (details opened from a list, meaningless without an id) and `spots` (unfinished — `shell-nav.test.ts` already pins that it must not be advertised, and the reason says to delete that line when it ships).

## Two things worth recording

- Closing on navigation started as an effect on `pathname` and tripped `react-hooks/set-state-in-effect` — correctly. Tapping a link *is* the event, so it closes in the click handler and observes nothing.
- My first browser check reported **Escape as broken when it was working perfectly**. The assertion matched the Log screen's own Boat Games link rather than the drawer's. The script is now scoped to the dialog. Worth flagging because a wrong assertion that reports failure is the lucky case; the same mistake pointing the other way passes silently.

## How it was checked

Chromium at 320px, fifteen assertions: every destination present, no horizontal overflow with the drawer open, Escape and backdrop both closing it, tapping through to Boat Games, and the Menu button present on screens other than the Log. `npm run verify` exits 0 — 789 tests, tripwires clean, 0 lint errors. `npm run build` clean.

## Known gap

`/tides` is immersive and has no header, so no Menu button there. The bottom bar still works from it. Redesigning the tide screen was explicitly out of scope per the shell's own docstring, so I left it and am saying so rather than letting you find it.

## Relationship to #65

Independent — different files, either order. #65 makes the Log screen's own Boat Games entry a visible card; this makes everything reachable from everywhere. #65 is the small fix, this is the actual answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SibpfrTGgxFEB99aUg7dVP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SibpfrTGgxFEB99aUg7dVP)_