### PR TITLE
T-007 scoring, standings and finalization

### DIFF
--- a/src/core/tournaments/official-scoring.test.ts
+++ b/src/core/tournaments/official-scoring.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { computeOfficialStandings } from "./official-scoring";
+
+const catches = [
+  { id: "c1", entryId: "a", speciesId: "yellowtail", weightG: 5000, lengthMm: 700, approved: true, disqualified: false },
+  { id: "c2", entryId: "a", speciesId: "yellowtail", weightG: 3000, lengthMm: 600, approved: true, disqualified: false },
+  { id: "c3", entryId: "b", speciesId: "dorado", weightG: 7000, lengthMm: 800, approved: true, disqualified: false },
+  { id: "c4", entryId: "b", speciesId: "dorado", weightG: 9000, lengthMm: 900, approved: false, disqualified: false },
+];
+
+describe("official tournament scoring", () => {
+  it("ignores unapproved catches", () => {
+    const rows = computeOfficialStandings(["a", "b"], catches, [], { family: "TOTAL_WEIGHT" });
+    expect(rows.find((r) => r.entryId === "a")?.score).toBe(8000);
+    expect(rows.find((r) => r.entryId === "b")?.score).toBe(7000);
+  });
+
+  it("applies catch removals before scoring without mutating catch history", () => {
+    const rows = computeOfficialStandings(["a"], catches, [
+      { id: "p1", entryId: "a", type: "CATCH_REMOVAL", catchId: "c1", active: true },
+    ], { family: "TOTAL_WEIGHT" });
+    expect(rows[0].score).toBe(3000);
+    expect(rows[0].eligibleCatchCount).toBe(1);
+  });
+
+  it("applies active deductions deterministically", () => {
+    const rows = computeOfficialStandings(["a"], catches, [
+      { id: "p1", entryId: "a", type: "WEIGHT_DEDUCTION", weightG: 1000, active: true },
+    ], { family: "TOTAL_WEIGHT" });
+    expect(rows[0].score).toBe(7000);
+    expect(rows[0].penaltyWeightG).toBe(1000);
+  });
+
+  it("keeps reversed penalties out of the fold", () => {
+    const rows = computeOfficialStandings(["a"], catches, [
+      { id: "p1", entryId: "a", type: "WEIGHT_DEDUCTION", weightG: 1000, active: false },
+    ], { family: "TOTAL_WEIGHT" });
+    expect(rows[0].score).toBe(8000);
+  });
+
+  it("disqualifies an entry without deleting source catches", () => {
+    const rows = computeOfficialStandings(["a", "b"], catches, [
+      { id: "p1", entryId: "a", type: "DISQUALIFICATION", active: true },
+    ], { family: "TOTAL_WEIGHT" });
+    expect(rows.find((r) => r.entryId === "a")?.disqualified).toBe(true);
+    expect(rows.find((r) => r.entryId === "a")?.score).toBe(0);
+    expect(rows[0].entryId).toBe("b");
+  });
+
+  it("supports best-N weight", () => {
+    const rows = computeOfficialStandings(["a"], catches, [], { family: "BEST_N_WEIGHT", bestN: 1 });
+    expect(rows[0].score).toBe(5000);
+  });
+
+  it("is stable under input ordering", () => {
+    const forward = computeOfficialStandings(["a", "b"], catches, [], { family: "TOTAL_WEIGHT" });
+    const reverse = computeOfficialStandings(["b", "a"], [...catches].reverse(), [], { family: "TOTAL_WEIGHT" });
+    expect(reverse).toEqual(forward);
+  });
+});

