### PR TITLE
PAY-003 crypto and MetaMask-compatible payment provider

### DIFF
--- a/src/core/tournaments/crypto-provider.test.ts
+++ b/src/core/tournaments/crypto-provider.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  CryptoPaymentProvider,
+  evaluateObservation,
+  validateQuote,
+  type CryptoGatewayPort,
+  type CryptoQuote,
+} from "./crypto-provider";
+
+const quote: CryptoQuote = {
+  quoteId: "q1",
+  fiatCurrency: "USD",
+  fiatAmountMinor: 5000,
+  cryptoAsset: "USDC",
+  cryptoAmountAtomic: "50000000",
+  chainNamespace: "eip155",
+  chainId: "8453",
+  recipientAddress: "0xabc",
+  expiresAt: "2030-01-01T00:00:00.000Z",
+};
+
+function gateway(): CryptoGatewayPort {
+  return {
+    createQuote: vi.fn(async () => quote),
+    getQuote: vi.fn(async () => quote),
+    observeTransaction: vi.fn(async (txHash) => ({
+      txHash,
+      chainId: "8453",
+      asset: "USDC",
+      amountAtomic: "50000000",
+      recipientAddress: "0xabc",
+      confirmations: 3,
+      final: true,
+    })),
+  };
+}
+
+describe("crypto payment safety", () => {
+  it("rejects expired quotes", () => {
+    expect(() => validateQuote({ ...quote, expiresAt: "2020-01-01T00:00:00.000Z" }, Date.now())).toThrow("expired");
+  });
+
+  it("does not treat a transaction submission as confirmation", async () => {
+    const provider = new CryptoPaymentProvider(gateway(), 2, () => Date.parse("2029-01-01T00:00:00.000Z"));
+    const payment = await provider.createPayment({ orderId: "o1", amountMinor: 5000, currency: "USD", idempotencyKey: "i1" });
+    provider.registerSubmission(payment.providerPaymentId, {
+      txHash: "0xtx",
+      chainNamespace: "eip155",
+      chainId: "8453",
+      asset: "USDC",
+      amountAtomic: "50000000",
+      recipientAddress: "0xabc",
+    });
+    expect(payment.status).toBe("PENDING");
+    expect((await provider.getStatus(payment.providerPaymentId)).status).toBe("CONFIRMED");
+  });
+
+  it("rejects the wrong network before observation", async () => {
+    const provider = new CryptoPaymentProvider(gateway(), 1, () => Date.parse("2029-01-01T00:00:00.000Z"));
+    const payment = await provider.createPayment({ orderId: "o1", amountMinor: 5000, currency: "USD", idempotencyKey: "i2" });
+    expect(() => provider.registerSubmission(payment.providerPaymentId, {
+      txHash: "0xtx",
+      chainNamespace: "eip155",
+      chainId: "1",
+      asset: "USDC",
+      amountAtomic: "50000000",
+      recipientAddress: "0xabc",
+    })).toThrow("wrong crypto network");
+  });
+
+  it("requires server-observed finality and confirmations", () => {
+    expect(evaluateObservation(quote, {
+      txHash: "0xtx",
+      chainId: "8453",
+      asset: "USDC",
+      amountAtomic: "50000000",
+      recipientAddress: "0xabc",
+      confirmations: 1,
+      final: false,
+    }, 2)).toBe("PENDING");
+  });
+
+  it("rejects underpayment and wrong asset", () => {
+    expect(evaluateObservation(quote, {
+      txHash: "0xtx",
+      chainId: "8453",
+      asset: "USDC",
+      amountAtomic: "49999999",
+      recipientAddress: "0xabc",
+      confirmations: 3,
+      final: true,
+    }, 2)).toBe("FAILED");
+
+    expect(evaluateObservation(quote, {
+      txHash: "0xtx",
+      chainId: "8453",
+      asset: "ETH",
+      amountAtomic: "50000000",
+      recipientAddress: "0xabc",
+      confirmations: 3,
+      final: true,
+    }, 2)).toBe("FAILED");
+  });
+
+  it("does not imply crypto payouts are enabled", async () => {
+    const provider = new CryptoPaymentProvider(gateway(), 1, () => Date.parse("2029-01-01T00:00:00.000Z"));
+    await expect(provider.refund({ providerPaymentId: "x", amountMinor: 100, idempotencyKey: "r1" })).rejects.toThrow("not enabled");
+  });
+});

