### PR TITLE
UI-001 tournament hub, create flow and overview shell

### DIFF
--- a/src/app/(app)/tournaments/[id]/overview/page.tsx
+++ b/src/app/(app)/tournaments/[id]/overview/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+import { TournamentOverview } from "@/features/tournaments/components/tournament-overview";
+
+export const metadata: Metadata = { title: "Tournament Overview | Fish Log Book" };
+
+export default async function TournamentOverviewPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return <TournamentOverview tournamentId={id} />;
+}

--- a/src/app/(app)/tournaments/new/page.tsx
+++ b/src/app/(app)/tournaments/new/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { CreateTournamentForm } from "@/features/tournaments/components/create-tournament-form";
+
+export const metadata: Metadata = { title: "Create Tournament | Fish Log Book" };
+
+export default function NewTournamentPage() {
+  return (
+    <div className="mx-auto flex max-w-reading flex-col gap-space-5 px-space-4 py-space-5">
+      <header className="flex flex-col gap-space-2">
+        <Link href="/tournaments" className="text-caption text-text-link">← Tournaments</Link>
+        <h1 className="text-h1 text-text-primary">Create tournament</h1>
+        <p className="text-body text-text-muted">
+          Start simple for friends or use the same tournament engine for an organization event.
+        </p>
+      </header>
+      <CreateTournamentForm />
+    </div>
+  );
+}

--- a/src/app/(app)/tournaments/page.tsx
+++ b/src/app/(app)/tournaments/page.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+import { TournamentHub } from "@/features/tournaments/components/tournament-hub";
+
+export const metadata: Metadata = { title: "Tournaments | Fish Log Book" };
+
+export default function TournamentsPage() {
+  return <TournamentHub />;
+}

--- a/src/core/tournaments/lifecycle.ts
+++ b/src/core/tournaments/lifecycle.ts
@@ -1,0 +1,69 @@
+export const TOURNAMENT_STATUSES = [
+  "DRAFT",
+  "REGISTRATION_OPEN",
+  "REGISTRATION_CLOSED",
+  "READY",
+  "LIVE",
+  "PAUSED",
+  "COMPLETED",
+  "RESULTS_PENDING",
+  "FINAL",
+  "CANCELLED",
+] as const;
+
+export type TournamentStatus = (typeof TOURNAMENT_STATUSES)[number];
+
+const ALLOWED: Readonly<Record<TournamentStatus, readonly TournamentStatus[]>> = {
+  DRAFT: ["REGISTRATION_OPEN", "CANCELLED"],
+  REGISTRATION_OPEN: ["REGISTRATION_CLOSED", "CANCELLED"],
+  REGISTRATION_CLOSED: ["READY", "REGISTRATION_OPEN", "CANCELLED"],
+  READY: ["LIVE", "CANCELLED"],
+  LIVE: ["PAUSED", "COMPLETED"],
+  PAUSED: ["LIVE", "COMPLETED", "CANCELLED"],
+  COMPLETED: ["RESULTS_PENDING"],
+  RESULTS_PENDING: ["FINAL"],
+  FINAL: [],
+  CANCELLED: [],
+};
+
+export function canTransitionTournament(
+  from: TournamentStatus,
+  to: TournamentStatus,
+): boolean {
+  return ALLOWED[from].includes(to);
+}
+
+export interface FrozenCompetitionVersions {
+  readonly ruleSetVersionId: string | null;
+  readonly scoringVersionId: string | null;
+  readonly verificationPolicyVersionId: string | null;
+  readonly boundaryVersionId: string | null;
+}
+
+export function hasAllLiveVersions(versions: FrozenCompetitionVersions): boolean {
+  return (
+    versions.ruleSetVersionId !== null &&
+    versions.scoringVersionId !== null &&
+    versions.verificationPolicyVersionId !== null &&
+    versions.boundaryVersionId !== null
+  );
+}
+
+export function validateTournamentTransition(input: {
+  readonly from: TournamentStatus;
+  readonly to: TournamentStatus;
+  readonly versions: FrozenCompetitionVersions;
+}): { readonly ok: true } | { readonly ok: false; readonly reason: string } {
+  if (!canTransitionTournament(input.from, input.to)) {
+    return { ok: false, reason: `Invalid tournament transition: ${input.from} -> ${input.to}` };
+  }
+
+  if (input.to === "LIVE" && !hasAllLiveVersions(input.versions)) {
+    return {
+      ok: false,
+      reason: "LIVE requires frozen rule, scoring, verification, and boundary versions.",
+    };
+  }
+
+  return { ok: true };
+}