--- a/src/core/tournaments/official-scoring.ts
+++ b/src/core/tournaments/official-scoring.ts
@@ -1,0 +1,119 @@
+export type ScoringFamily =
+  | "BIGGEST_FISH"
+  | "TOTAL_WEIGHT"
+  | "BEST_N_WEIGHT"
+  | "TOTAL_LENGTH"
+  | "BIGGEST_LENGTH"
+  | "POINTS"
+  | "SPECIES_POINTS"
+  | "SPECIES_MULTIPLIER"
+  | "EVERY_FISH_COUNTS";
+
+export interface EligibleCatch {
+  id: string;
+  entryId: string;
+  speciesId: string | null;
+  weightG: number | null;
+  lengthMm: number | null;
+  approved: boolean;
+  disqualified: boolean;
+  points?: number;
+}
+
+export interface AppliedPenalty {
+  id: string;
+  entryId: string;
+  type: "POINT_DEDUCTION" | "WEIGHT_DEDUCTION" | "TIME_PENALTY" | "CATCH_REMOVAL" | "DISQUALIFICATION" | "CUSTOM";
+  points?: number;
+  weightG?: number;
+  catchId?: string;
+  active: boolean;
+}
+
+export interface ScoreRule {
+  family: ScoringFamily;
+  bestN?: number;
+  speciesPoints?: Readonly<Record<string, number>>;
+  speciesMultiplier?: Readonly<Record<string, number>>;
+}
+
+export interface OfficialStanding {
+  entryId: string;
+  score: number;
+  eligibleCatchCount: number;
+  penaltyPoints: number;
+  penaltyWeightG: number;
+  disqualified: boolean;
+  rank: number;
+}
+
+function rawScore(catches: readonly EligibleCatch[], rule: ScoreRule): number {
+  switch (rule.family) {
+    case "BIGGEST_FISH":
+      return Math.max(0, ...catches.map((c) => c.weightG ?? 0));
+    case "TOTAL_WEIGHT":
+    case "EVERY_FISH_COUNTS":
+      return catches.reduce((sum, c) => sum + (c.weightG ?? 0), 0);
+    case "BEST_N_WEIGHT": {
+      const n = Math.max(1, rule.bestN ?? 1);
+      return catches.map((c) => c.weightG ?? 0).sort((a, b) => b - a).slice(0, n).reduce((a, b) => a + b, 0);
+    }
+    case "TOTAL_LENGTH":
+      return catches.reduce((sum, c) => sum + (c.lengthMm ?? 0), 0);
+    case "BIGGEST_LENGTH":
+      return Math.max(0, ...catches.map((c) => c.lengthMm ?? 0));
+    case "POINTS":
+      return catches.reduce((sum, c) => sum + (c.points ?? 0), 0);
+    case "SPECIES_POINTS":
+      return catches.reduce((sum, c) => sum + (c.speciesId ? rule.speciesPoints?.[c.speciesId] ?? 0 : 0), 0);
+    case "SPECIES_MULTIPLIER":
+      return catches.reduce((sum, c) => {
+        const base = c.points ?? c.weightG ?? c.lengthMm ?? 0;
+        const multiplier = c.speciesId ? rule.speciesMultiplier?.[c.speciesId] ?? 1 : 1;
+        return sum + base * multiplier;
+      }, 0);
+  }
+}
+
+export function computeOfficialStandings(
+  entryIds: readonly string[],
+  catches: readonly EligibleCatch[],
+  penalties: readonly AppliedPenalty[],
+  rule: ScoreRule,
+): OfficialStanding[] {
+  const rows = entryIds.map((entryId) => {
+    const entryPenalties = penalties.filter((p) => p.entryId === entryId && p.active);
+    const removedCatchIds = new Set(entryPenalties.filter((p) => p.type === "CATCH_REMOVAL" && p.catchId).map((p) => p.catchId!));
+    const eligible = catches.filter(
+      (c) => c.entryId === entryId && c.approved && !c.disqualified && !removedCatchIds.has(c.id),
+    );
+    const penaltyPoints = entryPenalties
+      .filter((p) => p.type === "POINT_DEDUCTION")
+      .reduce((sum, p) => sum + Math.abs(p.points ?? 0), 0);
+    const penaltyWeightG = entryPenalties
+      .filter((p) => p.type === "WEIGHT_DEDUCTION")
+      .reduce((sum, p) => sum + Math.abs(p.weightG ?? 0), 0);
+    const disqualified = entryPenalties.some((p) => p.type === "DISQUALIFICATION");
+    const base = rawScore(eligible, rule);
+    const score = disqualified ? 0 : Math.max(0, base - penaltyPoints - penaltyWeightG);
+    return { entryId, score, eligibleCatchCount: eligible.length, penaltyPoints, penaltyWeightG, disqualified, rank: 0 };
+  });
+
+  rows.sort((a, b) => {
+    if (a.disqualified !== b.disqualified) return a.disqualified ? 1 : -1;
+    if (b.score !== a.score) return b.score - a.score;
+    if (b.eligibleCatchCount !== a.eligibleCatchCount) return b.eligibleCatchCount - a.eligibleCatchCount;
+    return a.entryId.localeCompare(b.entryId);
+  });
+
+  let previous: OfficialStanding | null = null;
+  let rank = 0;
+  return rows.map((row, index) => {
+    if (!previous || row.score !== previous.score || row.disqualified !== previous.disqualified || row.eligibleCatchCount !== previous.eligibleCatchCount) {
+      rank = index + 1;
+    }
+    const ranked = { ...row, rank };
+    previous = ranked;
+    return ranked;
+  });
+}

