### PR TITLE
T-008 public leaderboard and safe tournament projections

### DIFF
--- a/src/core/tournaments/public-projection.test.ts
+++ b/src/core/tournaments/public-projection.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PUBLIC_CATCH_FIELDS,
+  PUBLIC_ENTRY_FIELDS,
+  PUBLIC_LEADERBOARD_FIELDS,
+  PUBLIC_TOURNAMENT_FIELDS,
+  containsPrivateField,
+} from "./public-projection";
+
+describe("public tournament projections", () => {
+  it("keeps private fields out of every public allowlist", () => {
+    for (const fields of [
+      PUBLIC_TOURNAMENT_FIELDS,
+      PUBLIC_ENTRY_FIELDS,
+      PUBLIC_CATCH_FIELDS,
+      PUBLIC_LEADERBOARD_FIELDS,
+    ]) {
+      expect(containsPrivateField(fields)).toBe(false);
+    }
+  });
+
+  it("detects raw location and integrity fields if somebody adds them later", () => {
+    expect(containsPrivateField(["id", "lat"])).toBe(true);
+    expect(containsPrivateField(["id", "gps_accuracy_m"])).toBe(true);
+    expect(containsPrivateField(["id", "fair_play_signal"])).toBe(true);
+    expect(containsPrivateField(["id", "wallet_address"])).toBe(true);
+  });
+
+  it("allows only approved/final catch-safe field names", () => {
+    expect(PUBLIC_CATCH_FIELDS).toContain("weight_g");
+    expect(PUBLIC_CATCH_FIELDS).toContain("length_mm");
+    expect(PUBLIC_CATCH_FIELDS).not.toContain("latitude" as never);
+    expect(PUBLIC_CATCH_FIELDS).not.toContain("device_metadata" as never);
+  });
+});

--- a/src/core/tournaments/public-projection.ts
+++ b/src/core/tournaments/public-projection.ts
@@ -1,0 +1,71 @@
+export const PUBLIC_TOURNAMENT_FIELDS = [
+  "id",
+  "slug",
+  "name",
+  "description",
+  "visibility",
+  "status",
+  "starts_at",
+  "ends_at",
+  "registration_opens_at",
+  "registration_closes_at",
+  "organization_id",
+  "created_at",
+] as const;
+
+export const PUBLIC_ENTRY_FIELDS = [
+  "id",
+  "tournament_id",
+  "entry_number",
+  "team_id",
+  "tournament_boat_id",
+  "display_name",
+] as const;
+
+export const PUBLIC_CATCH_FIELDS = [
+  "id",
+  "tournament_id",
+  "tournament_entry_id",
+  "species_id",
+  "weight_g",
+  "length_mm",
+  "captured_at_device",
+  "state",
+  "public_photo_path",
+] as const;
+
+export const PUBLIC_LEADERBOARD_FIELDS = [
+  "tournament_id",
+  "tournament_entry_id",
+  "division_id",
+  "rank",
+  "score_numeric",
+  "eligible_catch_count",
+  "is_disqualified",
+  "computed_at",
+] as const;
+
+export const PRIVATE_FIELD_NAMES = [
+  "latitude",
+  "longitude",
+  "lat",
+  "lng",
+  "gps_accuracy_m",
+  "device_id",
+  "device_metadata",
+  "original_metadata",
+  "fair_play_signal",
+  "verification_detail",
+  "email",
+  "claim_token_hash",
+  "wallet_address",
+  "payment_provider_id",
+  "registration_number",
+  "contact_phone",
+  "internal_notes",
+] as const;
+
+export function containsPrivateField(fields: readonly string[]): boolean {
+  const normalized = new Set(fields.map((field) => field.toLowerCase()));
+  return PRIVATE_FIELD_NAMES.some((field) => normalized.has(field));
+}