--- a/src/features/shell/destinations.ts
+++ b/src/features/shell/destinations.ts
@@ -63,6 +63,7 @@ export function destinationGroups(): readonly DestinationGroup[] {
       items: [
         { href: "/tides", label: "Tide", blurb: "Today's tide, and the days ahead" },
         { href: "/fish-legal", label: "Fish Legal", blurb: "Size and bag limits where you are" },
+        { href: "/tournaments", label: "Tournaments", blurb: "Create, join, and follow fishing tournaments" },
         ...(BOAT_GAMES_V1
           ? [
               {

--- a/src/features/tournaments/components/create-tournament-form.tsx
+++ b/src/features/tournaments/components/create-tournament-form.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { createClient } from "@/lib/supabase/client";
+import { TOURNAMENT_INPUT, TOURNAMENT_PRIMARY_BUTTON, TOURNAMENT_SECONDARY_BUTTON } from "../ui-classes";
+
+const VISIBILITIES = ["PRIVATE", "INVITE_ONLY", "UNLISTED", "PUBLIC"] as const;
+
+function toIsoOrNull(value: string) {
+  return value ? new Date(value).toISOString() : null;
+}
+
+export function CreateTournamentForm() {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [visibility, setVisibility] = useState<(typeof VISIBILITIES)[number]>("PRIVATE");
+  const [startsAt, setStartsAt] = useState("");
+  const [endsAt, setEndsAt] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    const supabase = createClient();
+    const { data: authData, error: authError } = await supabase.auth.getUser();
+    if (authError || !authData.user) {
+      setError("Sign in before creating a tournament.");
+      setSubmitting(false);
+      return;
+    }
+
+    const { data: organizationId, error: organizationError } = await supabase.rpc(
+      "ensure_personal_organization",
+    );
+    if (organizationError || !organizationId) {
+      setError(organizationError?.message ?? "Your tournament workspace could not be prepared.");
+      setSubmitting(false);
+      return;
+    }
+
+    const { data, error: insertError } = await supabase
+      .from("tournament")
+      .insert({
+        organization_id: organizationId,
+        name: name.trim(),
+        visibility,
+        status: "DRAFT",
+        starts_at: toIsoOrNull(startsAt),
+        ends_at: toIsoOrNull(endsAt),
+        created_by: authData.user.id,
+      })
+      .select("id")
+      .single();
+
+    if (insertError) {
+      setError(insertError.message);
+      setSubmitting(false);
+      return;
+    }
+
+    router.push(`/tournaments/${data.id}/overview`);
+    router.refresh();
+  }
+
+  return (
+    <form onSubmit={submit} className="flex flex-col gap-space-5">
+      <label className="flex flex-col gap-space-2">
+        <span className="text-label text-text-primary">Tournament name</span>
+        <input
+          required
+          maxLength={120}
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          className={TOURNAMENT_INPUT}
+          placeholder="Saturday Yellowtail Challenge"
+        />
+      </label>
+
+      <fieldset className="flex flex-col gap-space-2">
+        <legend className="text-label text-text-primary">Who can see it?</legend>
+        <div className="grid grid-cols-2 gap-space-2">
+          {VISIBILITIES.map((option) => (
+            <button
+              key={option}
+              type="button"
+              onClick={() => setVisibility(option)}
+              aria-pressed={visibility === option}
+              className={visibility === option ? TOURNAMENT_PRIMARY_BUTTON : TOURNAMENT_SECONDARY_BUTTON}
+            >
+              {option.toLowerCase().replaceAll("_", " ")}
+            </button>
+          ))}
+        </div>
+      </fieldset>
+
+      <div className="grid gap-space-4 sm:grid-cols-2">
+        <label className="flex flex-col gap-space-2">
+          <span className="text-label text-text-primary">Starts</span>
+          <input type="datetime-local" value={startsAt} onChange={(event) => setStartsAt(event.target.value)} className={TOURNAMENT_INPUT} />
+        </label>
+        <label className="flex flex-col gap-space-2">
+          <span className="text-label text-text-primary">Ends</span>
+          <input type="datetime-local" value={endsAt} onChange={(event) => setEndsAt(event.target.value)} className={TOURNAMENT_INPUT} />
+        </label>
+      </div>
+
+      <p className="text-caption text-text-muted">
+        This starts as a draft. Rules, scoring, verification and boundaries can be configured before it goes live.
+      </p>
+
+      {error ? <p className="text-body text-error-red" role="alert">{error}</p> : null}
+
+      <button type="submit" disabled={submitting || name.trim().length === 0} className={TOURNAMENT_PRIMARY_BUTTON}>
+        {submitting ? "Creating…" : "Create tournament"}
+      </button>
+    </form>
+  );
+}

--- a/src/features/tournaments/components/tournament-hub.tsx
+++ b/src/features/tournaments/components/tournament-hub.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { createClient } from "@/lib/supabase/client";
+import { TOURNAMENT_CARD, TOURNAMENT_PRIMARY_BUTTON } from "../ui-classes";
+
+type TournamentCardData = {
+  id: string;
+  name: string;
+  status: string;
+  visibility: string;
+  starts_at: string | null;
+  ends_at: string | null;
+  organization_id: string;
+};
+
+function statusLabel(status: string) {
+  return status.toLowerCase().replaceAll("_", " ");
+}
+
+function whenLabel(value: string | null) {
+  if (!value) return "Date not set";
+  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", year: "numeric" }).format(
+    new Date(value),
+  );
+}
+
+export function TournamentHub() {
+  const [owned, setOwned] = useState<TournamentCardData[]>([]);
+  const [publicTournaments, setPublicTournaments] = useState<TournamentCardData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const supabase = createClient();
+
+    async function load() {
+      const [ownedResult, publicResult] = await Promise.all([
+        supabase
+          .from("tournament")
+          .select("id,name,status,visibility,starts_at,ends_at,organization_id")
+          .is("deleted_at", null)
+          .order("created_at", { ascending: false }),
+        supabase
+          .from("public_tournament")
+          .select("id,name,status,visibility,starts_at,ends_at,organization_id")
+          .eq("visibility", "PUBLIC")
+          .order("created_at", { ascending: false })
+          .limit(12),
+      ]);
+
+      if (cancelled) return;
+      const firstError = ownedResult.error ?? publicResult.error;
+      if (firstError) {
+        setError(firstError.message);
+      } else {
+        setOwned((ownedResult.data ?? []) as TournamentCardData[]);
+        setPublicTournaments((publicResult.data ?? []) as TournamentCardData[]);
+      }
+      setLoading(false);
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="mx-auto flex max-w-reading flex-col gap-space-6 px-space-4 py-space-5">
+      <header className="flex flex-col gap-space-3">
+        <div className="flex items-start justify-between gap-space-4">
+          <div className="flex flex-col gap-space-1">
+            <h1 className="text-h1 text-text-primary">Tournaments</h1>
+            <p className="text-body text-text-muted">
+              Run a private trip competition or a full public event from the same tournament engine.
+            </p>
+          </div>
+        </div>
+        <Link href="/tournaments/new" className={TOURNAMENT_PRIMARY_BUTTON}>
+          Create tournament
+        </Link>
+      </header>
+
+      {loading ? <p className="text-body text-text-muted">Loading tournaments…</p> : null}
+      {error ? (
+        <div className={`${TOURNAMENT_CARD} flex flex-col gap-space-2`} role="alert">
+          <p className="text-body-strong text-error-red">Tournament data could not be loaded.</p>
+          <p className="text-caption text-text-muted">{error}</p>
+        </div>
+      ) : null}
+
+      {!loading && !error ? (
+        <>
+          <TournamentSection
+            title="My tournaments"
+            empty="You have not created or joined a tournament yet."
+            tournaments={owned}
+          />
+          <TournamentSection
+            title="Public tournaments"
+            empty="No public tournaments are available right now."
+            tournaments={publicTournaments.filter((item) => !owned.some((own) => own.id === item.id))}
+          />
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function TournamentSection({
+  title,
+  empty,
+  tournaments,
+}: {
+  title: string;
+  empty: string;
+  tournaments: TournamentCardData[];
+}) {
+  return (
+    <section className="flex flex-col gap-space-3" aria-labelledby={`${title.replaceAll(" ", "-").toLowerCase()}-heading`}>
+      <h2 id={`${title.replaceAll(" ", "-").toLowerCase()}-heading`} className="text-h3 text-text-primary">
+        {title}
+      </h2>
+      {tournaments.length === 0 ? (
+        <p className={`${TOURNAMENT_CARD} text-body text-text-muted`}>{empty}</p>
+      ) : (
+        <ul className="flex flex-col gap-space-3">
+          {tournaments.map((tournament) => (
+            <li key={tournament.id}>
+              <Link
+                href={`/tournaments/${tournament.id}/overview`}
+                className={`${TOURNAMENT_CARD} flex min-h-touch-floor flex-col gap-space-2`}
+              >
+                <span className="flex flex-wrap items-start justify-between gap-space-2">
+                  <span className="text-body-strong text-text-primary">{tournament.name}</span>
+                  <span className="rounded-full border border-hairline px-space-2 py-space-1 text-caption capitalize text-text-muted">
+                    {statusLabel(tournament.status)}
+                  </span>
+                </span>
+                <span className="text-caption text-text-muted">
+                  {whenLabel(tournament.starts_at)} · {tournament.visibility.toLowerCase().replaceAll("_", " ")}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/features/tournaments/components/tournament-overview.tsx
+++ b/src/features/tournaments/components/tournament-overview.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { createClient } from "@/lib/supabase/client";
+import type { TournamentStatus } from "@/core/tournaments/lifecycle";
+import { TOURNAMENT_CARD, TOURNAMENT_SECONDARY_BUTTON } from "../ui-classes";
+
+type TournamentOverviewData = {
+  id: string;
+  name: string;
+  status: TournamentStatus;
+  visibility: string;
+  starts_at: string | null;
+  ends_at: string | null;
+  organization_id: string;
+  active_rule_set_version_id: string | null;
+  active_scoring_version_id: string | null;
+  active_verification_policy_version_id: string | null;
+  active_boundary_version_id: string | null;
+};
+
+const NAV_ITEMS = [
+  ["Overview", "overview"],
+  ["Register", "register"],
+  ["Catches", "catches"],
+  ["Leaderboard", "leaderboard"],
+  ["Rules", "rules"],
+] as const;
+
+function formatDate(value: string | null) {
+  if (!value) return "Not scheduled";
+  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(value));
+}
+
+export function TournamentOverview({ tournamentId }: { tournamentId: string }) {
+  const [tournament, setTournament] = useState<TournamentOverviewData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const supabase = createClient();
+
+    async function load() {
+      const { data, error: queryError } = await supabase
+        .from("tournament")
+        .select(
+          "id,name,status,visibility,starts_at,ends_at,organization_id,active_rule_set_version_id,active_scoring_version_id,active_verification_policy_version_id,active_boundary_version_id",
+        )
+        .eq("id", tournamentId)
+        .is("deleted_at", null)
+        .maybeSingle();
+
+      if (cancelled) return;
+      if (queryError) setError(queryError.message);
+      else if (!data) setError("Tournament not found or you do not have access.");
+      else setTournament(data as TournamentOverviewData);
+      setLoading(false);
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [tournamentId]);
+
+  if (loading) {
+    return <div className="mx-auto max-w-reading px-space-4 py-space-5 text-body text-text-muted">Loading tournament…</div>;
+  }
+
+  if (error || !tournament) {
+    return (
+      <div className="mx-auto flex max-w-reading flex-col gap-space-4 px-space-4 py-space-5">
+        <p className={`${TOURNAMENT_CARD} text-body text-error-red`} role="alert">{error ?? "Tournament unavailable."}</p>
+        <Link href="/tournaments" className={TOURNAMENT_SECONDARY_BUTTON}>Back to tournaments</Link>
+      </div>
+    );
+  }
+
+  const versionsReady = [
+    tournament.active_rule_set_version_id,
+    tournament.active_scoring_version_id,
+    tournament.active_verification_policy_version_id,
+    tournament.active_boundary_version_id,
+  ].filter(Boolean).length;
+
+  return (
+    <div className="mx-auto flex max-w-reading flex-col gap-space-5 px-space-4 py-space-5">
+      <header className="flex flex-col gap-space-3">
+        <Link href="/tournaments" className="text-caption text-text-link">← Tournaments</Link>
+        <div className="flex flex-col gap-space-1">
+          <div className="flex flex-wrap items-center justify-between gap-space-2">
+            <h1 className="text-h1 text-text-primary">{tournament.name}</h1>
+            <span className="rounded-full border border-hairline px-space-3 py-space-1 text-caption capitalize text-text-muted">
+              {tournament.status.toLowerCase().replaceAll("_", " ")}
+            </span>
+          </div>
+          <p className="text-body text-text-muted">
+            {formatDate(tournament.starts_at)} · {tournament.visibility.toLowerCase().replaceAll("_", " ")}
+          </p>
+        </div>
+      </header>
+
+      <nav aria-label="Tournament sections" className="overflow-x-auto">
+        <ul className="flex min-w-max gap-space-2 pb-space-1">
+          {NAV_ITEMS.map(([label, route]) => (
+            <li key={route}>
+              <Link
+                href={`/tournaments/${tournament.id}/${route}`}
+                className="inline-flex min-h-touch-floor items-center rounded-full border border-hairline bg-surface px-space-3 text-label text-text-primary"
+              >
+                {label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      <section className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`} aria-labelledby="readiness-heading">
+        <div className="flex items-center justify-between gap-space-3">
+          <h2 id="readiness-heading" className="text-h3 text-text-primary">Competition readiness</h2>
+          <span className="text-caption text-text-muted">{versionsReady}/4 locked inputs selected</span>
+        </div>
+        <div className="h-space-2 overflow-hidden rounded-full bg-surface-muted" aria-hidden="true">
+          <div className="h-full bg-action" style={{ width: `${versionsReady * 25}%` }} />
+        </div>
+        <p className="text-caption text-text-muted">
+          Rules, scoring, verification policy and tournament boundaries must all be frozen before READY can move to LIVE.
+        </p>
+      </section>
+
+      <section className="grid gap-space-3 sm:grid-cols-2" aria-label="Tournament summary">
+        <article className={`${TOURNAMENT_CARD} flex flex-col gap-space-1`}>
+          <span className="text-caption text-text-muted">Starts</span>
+          <span className="text-body-strong text-text-primary">{formatDate(tournament.starts_at)}</span>
+        </article>
+        <article className={`${TOURNAMENT_CARD} flex flex-col gap-space-1`}>
+          <span className="text-caption text-text-muted">Ends</span>
+          <span className="text-body-strong text-text-primary">{formatDate(tournament.ends_at)}</span>
+        </article>
+      </section>
+
+      <section className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`}>
+        <h2 className="text-h3 text-text-primary">Next actions</h2>
+        <p className="text-body text-text-muted">
+          Registration, live catch logging, judging, operations and finance screens are being added in the next UI lanes without changing this tournament contract.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/src/features/tournaments/ui-classes.ts
+++ b/src/features/tournaments/ui-classes.ts
@@ -1,0 +1,11 @@
+export const TOURNAMENT_CARD =
+  "rounded-card border border-hairline bg-surface p-space-4 shadow-card";
+
+export const TOURNAMENT_PRIMARY_BUTTON =
+  "inline-flex min-h-touch-floor items-center justify-center rounded-control bg-action px-space-4 py-space-3 text-label text-on-action transition active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-50";
+
+export const TOURNAMENT_SECONDARY_BUTTON =
+  "inline-flex min-h-touch-floor items-center justify-center rounded-control border border-hairline bg-surface px-space-4 py-space-3 text-label text-text-primary transition active:scale-[0.99]";
+
+export const TOURNAMENT_INPUT =
+  "min-h-touch-floor w-full rounded-control border border-hairline bg-surface px-space-3 py-space-3 text-body text-text-primary outline-none focus:border-text-link";


### PR DESCRIPTION
- Adds a mobile-first `/tournaments` hub backed by the real tournament table plus the explicit `public_tournament` safe projection.
- Adds `/tournaments/new` creation using the canonical `ensure_personal_organization()` tenant path and the merged Tournament domain.
- Adds a lifecycle/readiness-aware tournament overview shell with progressive navigation and the four frozen LIVE prerequisites.
- Reuses repository design tokens and keeps provider/judge/catch internals out of this lane.

Closes #98