--- a/supabase/migrations/20260905194000_tournament_scoring.sql
+++ b/supabase/migrations/20260905194000_tournament_scoring.sql
@@ -1,0 +1,145 @@
+-- T-007 — deterministic tournament scoring, standings, snapshots and finalization.
+-- Depends on T-006 adjudication. Scoring consumes approved catches + append-only penalties.
+-- Scoring never initiates payments.
+
+create table if not exists public.score_computation (
+  id uuid primary key default gen_random_uuid(),
+  tournament_id uuid not null references public.tournament(id) on delete cascade,
+  organization_id uuid not null references public.organization(id) on delete cascade,
+  scoring_version_id uuid not null references public.tournament_scoring_version(id) on delete restrict,
+  source_cutoff_at timestamptz not null,
+  source_hash text not null,
+  computed_at timestamptz not null default now(),
+  computed_by uuid references public.angler(id) on delete set null,
+  status text not null default 'COMPLETE' check (status in ('RUNNING','COMPLETE','FAILED')),
+  failure_reason text,
+  unique (tournament_id, scoring_version_id, source_hash)
+);
+
+create table if not exists public.standing (
+  id uuid primary key default gen_random_uuid(),
+  score_computation_id uuid not null references public.score_computation(id) on delete cascade,
+  tournament_id uuid not null references public.tournament(id) on delete cascade,
+  organization_id uuid not null references public.organization(id) on delete cascade,
+  tournament_entry_id uuid not null references public.tournament_entry(id) on delete cascade,
+  division_id uuid references public.tournament_division(id) on delete set null,
+  rank integer not null check (rank > 0),
+  score_numeric numeric not null,
+  tie_break_value numeric,
+  eligible_catch_count integer not null default 0 check (eligible_catch_count >= 0),
+  penalty_points numeric not null default 0,
+  penalty_weight_g numeric not null default 0,
+  is_disqualified boolean not null default false,
+  detail jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (score_computation_id, tournament_entry_id, division_id)
+);
+
+create table if not exists public.leaderboard_snapshot (
+  id uuid primary key default gen_random_uuid(),
+  tournament_id uuid not null references public.tournament(id) on delete cascade,
+  organization_id uuid not null references public.organization(id) on delete cascade,
+  score_computation_id uuid not null references public.score_computation(id) on delete restrict,
+  snapshot_kind text not null default 'LIVE' check (snapshot_kind in ('LIVE','CHECKPOINT','FINAL')),
+  generated_at timestamptz not null default now(),
+  payload jsonb not null,
+  source_hash text not null,
+  unique (tournament_id, snapshot_kind, source_hash)
+);
+
+create table if not exists public.final_result_set (
+  id uuid primary key default gen_random_uuid(),
+  tournament_id uuid not null references public.tournament(id) on delete cascade,
+  organization_id uuid not null references public.organization(id) on delete cascade,
+  version integer not null check (version > 0),
+  score_computation_id uuid not null references public.score_computation(id) on delete restrict,
+  rules_version_id uuid not null references public.tournament_rule_set_version(id) on delete restrict,
+  scoring_version_id uuid not null references public.tournament_scoring_version(id) on delete restrict,
+  verification_policy_version_id uuid not null references public.tournament_verification_policy_version(id) on delete restrict,
+  boundary_version_id uuid not null references public.tournament_boundary_version(id) on delete restrict,
+  finalized_by uuid not null references public.angler(id) on delete restrict,
+  finalized_at timestamptz not null default now(),
+  correction_reason text,
+  supersedes_final_result_set_id uuid references public.final_result_set(id) on delete restrict,
+  source_hash text not null,
+  unique (tournament_id, version),
+  unique (tournament_id, source_hash)
+);
+
+create table if not exists public.final_result_award (
+  id uuid primary key default gen_random_uuid(),
+  final_result_set_id uuid not null references public.final_result_set(id) on delete cascade,
+  tournament_award_category_id uuid not null references public.tournament_award_category(id) on delete restrict,
+  tournament_entry_id uuid references public.tournament_entry(id) on delete restrict,
+  tournament_team_id uuid references public.tournament_team(id) on delete restrict,
+  tournament_boat_id uuid references public.tournament_boat(id) on delete restrict,
+  rank integer not null check (rank > 0),
+  winning_value numeric,
+  detail jsonb not null default '{}'::jsonb,
+  constraint final_result_award_one_target check (
+    ((tournament_entry_id is not null)::int +
+     (tournament_team_id is not null)::int +
+     (tournament_boat_id is not null)::int) = 1
+  )
+);
+
+create index if not exists standing_tournament_rank_idx on public.standing (tournament_id, rank);
+create index if not exists standing_entry_idx on public.standing (tournament_entry_id);
+create index if not exists final_result_set_tournament_version_idx on public.final_result_set (tournament_id, version desc);
+
+alter table public.score_computation enable row level security;
+alter table public.standing enable row level security;
+alter table public.leaderboard_snapshot enable row level security;
+alter table public.final_result_set enable row level security;
+alter table public.final_result_award enable row level security;
+
+revoke all on public.score_computation, public.standing, public.leaderboard_snapshot,
+  public.final_result_set, public.final_result_award from anon;
+
+grant select, insert on public.score_computation to authenticated;
+grant select, insert on public.standing to authenticated;
+grant select, insert on public.leaderboard_snapshot to authenticated;
+grant select, insert on public.final_result_set to authenticated;
+grant select, insert on public.final_result_award to authenticated;
+
+create policy score_computation_org_read on public.score_computation
+for select to authenticated using (public.is_organization_member(organization_id));
+create policy score_computation_admin_insert on public.score_computation
+for insert to authenticated with check (public.is_organization_member(organization_id, array['OWNER','ADMIN','STAFF']));
+
+create policy standing_org_read on public.standing
+for select to authenticated using (public.is_organization_member(organization_id));
+create policy standing_admin_insert on public.standing
+for insert to authenticated with check (public.is_organization_member(organization_id, array['OWNER','ADMIN','STAFF']));
+
+create policy leaderboard_snapshot_org_read on public.leaderboard_snapshot
+for select to authenticated using (public.is_organization_member(organization_id));
+create policy leaderboard_snapshot_admin_insert on public.leaderboard_snapshot
+for insert to authenticated with check (public.is_organization_member(organization_id, array['OWNER','ADMIN','STAFF']));
+
+create policy final_result_set_org_read on public.final_result_set
+for select to authenticated using (public.is_organization_member(organization_id));
+create policy final_result_set_admin_insert on public.final_result_set
+for insert to authenticated with check (public.is_organization_member(organization_id, array['OWNER','ADMIN','STAFF']));
+
+create policy final_result_award_org_read on public.final_result_award
+for select to authenticated using (exists (
+  select 1 from public.final_result_set fr
+  where fr.id = final_result_set_id and public.is_organization_member(fr.organization_id)
+));
+create policy final_result_award_admin_insert on public.final_result_award
+for insert to authenticated with check (exists (
+  select 1 from public.final_result_set fr
+  where fr.id = final_result_set_id and public.is_organization_member(fr.organization_id, array['OWNER','ADMIN','STAFF'])
+));
+
+create or replace function public.next_final_result_version(target_tournament_id uuid)
+returns integer language sql stable security definer set search_path = public as $$
+  select coalesce(max(version), 0) + 1 from public.final_result_set where tournament_id = target_tournament_id;
+$$;
+revoke all on function public.next_final_result_version(uuid) from public;
+grant execute on function public.next_final_result_version(uuid) to authenticated;
+
+comment on table public.score_computation is 'Reproducible score computation over an exact scoring version and source hash.';
+comment on table public.final_result_set is 'Immutable official result version. Corrections create a new version and optionally supersede a prior result.';
+comment on table public.final_result_award is 'Official award result only; no financial or payout side effects.';


### PR DESCRIPTION
- Adds reproducible ScoreComputation, Standing, LeaderboardSnapshot, FinalResultSet, and final award records tied to exact rule/scoring/verification/boundary versions.
- Adds a deterministic pure scoring fold that consumes approved catches plus active append-only penalties without mutating source history.
- Supports BIGGEST_FISH, TOTAL_WEIGHT, BEST_N_WEIGHT, TOTAL_LENGTH, BIGGEST_LENGTH, POINTS, SPECIES_POINTS, SPECIES_MULTIPLIER, and EVERY_FISH_COUNTS families. Scoring has no payment side effects.

Stacked on T-006 / PR #91. Merge in dependency order.

Closes #78