--- a/supabase/migrations/20260905195500_tournament_public_projections.sql
+++ b/supabase/migrations/20260905195500_tournament_public_projections.sql
@@ -1,0 +1,114 @@
+-- T-008 — explicit public-safe tournament projections.
+-- Public access is allowlisted through views/functions only. Raw GPS, device metadata,
+-- original evidence, Fair Play details, payments, wallet addresses, private vessel data,
+-- contact information, and internal notes remain private.
+
+create or replace view public.public_tournament as
+select
+  t.id,
+  t.slug,
+  t.name,
+  t.description,
+  t.visibility,
+  t.status,
+  t.starts_at,
+  t.ends_at,
+  t.registration_opens_at,
+  t.registration_closes_at,
+  t.organization_id,
+  t.created_at
+from public.tournament t
+where t.deleted_at is null
+  and t.visibility in ('PUBLIC','UNLISTED');
+
+create or replace view public.public_tournament_entry as
+select
+  e.id,
+  e.tournament_id,
+  e.entry_number,
+  e.team_id,
+  e.tournament_boat_id,
+  i.display_name
+from public.tournament_entry e
+join public.tournament_entry_identity i on i.tournament_entry_id = e.id
+join public.tournament t on t.id = e.tournament_id
+where e.deleted_at is null
+  and e.registration_status = 'CONFIRMED'
+  and t.deleted_at is null
+  and t.visibility in ('PUBLIC','UNLISTED');
+
+create or replace view public.public_tournament_catch as
+select
+  c.id,
+  c.tournament_id,
+  c.tournament_entry_id,
+  c.species_id,
+  c.weight_g,
+  c.length_mm,
+  c.captured_at_device,
+  c.state,
+  e.storage_path as public_photo_path
+from public.tournament_catch c
+join public.tournament t on t.id = c.tournament_id
+left join lateral (
+  select ce.storage_path
+  from public.catch_evidence ce
+  where ce.tournament_catch_id = c.id
+    and ce.evidence_type = 'PHOTO'
+  order by ce.created_at asc
+  limit 1
+) e on true
+where t.deleted_at is null
+  and t.visibility in ('PUBLIC','UNLISTED')
+  and c.state in ('APPROVED','FINAL');
+
+create or replace view public.public_leaderboard as
+select
+  s.tournament_id,
+  s.tournament_entry_id,
+  s.division_id,
+  s.rank,
+  s.score_numeric,
+  s.eligible_catch_count,
+  s.is_disqualified,
+  sc.computed_at
+from public.standing s
+join public.score_computation sc on sc.id = s.score_computation_id
+join public.tournament t on t.id = s.tournament_id
+where t.deleted_at is null
+  and t.visibility in ('PUBLIC','UNLISTED')
+  and sc.status = 'COMPLETE';
+
+revoke all on public.public_tournament from anon, authenticated;
+revoke all on public.public_tournament_entry from anon, authenticated;
+revoke all on public.public_tournament_catch from anon, authenticated;
+revoke all on public.public_leaderboard from anon, authenticated;
+
+grant select on public.public_tournament to anon, authenticated;
+grant select on public.public_tournament_entry to anon, authenticated;
+grant select on public.public_tournament_catch to anon, authenticated;
+grant select on public.public_leaderboard to anon, authenticated;
+
+comment on view public.public_tournament is 'Allowlisted tournament metadata for PUBLIC/UNLISTED discovery. PRIVATE and INVITE_ONLY are excluded.';
+comment on view public.public_tournament_entry is 'Public competitor display projection. No email, claim token, user id, contact details or payment state.';
+comment on view public.public_tournament_catch is 'Approved public catch projection. No raw GPS, device metadata, original evidence metadata, Fair Play signals or internal notes.';
+comment on view public.public_leaderboard is 'Public official standing projection. No scoring internals, penalty detail, payment or private integrity metadata.';
+
+create or replace function public.get_public_tournament(target_slug text)
+returns setof public.public_tournament
+language sql stable security definer set search_path = public as $$
+  select * from public.public_tournament where slug = target_slug limit 1;
+$$;
+
+create or replace function public.get_public_leaderboard(target_tournament_id uuid)
+returns setof public.public_leaderboard
+language sql stable security definer set search_path = public as $$
+  select * from public.public_leaderboard
+  where tournament_id = target_tournament_id
+  order by rank asc, tournament_entry_id asc;
+$$;
+
+revoke all on function public.get_public_tournament(text) from public;
+revoke all on function public.get_public_leaderboard(uuid) from public;
+grant execute on function public.get_public_tournament(text) to anon, authenticated;
+grant execute on function public.get_public_leaderboard(uuid) to anon, authenticated;


### PR DESCRIPTION
- Adds explicit allowlisted public projections for tournament metadata, confirmed entry display names, approved/final catches, and official leaderboard rows.
- Excludes raw GPS, device metadata, original evidence metadata, Fair Play/verification details, payments, wallet addresses, private vessel registration/contact fields, and internal notes.
- Adds public projection field allowlists with privacy regression tests.

Stacked on T-007 / PR #92. Merge in dependency order.

Closes #79