--- a/src/core/tournaments/crypto-provider.ts
+++ b/src/core/tournaments/crypto-provider.ts
@@ -1,0 +1,127 @@
+import type { PaymentProvider, PaymentRequest, PaymentResult, RefundRequest, RefundResult } from "./payments";
+
+export interface CryptoQuote {
+  quoteId: string;
+  fiatCurrency: string;
+  fiatAmountMinor: number;
+  cryptoAsset: string;
+  cryptoAmountAtomic: string;
+  chainNamespace: string;
+  chainId: string;
+  recipientAddress: string;
+  expiresAt: string;
+}
+
+export interface CryptoSubmission {
+  txHash: string;
+  chainNamespace: string;
+  chainId: string;
+  asset: string;
+  amountAtomic: string;
+  recipientAddress: string;
+}
+
+export interface ChainObservation {
+  txHash: string;
+  chainId: string;
+  asset: string;
+  amountAtomic: string;
+  recipientAddress: string;
+  confirmations: number;
+  final: boolean;
+  failed?: boolean;
+}
+
+export interface CryptoGatewayPort {
+  createQuote(request: PaymentRequest): Promise<CryptoQuote>;
+  getQuote(quoteId: string): Promise<CryptoQuote>;
+  observeTransaction(txHash: string, chainId: string): Promise<ChainObservation>;
+  createRefundInstruction?(request: RefundRequest): Promise<RefundResult>;
+}
+
+export interface CryptoPaymentState {
+  providerPaymentId: string;
+  quote: CryptoQuote;
+  submission?: CryptoSubmission;
+}
+
+export function validateQuote(quote: CryptoQuote, nowMs: number): void {
+  if (Date.parse(quote.expiresAt) <= nowMs) throw new Error("crypto quote expired");
+  if (!quote.chainNamespace || !quote.chainId || !quote.cryptoAsset) throw new Error("crypto quote missing network or asset");
+  if (!quote.recipientAddress) throw new Error("crypto quote missing recipient");
+}
+
+export function evaluateObservation(
+  quote: CryptoQuote,
+  observation: ChainObservation,
+  requiredConfirmations: number,
+): PaymentResult["status"] {
+  if (observation.failed) return "FAILED";
+  if (observation.chainId !== quote.chainId) return "FAILED";
+  if (observation.asset.toLowerCase() !== quote.cryptoAsset.toLowerCase()) return "FAILED";
+  if (observation.recipientAddress.toLowerCase() !== quote.recipientAddress.toLowerCase()) return "FAILED";
+  if (BigInt(observation.amountAtomic) < BigInt(quote.cryptoAmountAtomic)) return "FAILED";
+  if (!observation.final || observation.confirmations < requiredConfirmations) return "PENDING";
+  return "CONFIRMED";
+}
+
+export class CryptoPaymentProvider implements PaymentProvider {
+  readonly name = "crypto";
+  private readonly states = new Map<string, CryptoPaymentState>();
+
+  constructor(
+    private readonly gateway: CryptoGatewayPort,
+    private readonly requiredConfirmations = 1,
+    private readonly now: () => number = () => Date.now(),
+  ) {}
+
+  async createPayment(request: PaymentRequest): Promise<PaymentResult> {
+    const quote = await this.gateway.createQuote(request);
+    validateQuote(quote, this.now());
+    const id = `crypto:${quote.quoteId}`;
+    this.states.set(id, { providerPaymentId: id, quote });
+    return {
+      provider: this.name,
+      providerPaymentId: id,
+      status: "PENDING",
+      amountMinor: request.amountMinor,
+      currency: request.currency.toUpperCase(),
+    };
+  }
+
+  registerSubmission(providerPaymentId: string, submission: CryptoSubmission): void {
+    const state = this.states.get(providerPaymentId);
+    if (!state) throw new Error("unknown crypto payment");
+    if (submission.chainId !== state.quote.chainId) throw new Error("wrong crypto network");
+    if (submission.asset.toLowerCase() !== state.quote.cryptoAsset.toLowerCase()) throw new Error("wrong crypto asset");
+    state.submission = submission;
+  }
+
+  async confirmPayment(providerPaymentId: string): Promise<PaymentResult> {
+    return this.getStatus(providerPaymentId);
+  }
+
+  async getStatus(providerPaymentId: string): Promise<PaymentResult> {
+    const state = this.states.get(providerPaymentId);
+    if (!state) throw new Error("unknown crypto payment");
+    validateQuote(state.quote, state.submission ? Date.parse(state.quote.expiresAt) - 1 : this.now());
+    if (!state.submission) return this.result(state, "PENDING");
+    const observation = await this.gateway.observeTransaction(state.submission.txHash, state.submission.chainId);
+    return this.result(state, evaluateObservation(state.quote, observation, this.requiredConfirmations));
+  }
+
+  async refund(request: RefundRequest): Promise<RefundResult> {
+    if (!this.gateway.createRefundInstruction) throw new Error("crypto refunds are not enabled for this provider");
+    return this.gateway.createRefundInstruction(request);
+  }
+
+  private result(state: CryptoPaymentState, status: PaymentResult["status"]): PaymentResult {
+    return {
+      provider: this.name,
+      providerPaymentId: state.providerPaymentId,
+      status,
+      amountMinor: state.quote.fiatAmountMinor,
+      currency: state.quote.fiatCurrency.toUpperCase(),
+    };
+  }
+}

