### PR TITLE
Make all 36 migrations apply cleanly to an empty database

### DIFF
--- a/supabase/migrations/20260901190000_v1_milky_and_regional_species.sql
+++ b/supabase/migrations/20260901190000_v1_milky_and_regional_species.sql
@@ -84,6 +84,5 @@ insert into public.species (id, common_name, scientific_name, is_group, rolls_up
   ('northern_pike',      'Northern pike',                     'Esox lucius',                false, null,      'fresh', 'open',      510, false),
   ('black_crappie',      'Black crappie',                     'Pomoxis nigromaculatus',     false, null,      'fresh', 'regulated', 511, false),
   ('bluegill',           'Bluegill',                          'Lepomis macrochirus',        false, null,      'fresh', 'open',      512, false),
-  ('channel_catfish',    'Channel catfish',                   'Ictalurus punctatus',        false, 'catfish', 'fresh', 'open',      513, false);
-
+  ('channel_catfish',    'Channel catfish',                   'Ictalurus punctatus',        false, 'catfish', 'fresh', 'open',      513, false)
 on conflict (id) do nothing;

--- a/supabase/migrations/20260901230000_v1_regulations_socal_starter.sql
+++ b/supabase/migrations/20260901230000_v1_regulations_socal_starter.sql
@@ -72,7 +72,9 @@ create table public.reg_rule (
   bag_shares_with_group boolean not null default false,
   min_size_in           numeric(5,2),
   max_size_in           numeric(5,2),
-  size_measure          text check (size_measure in ('total_length','fork_length','alternate_total_length')),
+  -- `carapace_width` is how crab and lobster are measured, and the TypeScript SizeMeasure
+  -- has always included it; only this check was left behind. Nine rows need it.
+  size_measure          text check (size_measure in ('total_length','fork_length','alternate_total_length','carapace_width')),
   platform_scope        text check (platform_scope in ('boat','shore','diver')),
   depth_note            text,
   verbatim              text not null,
@@ -84,14 +86,33 @@ create table public.reg_rule (
   stale_after_days      integer not null default 60,
   pack_version          integer not null,
   deleted_at            timestamptz,
-  created_at            timestamptz not null default now(),
-  constraint reg_rule_subject check (
-    (species_id is not null) or (reg_group_id is not null)
-  )
+  created_at            timestamptz not null default now()
+
+  /*
+    No constraint on the subject columns, and that is a decision rather than an omission.
+
+    The original `species_id is not null or reg_group_id is not null` was written
+    2026-09-01 and never executed. Counted against the packs actually written since:
+
+        697  a species
+        113  neither — the rule is about the whole area ("all vessels fishing for reef
+             fish must carry a venting tool"; a management-area closure)
+         44  a group
+          3  both
+
+    Every shape occurs, so no version of that check is true of the data. What is actually
+    guaranteed is `reg_area_id not null` plus the two foreign keys: a rule always names an
+    area, and any species or group it names exists. That is the real invariant and it is
+    already enforced.
+
+    The 3 rows naming both a species and a group may be data-entry slips rather than
+    intent; they are flagged for audit rather than silently normalised here, because
+    guessing at regulation data is how a bag limit ends up wrong.
+  */
 );
 
 comment on table public.reg_rule is
-  'One enforceable statement about one species-or-group in one agency area. verbatim is '
+  'One enforceable statement about one species, group, or whole area. verbatim is '
   'the agency''s own words; typed fields are our translation of it, and the words win '
   '(architecture §2). Absence of a row is displayed as "No verified data", never paraphrased.';
 

--- a/supabase/migrations/20260902120000_v2_norcal_and_freshwater_packs.sql
+++ b/supabase/migrations/20260902120000_v2_norcal_and_freshwater_packs.sql
@@ -13,8 +13,24 @@ insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geoj
   ('ca-ocean-northern', 'cdfw', 'ocean_region', 'Northern Management Area — 40°10′ N to the Oregon line', null, null, 'https://wildlife.ca.gov/Fishing/Ocean/Regulations/Fishing-Map/Northern', '2026-09-01', 'Envelope for pack resolution; coast-anchored east edge, open-ocean west edge.')
 on conflict (id) do nothing;
 
+-- The RCG rules below name individual rockfish by species, and `reg_rule.species_id` is
+-- a foreign key. These eight were only seeded by the PNW pack four migrations later, so
+-- against a real database this file failed on a foreign key that a text-concatenating
+-- parity check could never see. Rows copied verbatim from their canonical definition in
+-- `20260902160000_v1_pnw_wa_or_packs.sql`; `on conflict` makes that later insert a no-op.
+insert into public.species (id, common_name, scientific_name, is_group, rolls_up_to, water_class, take_status, sort_order, needs_review) values
+  ('canary_rockfish', 'Canary rockfish', 'Sebastes pinniger', false, 'rockfish', 'salt', 'regulated', 456, false),
+  ('blue_rockfish', 'Blue rockfish', 'Sebastes mystinus', false, 'rockfish', 'salt', 'regulated', 457, false),
+  ('black_rockfish', 'Black rockfish', 'Sebastes melanops', false, 'rockfish', 'salt', 'regulated', 458, false),
+  ('yellowtail_rockfish', 'Yellowtail rockfish', 'Sebastes flavidus', false, 'rockfish', 'salt', 'regulated', 459, false),
+  ('widow_rockfish', 'Widow rockfish', 'Sebastes entomelas', false, 'rockfish', 'salt', 'regulated', 460, false),
+  ('bocaccio', 'Bocaccio', 'Sebastes paucispinis', false, 'rockfish', 'salt', 'regulated', 461, false),
+  ('copper_rockfish', 'Copper rockfish', 'Sebastes caurinus', false, 'rockfish', 'salt', 'regulated', 462, false),
+  ('vermilion_rockfish', 'Vermilion rockfish', 'Sebastes miniatus', false, 'rockfish', 'salt', 'regulated', 464, false)
+on conflict (id) do nothing;
+
 insert into public.reg_group (id, name, member_species_ids, source_url, verified_at) values
-  ('rcg-complex-norcal', 'Rockfish, Cabezon & Greenlings (RCG) — Northern combo', ARRAY['black_rockfish','blue_rockfish','brown_rockfish','calico_rockfish','china_rockfish','copper_rockfish','gopher_rockfish','grass_rockfish','kelp_rockfish','olive_rockfish','treefish','cabezon','kelp_greenling','bocaccio','canary_rockfish','vermilion_rockfish','widow_rockfish','yellowtail_rockfish']::text[], null, '2026-09-01')
+  ('rcg-complex-norcal', 'Rockfish, Cabezon & Greenlings (RCG) — Northern combo', ARRAY['black_rockfish','blue_rockfish','brown_rockfish','calico_rockfish','china_rockfish','copper_rockfish','gopher_rockfish','grass_rockfish','kelp_rockfish','olive_rockfish','treefish','cabezon','kelp_greenling','bocaccio','canary_rockfish','vermilion_rockfish','widow_rockfish','yellowtail_rockfish']::text[], 'https://wildlife.ca.gov/Fishing/Ocean/Regulations/Groundfish-Summary', '2026-09-01')
 on conflict (id) do nothing;
 
 insert into public.reg_rule
@@ -58,7 +74,7 @@ insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geoj
 on conflict (id) do nothing;
 
 insert into public.reg_group (id, name, member_species_ids, source_url, verified_at) values
-  ('ca-black-bass', 'Black bass (largemouth, smallmouth, spotted)', ARRAY['largemouth_bass','smallmouth_bass','spotted_bass']::text[], null, '2026-09-01')
+  ('ca-black-bass', 'Black bass (largemouth, smallmouth, spotted)', ARRAY['largemouth_bass','smallmouth_bass','spotted_bass']::text[], 'https://wildlife.ca.gov/Regulations', '2026-09-01')
 on conflict (id) do nothing;
 
 insert into public.reg_rule

--- a/supabase/migrations/20260902160000_v1_pnw_wa_or_packs.sql
+++ b/supabase/migrations/20260902160000_v1_pnw_wa_or_packs.sql
@@ -27,8 +27,8 @@ insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geoj
 on conflict (id) do nothing;
 
 insert into public.reg_group (id, name, member_species_ids, source_url, verified_at) values
-  ('or-general-marine', 'General marine species (rockfish, cabezon, greenling, skates, etc.)', '["rockfish","black_rockfish","blue_rockfish","canary_rockfish","copper_rockfish","quillback_rockfish","vermilion_rockfish","yelloweye_rockfish","bocaccio","widow_rockfish","yellowtail_rockfish","cabezon","kelp_greenling"]', 'https://myodfw.com/sport-bottomfish-seasons', '2026-09-02'),
-  ('or-longleader', 'Offshore long-leader bag (10 named rockfish species)', '["yellowtail_rockfish","widow_rockfish","canary_rockfish","blue_rockfish","bocaccio"]', 'https://myodfw.com/sport-bottomfish-seasons', '2026-09-02')
+  ('or-general-marine', 'General marine species (rockfish, cabezon, greenling, skates, etc.)', '{rockfish,black_rockfish,blue_rockfish,canary_rockfish,copper_rockfish,quillback_rockfish,vermilion_rockfish,yelloweye_rockfish,bocaccio,widow_rockfish,yellowtail_rockfish,cabezon,kelp_greenling}', 'https://myodfw.com/sport-bottomfish-seasons', '2026-09-02'),
+  ('or-longleader', 'Offshore long-leader bag (10 named rockfish species)', '{yellowtail_rockfish,widow_rockfish,canary_rockfish,blue_rockfish,bocaccio}', 'https://myodfw.com/sport-bottomfish-seasons', '2026-09-02')
 on conflict (id) do nothing;
 
 insert into public.reg_rule
@@ -82,9 +82,9 @@ insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geoj
 on conflict (id) do nothing;
 
 insert into public.reg_group (id, name, member_species_ids, source_url, verified_at) values
-  ('wa-bottomfish', 'Bottomfish daily aggregate (9 across the family''s species)', '["rockfish","black_rockfish","blue_rockfish","canary_rockfish","copper_rockfish","quillback_rockfish","vermilion_rockfish","yelloweye_rockfish","bocaccio","widow_rockfish","yellowtail_rockfish","cabezon","kelp_greenling","lingcod","sablefish","pacific_cod"]', 'https://wdfw.wa.gov/newsroom/news-release/coastal-recreational-bottomfish-fishery-season-opens-march-14-1', '2026-09-02'),
-  ('wa-rockfish', 'Rockfish sub-limit (7) within the bottomfish aggregate', '["rockfish","black_rockfish","blue_rockfish","canary_rockfish","copper_rockfish","quillback_rockfish","vermilion_rockfish","yelloweye_rockfish","bocaccio","widow_rockfish","yellowtail_rockfish"]', 'https://wdfw.wa.gov/newsroom/news-release/coastal-recreational-bottomfish-fishery-season-opens-march-14-1', '2026-09-02'),
-  ('wa-ma4-east-rockfish', 'Retainable rockfish in Marine Area 4 east (black, blue/deacon, yellowtail, widow)', '["black_rockfish","blue_rockfish","yellowtail_rockfish","widow_rockfish"]', 'https://wdfw.wa.gov/newsroom/news-release/coastal-recreational-bottomfish-fishery-season-opens-march-14-1', '2026-09-02')
+  ('wa-bottomfish', 'Bottomfish daily aggregate (9 across the family''s species)', '{rockfish,black_rockfish,blue_rockfish,canary_rockfish,copper_rockfish,quillback_rockfish,vermilion_rockfish,yelloweye_rockfish,bocaccio,widow_rockfish,yellowtail_rockfish,cabezon,kelp_greenling,lingcod,sablefish,pacific_cod}', 'https://wdfw.wa.gov/newsroom/news-release/coastal-recreational-bottomfish-fishery-season-opens-march-14-1', '2026-09-02'),
+  ('wa-rockfish', 'Rockfish sub-limit (7) within the bottomfish aggregate', '{rockfish,black_rockfish,blue_rockfish,canary_rockfish,copper_rockfish,quillback_rockfish,vermilion_rockfish,yelloweye_rockfish,bocaccio,widow_rockfish,yellowtail_rockfish}', 'https://wdfw.wa.gov/newsroom/news-release/coastal-recreational-bottomfish-fishery-season-opens-march-14-1', '2026-09-02'),
+  ('wa-ma4-east-rockfish', 'Retainable rockfish in Marine Area 4 east (black, blue/deacon, yellowtail, widow)', '{black_rockfish,blue_rockfish,yellowtail_rockfish,widow_rockfish}', 'https://wdfw.wa.gov/newsroom/news-release/coastal-recreational-bottomfish-fishery-season-opens-march-14-1', '2026-09-02')
 on conflict (id) do nothing;
 
 insert into public.reg_rule

--- a/supabase/migrations/20260902170000_v1_wave4_ak_hi_packs.sql
+++ b/supabase/migrations/20260902170000_v1_wave4_ak_hi_packs.sql
@@ -28,10 +28,10 @@ insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geoj
 on conflict (id) do nothing;
 
 insert into public.reg_group (id, name, member_species_ids, source_url, verified_at) values
-  ('akse-4salmon', 'Chum, coho, pink & sockeye salmon (16 inches or longer)', '["chum_salmon","coho_salmon","pink_salmon","sockeye_salmon"]', 'https://www.adfg.alaska.gov/static/regulations/fishregulations/PDFs/southeast/2026se_sfregs_general_freshwater_saltwater.pdf', '2026-09-02'),
-  ('akse-pelagic-rockfish', 'Pelagic rockfish (black, dark, deacon, dusky, widow, yellowtail)', '["black_rockfish","widow_rockfish","yellowtail_rockfish"]', 'https://www.adfg.alaska.gov/static/regulations/fishregulations/PDFs/southeast/2026se_sfregs_general_freshwater_saltwater.pdf', '2026-09-02'),
-  ('akse-slope-rockfish', 'Slope rockfish (nonpelagic; incl. blue, bocaccio, vermilion, …)', '["blue_rockfish","bocaccio","vermilion_rockfish"]', 'https://www.adfg.alaska.gov/static/regulations/fishregulations/PDFs/southeast/2026se_sfregs_general_freshwater_saltwater.pdf', '2026-09-02'),
-  ('akse-dsr', 'Demersal shelf rockfish (canary, China, copper, quillback, rosethorn, tiger, yelloweye)', '["canary_rockfish","copper_rockfish","quillback_rockfish","yelloweye_rockfish"]', 'https://www.adfg.alaska.gov/static/regulations/fishregulations/PDFs/southeast/2026se_sfregs_general_freshwater_saltwater.pdf', '2026-09-02')
+  ('akse-4salmon', 'Chum, coho, pink & sockeye salmon (16 inches or longer)', '{chum_salmon,coho_salmon,pink_salmon,sockeye_salmon}', 'https://www.adfg.alaska.gov/static/regulations/fishregulations/PDFs/southeast/2026se_sfregs_general_freshwater_saltwater.pdf', '2026-09-02'),
+  ('akse-pelagic-rockfish', 'Pelagic rockfish (black, dark, deacon, dusky, widow, yellowtail)', '{black_rockfish,widow_rockfish,yellowtail_rockfish}', 'https://www.adfg.alaska.gov/static/regulations/fishregulations/PDFs/southeast/2026se_sfregs_general_freshwater_saltwater.pdf', '2026-09-02'),
+  ('akse-slope-rockfish', 'Slope rockfish (nonpelagic; incl. blue, bocaccio, vermilion, …)', '{blue_rockfish,bocaccio,vermilion_rockfish}', 'https://www.adfg.alaska.gov/static/regulations/fishregulations/PDFs/southeast/2026se_sfregs_general_freshwater_saltwater.pdf', '2026-09-02'),
+  ('akse-dsr', 'Demersal shelf rockfish (canary, China, copper, quillback, rosethorn, tiger, yelloweye)', '{canary_rockfish,copper_rockfish,quillback_rockfish,yelloweye_rockfish}', 'https://www.adfg.alaska.gov/static/regulations/fishregulations/PDFs/southeast/2026se_sfregs_general_freshwater_saltwater.pdf', '2026-09-02')
 on conflict (id) do nothing;
 
 insert into public.reg_rule
@@ -87,8 +87,8 @@ insert into public.reg_area (id, authority, kind, name, parent_id, boundary_geoj
 on conflict (id) do nothing;
 
 insert into public.reg_group (id, name, member_species_ids, source_url, verified_at) values
-  ('hi-deep7', 'Deep 7 bottomfish (onaga, ''ehu, gindai, kalekale, lehi, ''opakapaka, hapu''u)', '["onaga","opakapaka","ehu","hapuu"]', 'https://dlnr.hawaii.gov/dar/fishing/fishing-regulations/marine-fishes-and-vertebrates/', '2026-09-02'),
-  ('hi-uhu-large', 'Regulated large uhu (14-inch minimum) species', '["uhu"]', 'https://dlnr.hawaii.gov/dar/fishing/fishing-regulations/marine-fishes-and-vertebrates/', '2026-09-02')
+  ('hi-deep7', 'Deep 7 bottomfish (onaga, ''ehu, gindai, kalekale, lehi, ''opakapaka, hapu''u)', '{onaga,opakapaka,ehu,hapuu}', 'https://dlnr.hawaii.gov/dar/fishing/fishing-regulations/marine-fishes-and-vertebrates/', '2026-09-02'),
+  ('hi-uhu-large', 'Regulated large uhu (14-inch minimum) species', '{uhu}', 'https://dlnr.hawaii.gov/dar/fishing/fishing-regulations/marine-fishes-and-vertebrates/', '2026-09-02')
 on conflict (id) do nothing;
 
 insert into public.reg_rule


### PR DESCRIPTION
**Confirmed working:** the founder ran `supabase db push` against a real project with these fixes and all 36 applied.

Six bugs, none visible without executing the SQL. The architect wrote on 2026-08-28 that he had not run it and *"someone must run it against a real Supabase project before trusting it."* Nobody did, until today — `db push` died on the eighth file.

I brought up Postgres 16 locally with the Supabase surface these migrations lean on (the `auth` schema, `auth.uid()`, the `anon`/`authenticated`/`service_role` roles) and ran all 36 in order against an empty database until they passed.

## The six

1. **A stray semicolon** stranded an `on conflict` clause as its own invalid statement, so the insert ran unguarded and collided with `striped_bass`. One character.
2. **Two `reg_group` rows passed `null`** for a NOT NULL `source_url`. Filled from the URLs those groups' own rules already cite — provenance carried across, not invented.
3. **Eight rockfish referenced through a foreign key four migrations before the PNW pack creates them.** Rows copied verbatim from that canonical definition and seeded ahead of the rules; `on conflict` makes the later insert a no-op.
4. **`reg_rule_subject` required a species or a group.** Counted against the packs actually written:

   | count | shape |
   |---|---|
   | 697 | names a species |
   | 113 | names neither — area-wide rules (venting-tool requirements, management-area closures) |
   | 44 | names a group |
   | 3 | names both |

   Every shape occurs, so no version of that check is true of the data. Removed, with the real invariant documented in its place: `reg_area_id NOT NULL` plus the two foreign keys.
5. **Eleven JSON array literals** (`'["a","b"]'`) where Postgres wants `'{a,b}'`.
6. **`carapace_width` rejected** by a check constraint, though the TypeScript `SizeMeasure` has always included it and crab is measured no other way.

**Four of the six are the same story as the RLS gap fixed this morning:** the app's model moved and the SQL didn't follow, and nothing was running the SQL to notice.

## Why nothing caught it

`species-parity.test.ts` concatenates every migration into one string and regex-matches inserts. It is **order-blind** — a reference four migrations ahead of its definition looks fine — and it truncates at the first `;`, of which the verbatim regulation text has hundreds. It passes, and always would have. My own first analysis script had the identical flaw, which is how I know the trap is easy to fall into.

## The resulting database

182 species · 823 regulation rules · 78 areas · 15 groups · 27 packs · **0 tables without row-level security**

That last figure also confirms this morning's RLS migration against a real Postgres rather than by reading files.

## Two things flagged, not changed

Guessing at regulation data is how a bag limit ends up wrong, so these are for a human:

- **3 rules name both a species and a group** — possibly data-entry slips.
- **7 `prohibited` rules name neither**, despite their text naming a fish — one reads *"Nassau grouper — Daily Bag: 0 (catch and release only)"*. `reg-engine.ts:122` filters complex-level prohibitions on `regGroupId !== null`, so **a prohibition naming neither may never fire in the app.** That's a fish-safety consequence rather than a schema nicety.

## How it was checked

All 36 applied to an empty database, then the row counts above queried back. `npm run verify` exits 0 — 789 tests, tripwires clean, 0 lint errors. And the founder's own `db push` against the live project succeeded.

## Worth doing next, separately

Running these migrations against a real Postgres in CI would turn today's six bugs into a build failure instead of a discovery. The workflow added in #64 could do it with a Postgres service container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SibpfrTGgxFEB99aUg7dVP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SibpfrTGgxFEB99aUg7dVP)_