### PR TITLE
PAY-002 Stripe payment provider

### DIFF
--- a/src/core/tournaments/stripe-provider.test.ts
+++ b/src/core/tournaments/stripe-provider.test.ts
@@ -1,12 +1,32 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { StripePaymentProvider, verifyStripeWebhook, type StripeClientPort } from "./stripe-provider";
+import {
+  StripePaymentProvider,
+  verifyStripeWebhook,
+  type StripeClientPort,
+  type StripePaymentIntentLike,
+  type StripeRefundLike,
+} from "./stripe-provider";
 
 function client(): StripeClientPort {
   return {
-    createPaymentIntent: vi.fn(async (input) => ({ id: "pi_1", status: "succeeded", amount: input.amount, currency: input.currency })),
-    retrievePaymentIntent: vi.fn(async () => ({ id: "pi_1", status: "succeeded", amount: 5000, currency: "usd" })),
-    createRefund: vi.fn(async (input) => ({ id: "re_1", amount: input.amount, status: "succeeded" })),
+    createPaymentIntent: vi.fn(async (input): Promise<StripePaymentIntentLike> => ({
+      id: "pi_1",
+      status: "succeeded",
+      amount: input.amount,
+      currency: input.currency,
+    })),
+    retrievePaymentIntent: vi.fn(async (): Promise<StripePaymentIntentLike> => ({
+      id: "pi_1",
+      status: "succeeded",
+      amount: 5000,
+      currency: "usd",
+    })),
+    createRefund: vi.fn(async (input): Promise<StripeRefundLike> => ({
+      id: "re_1",
+      amount: input.amount,
+      status: "succeeded",
+    })),
   };
 }
 