--- a/supabase/migrations/20260905204000_tournament_crypto_provider.sql
+++ b/supabase/migrations/20260905204000_tournament_crypto_provider.sql
@@ -1,0 +1,106 @@
+-- PAY-003 — crypto collection provider persistence.
+-- Collection is separate from payout capability. No private keys, seed phrases, or wallet secrets.
+
+create table if not exists public.wallet_connection (
+  id uuid primary key default gen_random_uuid(),
+  angler_id uuid not null references public.angler(id) on delete cascade,
+  wallet_address text not null,
+  chain_namespace text not null,
+  chain_id text not null,
+  connected_at timestamptz not null default now(),
+  last_verified_at timestamptz,
+  disconnected_at timestamptz,
+  unique (angler_id, chain_namespace, chain_id, wallet_address)
+);
+
+create table if not exists public.crypto_payment_quote (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references public.organization(id) on delete cascade,
+  order_id uuid not null references public.tournament_order(id) on delete cascade,
+  fiat_currency text not null,
+  fiat_amount_minor bigint not null check (fiat_amount_minor >= 0),
+  crypto_asset text not null,
+  crypto_amount_atomic numeric not null check (crypto_amount_atomic > 0),
+  chain_namespace text not null,
+  chain_id text not null,
+  rate_source text not null,
+  quoted_at timestamptz not null default now(),
+  expires_at timestamptz not null,
+  created_at timestamptz not null default now(),
+  constraint crypto_quote_expiry_after_quote check (expires_at > quoted_at)
+);
+
+create table if not exists public.crypto_payment (
+  id uuid primary key default gen_random_uuid(),
+  payment_id uuid not null references public.payment(id) on delete restrict,
+  quote_id uuid not null references public.crypto_payment_quote(id) on delete restrict,
+  payer_wallet_address text not null,
+  recipient_wallet_address text not null,
+  chain_namespace text not null,
+  chain_id text not null,
+  crypto_asset text not null,
+  expected_amount_atomic numeric not null check (expected_amount_atomic > 0),
+  tx_hash text,
+  status text not null default 'AWAITING_TX' check (status in ('AWAITING_TX','SUBMITTED','CONFIRMING','CONFIRMED','FAILED','EXPIRED','WRONG_NETWORK','WRONG_ASSET','UNDERPAID','OVERPAID')),
+  submitted_at timestamptz,
+  confirmed_at timestamptz,
+  confirmations integer not null default 0 check (confirmations >= 0),
+  block_reference text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (chain_namespace, chain_id, tx_hash)
+);
+
+create table if not exists public.crypto_chain_observation (
+  id uuid primary key default gen_random_uuid(),
+  crypto_payment_id uuid not null references public.crypto_payment(id) on delete cascade,
+  tx_hash text not null,
+  observed_chain_id text not null,
+  observed_asset text not null,
+  observed_amount_atomic numeric not null,
+  recipient_wallet_address text not null,
+  confirmations integer not null default 0,
+  finality_status text not null check (finality_status in ('SEEN','CONFIRMING','FINAL','REORGED','FAILED')),
+  observed_at timestamptz not null default now(),
+  unique (crypto_payment_id, tx_hash, confirmations, finality_status)
+);
+
+alter table public.wallet_connection enable row level security;
+alter table public.crypto_payment_quote enable row level security;
+alter table public.crypto_payment enable row level security;
+alter table public.crypto_chain_observation enable row level security;
+
+revoke all on public.wallet_connection, public.crypto_payment_quote, public.crypto_payment, public.crypto_chain_observation from anon;
+grant select, insert, update on public.wallet_connection to authenticated;
+grant select on public.crypto_payment_quote, public.crypto_payment, public.crypto_chain_observation to authenticated;
+
+create policy wallet_connection_owner on public.wallet_connection
+for all to authenticated using (angler_id = auth.uid()) with check (angler_id = auth.uid());
+
+create policy crypto_quote_read on public.crypto_payment_quote
+for select to authenticated using (exists (
+  select 1 from public.tournament_order o where o.id = order_id and (
+    o.purchaser_angler_id = auth.uid() or public.is_organization_member(o.organization_id, array['OWNER','ADMIN'])
+  )
+));
+
+create policy crypto_payment_read on public.crypto_payment
+for select to authenticated using (exists (
+  select 1 from public.payment p join public.tournament_order o on o.id = p.order_id
+  where p.id = payment_id and (o.purchaser_angler_id = auth.uid() or public.is_organization_member(o.organization_id, array['OWNER','ADMIN']))
+));
+
+create policy crypto_observation_read on public.crypto_chain_observation
+for select to authenticated using (exists (
+  select 1 from public.crypto_payment cp
+  join public.payment p on p.id = cp.payment_id
+  join public.tournament_order o on o.id = p.order_id
+  where cp.id = crypto_payment_id and (o.purchaser_angler_id = auth.uid() or public.is_organization_member(o.organization_id, array['OWNER','ADMIN']))
+));
+
+create trigger tg_crypto_payment_updated_at before update on public.crypto_payment
+for each row execute function public.tg_set_updated_at();
+
+comment on table public.wallet_connection is 'Public wallet address linkage only. Never stores private keys, seed phrases, passwords, or signing secrets.';
+comment on table public.crypto_payment_quote is 'Temporary fiat-to-crypto quote with explicit source, chain, asset and expiry.';
+comment on table public.crypto_payment is 'Crypto collection state. Wallet signature or submitted transaction is not payment confirmation; server-verified finality is required.';


### PR DESCRIPTION
- Adds wallet-address linkage, expiring fiat-to-crypto quotes, crypto payment records, and server-observed chain finality without storing private keys, seed phrases, passwords, or signing secrets.
- Implements a wallet/provider-neutral CryptoPaymentProvider compatible with MetaMask-style flows while keeping wallet UX out of tournament domain code.
- Treats signature/submitted transaction as pending only; confirms payment only after server-observed network/asset/recipient/amount/finality checks. Crypto collection does not enable crypto payouts.

Stacked on PAY-001 / PR #94. PAY-002 and PAY-003 are sibling provider lanes and can be reviewed independently after PAY-001.

Closes #82