### PR TITLE
UI-002 tournament registration and entry flow

### DIFF
--- a/src/app/(app)/tournaments/[id]/register/page.tsx
+++ b/src/app/(app)/tournaments/[id]/register/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+import { TournamentRegistration } from "@/features/tournaments/components/tournament-registration";
+
+export const metadata: Metadata = { title: "Tournament Registration | Fish Log Book" };
+
+export default async function TournamentRegistrationPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return <TournamentRegistration tournamentId={id} />;
+}

--- a/src/features/tournaments/components/tournament-registration.tsx
+++ b/src/features/tournaments/components/tournament-registration.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { createClient } from "@/lib/supabase/client";
+import { TOURNAMENT_CARD, TOURNAMENT_INPUT, TOURNAMENT_PRIMARY_BUTTON, TOURNAMENT_SECONDARY_BUTTON } from "../ui-classes";
+
+type TournamentRegistrationState = {
+  id: string;
+  name: string;
+  status: string;
+  visibility: string;
+};
+
+type ExistingEntry = {
+  id: string;
+  registration_status: string;
+  eligibility_status: string;
+  check_in_status: string;
+  competition_status: string;
+};
+
+export function TournamentRegistration({ tournamentId }: { tournamentId: string }) {
+  const [tournament, setTournament] = useState<TournamentRegistrationState | null>(null);
+  const [entry, setEntry] = useState<ExistingEntry | null>(null);
+  const [displayName, setDisplayName] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function refresh() {
+    const supabase = createClient();
+    const { data: authData } = await supabase.auth.getUser();
+    const { data: tournamentData, error: tournamentError } = await supabase
+      .from("tournament")
+      .select("id,name,status,visibility")
+      .eq("id", tournamentId)
+      .maybeSingle();
+
+    if (tournamentError || !tournamentData) {
+      setError(tournamentError?.message ?? "Tournament unavailable.");
+      setLoading(false);
+      return;
+    }
+
+    setTournament(tournamentData as TournamentRegistrationState);
+
+    if (authData.user) {
+      const { data: identityRows } = await supabase
+        .from("tournament_entry_identity")
+        .select("tournament_entry_id")
+        .eq("claimed_angler_id", authData.user.id);
+
+      const candidateIds = (identityRows ?? []).map((row) => row.tournament_entry_id);
+      if (candidateIds.length > 0) {
+        const { data: entryData } = await supabase
+          .from("tournament_entry")
+          .select("id,registration_status,eligibility_status,check_in_status,competition_status")
+          .eq("tournament_id", tournamentId)
+          .in("id", candidateIds)
+          .is("deleted_at", null)
+          .maybeSingle();
+        setEntry((entryData as ExistingEntry | null) ?? null);
+      }
+    }
+
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    void Promise.resolve().then(refresh);
+    // tournamentId is the only external input; refresh intentionally owns the client instance.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tournamentId]);
+
+  async function register(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    const supabase = createClient();
+    const { error: registrationError } = await supabase.rpc("register_self_for_tournament", {
+      target_tournament_id: tournamentId,
+      participant_display_name: displayName.trim(),
+    });
+
+    if (registrationError) {
+      setError(registrationError.message);
+      setSubmitting(false);
+      return;
+    }
+
+    await refresh();
+    setSubmitting(false);
+  }
+
+  if (loading) {
+    return <div className="mx-auto max-w-reading px-space-4 py-space-5 text-body text-text-muted">Loading registration…</div>;
+  }
+
+  if (!tournament) {
+    return <div className="mx-auto max-w-reading px-space-4 py-space-5 text-body text-error-red">{error ?? "Tournament unavailable."}</div>;
+  }
+
+  return (
+    <div className="mx-auto flex max-w-reading flex-col gap-space-5 px-space-4 py-space-5">
+      <header className="flex flex-col gap-space-2">
+        <Link href={`/tournaments/${tournament.id}/overview`} className="text-caption text-text-link">← Overview</Link>
+        <h1 className="text-h1 text-text-primary">Register</h1>
+        <p className="text-body text-text-muted">{tournament.name}</p>
+      </header>
+
+      {entry ? (
+        <section className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`}>
+          <h2 className="text-h3 text-text-primary">Your entry</h2>
+          <dl className="grid grid-cols-2 gap-space-3 text-caption">
+            <div><dt className="text-text-muted">Registration</dt><dd className="capitalize text-text-primary">{entry.registration_status.toLowerCase().replaceAll("_", " ")}</dd></div>
+            <div><dt className="text-text-muted">Eligibility</dt><dd className="capitalize text-text-primary">{entry.eligibility_status.toLowerCase().replaceAll("_", " ")}</dd></div>
+            <div><dt className="text-text-muted">Check-in</dt><dd className="capitalize text-text-primary">{entry.check_in_status.toLowerCase().replaceAll("_", " ")}</dd></div>
+            <div><dt className="text-text-muted">Competition</dt><dd className="capitalize text-text-primary">{entry.competition_status.toLowerCase().replaceAll("_", " ")}</dd></div>
+          </dl>
+          <p className="text-caption text-text-muted">Payment, eligibility and competition status are tracked separately so one cannot silently change another.</p>
+        </section>
+      ) : tournament.status === "REGISTRATION_OPEN" ? (
+        <form onSubmit={register} className={`${TOURNAMENT_CARD} flex flex-col gap-space-4`}>
+          <div className="flex flex-col gap-space-1">
+            <h2 className="text-h3 text-text-primary">Enter tournament</h2>
+            <p className="text-caption text-text-muted">Your account is linked to this entry, while the tournament keeps its own historical participant identity.</p>
+          </div>
+          <label className="flex flex-col gap-space-2">
+            <span className="text-label text-text-primary">Display name</span>
+            <input required maxLength={80} value={displayName} onChange={(event) => setDisplayName(event.target.value)} className={TOURNAMENT_INPUT} placeholder="Name shown in the tournament" />
+          </label>
+          {error ? <p role="alert" className="text-body text-error-red">{error}</p> : null}
+          <button type="submit" className={TOURNAMENT_PRIMARY_BUTTON} disabled={submitting || displayName.trim().length === 0}>
+            {submitting ? "Registering…" : "Register"}
+          </button>
+        </form>
+      ) : (
+        <section className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`}>
+          <h2 className="text-h3 text-text-primary">Registration is not open</h2>
+          <p className="text-body text-text-muted">Current tournament state: {tournament.status.toLowerCase().replaceAll("_", " ")}.</p>
+          <Link href={`/tournaments/${tournament.id}/overview`} className={TOURNAMENT_SECONDARY_BUTTON}>Back to overview</Link>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/supabase/migrations/20260905200000_tournament_self_registration.sql
+++ b/supabase/migrations/20260905200000_tournament_self_registration.sql
@@ -1,0 +1,90 @@
+-- UI-002 — authenticated participant self-registration without weakening tournament_entry RLS.
+-- Organizer-created guest/imported entries continue through the T-003 admin path.
+
+create or replace function public.register_self_for_tournament(
+  target_tournament_id uuid,
+  participant_display_name text
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  uid uuid := auth.uid();
+  target public.tournament;
+  existing_entry_id uuid;
+  new_entry_id uuid;
+begin
+  if uid is null then
+    raise exception 'authentication required' using errcode = '42501';
+  end if;
+
+  if participant_display_name is null or length(btrim(participant_display_name)) = 0 then
+    raise exception 'display name required' using errcode = 'check_violation';
+  end if;
+
+  select * into target
+    from public.tournament
+   where id = target_tournament_id
+     and deleted_at is null;
+
+  if target.id is null then
+    raise exception 'tournament not found' using errcode = 'P0002';
+  end if;
+
+  if target.status <> 'REGISTRATION_OPEN' then
+    raise exception 'registration is not open' using errcode = 'check_violation';
+  end if;
+
+  select e.id into existing_entry_id
+    from public.tournament_entry e
+    join public.tournament_entry_identity i on i.tournament_entry_id = e.id
+   where e.tournament_id = target.id
+     and e.deleted_at is null
+     and i.claimed_angler_id = uid
+   limit 1;
+
+  if existing_entry_id is not null then
+    return existing_entry_id;
+  end if;
+
+  insert into public.tournament_entry (
+    tournament_id,
+    organization_id,
+    registration_status,
+    eligibility_status,
+    check_in_status,
+    competition_status
+  ) values (
+    target.id,
+    target.organization_id,
+    'PENDING',
+    'UNKNOWN',
+    'NOT_CHECKED_IN',
+    'NOT_STARTED'
+  ) returning id into new_entry_id;
+
+  insert into public.tournament_entry_identity (
+    tournament_entry_id,
+    identity_type,
+    display_name,
+    claimed_angler_id,
+    claimed_at
+  ) values (
+    new_entry_id,
+    'REGISTERED_USER',
+    btrim(participant_display_name),
+    uid,
+    now()
+  );
+
+  return new_entry_id;
+end;
+$$;
+
+revoke all on function public.register_self_for_tournament(uuid, text) from public;
+grant execute on function public.register_self_for_tournament(uuid, text) to authenticated;
+
+comment on function public.register_self_for_tournament(uuid, text) is
+  'Creates one authenticated TournamentEntry while preserving admin-only raw entry writes. Payment and eligibility remain separate states.';


### PR DESCRIPTION
- Adds an authenticated self-registration RPC that creates a TournamentEntry without weakening the admin-only raw entry RLS path.
- Keeps registration, eligibility, payment/check-in, and competition state separate.
- Adds `/tournaments/[id]/register` with real entry status display and self-registration against REGISTRATION_OPEN tournaments.
- Preserves organizer-created guest/imported entry paths from T-003; no claim-token or private contact data is exposed.

Stacked on UI-001 / PR #103. Merge in dependency order.

Closes #99