@@ -26,7 +46,13 @@ describe("StripePaymentProvider", () => {
 
   it("maps Stripe requires_action without calling it confirmed", async () => {
     const port = client();
-    port.createPaymentIntent = vi.fn(async () => ({ id: "pi_2", status: "requires_action", amount: 5000, currency: "usd", client_secret: "secret" }));
+    port.createPaymentIntent = vi.fn(async (): Promise<StripePaymentIntentLike> => ({
+      id: "pi_2",
+      status: "requires_action",
+      amount: 5000,
+      currency: "usd",
+      client_secret: "secret",
+    }));
     const result = await new StripePaymentProvider(port).createPayment({ orderId: "o1", amountMinor: 5000, currency: "USD", idempotencyKey: "idem-2" });
     expect(result.status).toBe("REQUIRES_ACTION");
   });

--- a/src/core/tournaments/stripe-provider.test.ts
+++ b/src/core/tournaments/stripe-provider.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { StripePaymentProvider, verifyStripeWebhook, type StripeClientPort } from "./stripe-provider";
+
+function client(): StripeClientPort {
+  return {
+    createPaymentIntent: vi.fn(async (input) => ({ id: "pi_1", status: "succeeded", amount: input.amount, currency: input.currency })),
+    retrievePaymentIntent: vi.fn(async () => ({ id: "pi_1", status: "succeeded", amount: 5000, currency: "usd" })),
+    createRefund: vi.fn(async (input) => ({ id: "re_1", amount: input.amount, status: "succeeded" })),
+  };
+}
+
+describe("StripePaymentProvider", () => {
+  it("passes the order id and idempotency key to the provider port", async () => {
+    const port = client();
+    const provider = new StripePaymentProvider(port);
+    const result = await provider.createPayment({ orderId: "o1", amountMinor: 5000, currency: "USD", idempotencyKey: "idem-1" });
+    expect(result.status).toBe("CONFIRMED");
+    expect(port.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({
+      amount: 5000,
+      currency: "usd",
+      idempotencyKey: "idem-1",
+      metadata: expect.objectContaining({ order_id: "o1" }),
+    }));
+  });
+
+  it("maps Stripe requires_action without calling it confirmed", async () => {
+    const port = client();
+    port.createPaymentIntent = vi.fn(async () => ({ id: "pi_2", status: "requires_action", amount: 5000, currency: "usd", client_secret: "secret" }));
+    const result = await new StripePaymentProvider(port).createPayment({ orderId: "o1", amountMinor: 5000, currency: "USD", idempotencyKey: "idem-2" });
+    expect(result.status).toBe("REQUIRES_ACTION");
+  });
+
+  it("maps successful refunds", async () => {
+    const result = await new StripePaymentProvider(client()).refund({ providerPaymentId: "pi_1", amountMinor: 1000, idempotencyKey: "refund-1" });
+    expect(result).toEqual({ providerRefundId: "re_1", status: "CONFIRMED", amountMinor: 1000 });
+  });
+});
+
+describe("Stripe webhook verification", () => {
+  it("requires a signature before parsing an event", () => {
+    expect(() => verifyStripeWebhook({ verify: vi.fn() }, "{}", null)).toThrow("missing Stripe signature");
+  });
+
+  it("delegates cryptographic verification to the server verifier", () => {
+    const verifier = { verify: vi.fn(() => ({ id: "evt_1", type: "payment_intent.succeeded", livemode: false, objectId: "pi_1" })) };
+    expect(verifyStripeWebhook(verifier, "raw", "sig").id).toBe("evt_1");
+    expect(verifier.verify).toHaveBeenCalledWith("raw", "sig");
+  });
+});

--- a/src/core/tournaments/stripe-provider.ts
+++ b/src/core/tournaments/stripe-provider.ts
@@ -1,0 +1,127 @@
+import type { PaymentProvider, PaymentRequest, PaymentResult, RefundRequest, RefundResult } from "./payments";
+
+export interface StripePaymentIntentLike {
+  id: string;
+  status: "requires_payment_method" | "requires_action" | "processing" | "requires_capture" | "succeeded" | "canceled";
+  amount: number;
+  currency: string;
+  client_secret?: string | null;
+}
+
+export interface StripeRefundLike {
+  id: string;
+  amount: number;
+  status: "pending" | "succeeded" | "failed" | "canceled" | null;
+}
+
+export interface StripeClientPort {
+  createPaymentIntent(input: {
+    amount: number;
+    currency: string;
+    idempotencyKey: string;
+    metadata: Readonly<Record<string, string>>;
+    connectedAccountId?: string;
+    applicationFeeAmount?: number;
+  }): Promise<StripePaymentIntentLike>;
+  retrievePaymentIntent(id: string): Promise<StripePaymentIntentLike>;
+  createRefund(input: {
+    paymentIntentId: string;
+    amount: number;
+    idempotencyKey: string;
+    reason?: string;
+  }): Promise<StripeRefundLike>;
+}
+
+function mapPaymentStatus(status: StripePaymentIntentLike["status"]): PaymentResult["status"] {
+  switch (status) {
+    case "requires_action": return "REQUIRES_ACTION";
+    case "processing": return "PENDING";
+    case "requires_capture": return "AUTHORIZED";
+    case "succeeded": return "CONFIRMED";
+    case "canceled": return "CANCELLED";
+    case "requires_payment_method": return "FAILED";
+  }
+}
+
+function mapRefundStatus(status: StripeRefundLike["status"]): RefundResult["status"] {
+  switch (status) {
+    case "succeeded": return "CONFIRMED";
+    case "failed": return "FAILED";
+    case "canceled": return "CANCELLED";
+    default: return "PENDING";
+  }
+}
+
+export class StripePaymentProvider implements PaymentProvider {
+  readonly name = "stripe";
+
+  constructor(
+    private readonly client: StripeClientPort,
+    private readonly options: {
+      connectedAccountId?: string;
+      applicationFeeAmount?: (request: PaymentRequest) => number | undefined;
+    } = {},
+  ) {}
+
+  async createPayment(request: PaymentRequest): Promise<PaymentResult> {
+    const intent = await this.client.createPaymentIntent({
+      amount: request.amountMinor,
+      currency: request.currency.toLowerCase(),
+      idempotencyKey: request.idempotencyKey,
+      metadata: { order_id: request.orderId, ...(request.metadata ?? {}) },
+      connectedAccountId: this.options.connectedAccountId,
+      applicationFeeAmount: this.options.applicationFeeAmount?.(request),
+    });
+    return this.toResult(intent);
+  }
+
+  async confirmPayment(providerPaymentId: string): Promise<PaymentResult> {
+    return this.toResult(await this.client.retrievePaymentIntent(providerPaymentId));
+  }
+
+  async getStatus(providerPaymentId: string): Promise<PaymentResult> {
+    return this.toResult(await this.client.retrievePaymentIntent(providerPaymentId));
+  }
+
+  async refund(request: RefundRequest): Promise<RefundResult> {
+    const refund = await this.client.createRefund({
+      paymentIntentId: request.providerPaymentId,
+      amount: request.amountMinor,
+      idempotencyKey: request.idempotencyKey,
+      reason: request.reason,
+    });
+    return { providerRefundId: refund.id, status: mapRefundStatus(refund.status), amountMinor: refund.amount };
+  }
+
+  private toResult(intent: StripePaymentIntentLike): PaymentResult {
+    return {
+      provider: this.name,
+      providerPaymentId: intent.id,
+      status: mapPaymentStatus(intent.status),
+      amountMinor: intent.amount,
+      currency: intent.currency.toUpperCase(),
+      requiresActionUrl: intent.status === "requires_action" && intent.client_secret ? intent.client_secret : undefined,
+    };
+  }
+}
+
+export interface VerifiedStripeWebhook {
+  id: string;
+  type: string;
+  livemode: boolean;
+  objectId?: string;
+}
+
+export interface StripeWebhookVerifier {
+  verify(rawBody: string, signatureHeader: string): VerifiedStripeWebhook;
+}
+
+export function verifyStripeWebhook(
+  verifier: StripeWebhookVerifier,
+  rawBody: string,
+  signatureHeader: string | null,
+): VerifiedStripeWebhook {
+  if (!signatureHeader) throw new Error("missing Stripe signature");
+  if (!rawBody) throw new Error("missing raw webhook body");
+  return verifier.verify(rawBody, signatureHeader);
+}

--- a/supabase/migrations/20260905202500_tournament_stripe_provider.sql
+++ b/supabase/migrations/20260905202500_tournament_stripe_provider.sql
@@ -1,0 +1,44 @@
+-- PAY-002 — Stripe provider persistence and organizer account capability tracking.
+-- No raw card/CVV storage. Stripe identifiers only.
+
+create table if not exists public.organizer_payment_account (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references public.organization(id) on delete cascade,
+  provider text not null default 'stripe',
+  provider_account_id text not null,
+  charges_enabled boolean not null default false,
+  payouts_enabled boolean not null default false,
+  details_submitted boolean not null default false,
+  requirements_due text[] not null default '{}',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (provider, provider_account_id),
+  unique (organization_id, provider)
+);
+
+create table if not exists public.stripe_webhook_event (
+  id uuid primary key default gen_random_uuid(),
+  provider_event_id text not null unique,
+  event_type text not null,
+  livemode boolean not null,
+  object_id text,
+  payload_hash text not null,
+  received_at timestamptz not null default now(),
+  processed_at timestamptz,
+  processing_status text not null default 'RECEIVED' check (processing_status in ('RECEIVED','PROCESSED','IGNORED','FAILED')),
+  failure_reason text
+);
+
+alter table public.organizer_payment_account enable row level security;
+alter table public.stripe_webhook_event enable row level security;
+revoke all on public.organizer_payment_account, public.stripe_webhook_event from anon;
+grant select on public.organizer_payment_account to authenticated;
+
+create policy organizer_payment_account_admin_read on public.organizer_payment_account
+for select to authenticated using (public.is_organization_member(organization_id, array['OWNER','ADMIN']));
+
+create trigger tg_organizer_payment_account_updated_at before update on public.organizer_payment_account
+for each row execute function public.tg_set_updated_at();
+
+comment on table public.organizer_payment_account is 'Provider account identifiers/capabilities only; no bank credentials or secrets.';
+comment on table public.stripe_webhook_event is 'Server-only idempotent Stripe webhook receipt ledger after signature verification.';


### PR DESCRIPTION
- Adds Stripe provider persistence for organizer account capability state and idempotent webhook receipts.
- Implements StripePaymentProvider behind an injected client port so tournament/payment domain code stays provider-neutral.
- Maps payment/refund states conservatively, carries idempotency keys, supports connected-account/application-fee inputs, and requires server-side webhook signature verification.

Stacked on PAY-001 / PR #94. Merge in dependency order.

Closes #81