### PR TITLE
BUG-105 harden tournament runtime loading

### DIFF
--- a/src/app/(app)/tournaments/error.tsx
+++ b/src/app/(app)/tournaments/error.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import Link from "next/link";
+
+import { TOURNAMENT_CARD, TOURNAMENT_PRIMARY_BUTTON, TOURNAMENT_SECONDARY_BUTTON } from "@/features/tournaments/ui-classes";
+
+export default function TournamentError({ reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <div className="mx-auto flex max-w-reading flex-col gap-space-5 px-space-4 py-space-5">
+      <header className="flex flex-col gap-space-2">
+        <h1 className="text-h1 text-text-primary">Tournaments</h1>
+        <p className="text-body text-text-muted">This tournament page hit an unexpected error.</p>
+      </header>
+
+      <section className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`} role="alert">
+        <p className="text-body-strong text-error-red">The page could not finish loading.</p>
+        <p className="text-caption text-text-muted">
+          Your app is still available. Retry this page, or return to the calendar while the tournament data connection recovers.
+        </p>
+        <button type="button" className={TOURNAMENT_PRIMARY_BUTTON} onClick={reset}>
+          Try again
+        </button>
+        <Link href="/" className={TOURNAMENT_SECONDARY_BUTTON}>
+          Back to calendar
+        </Link>
+      </section>
+    </div>
+  );
+}

--- a/src/features/tournaments/components/tournament-hub.tsx
+++ b/src/features/tournaments/components/tournament-hub.tsx
@@ -35,32 +35,39 @@ export function TournamentHub() {
 
   useEffect(() => {
     let cancelled = false;
-    const supabase = createClient();
 
     async function load() {
-      const [ownedResult, publicResult] = await Promise.all([
-        supabase
-          .from("tournament")
-          .select("id,name,status,visibility,starts_at,ends_at,organization_id")
-          .is("deleted_at", null)
-          .order("created_at", { ascending: false }),
-        supabase
-          .from("public_tournament")
-          .select("id,name,status,visibility,starts_at,ends_at,organization_id")
-          .eq("visibility", "PUBLIC")
-          .order("created_at", { ascending: false })
-          .limit(12),
-      ]);
+      try {
+        const supabase = createClient();
+        const [ownedResult, publicResult] = await Promise.all([
+          supabase
+            .from("tournament")
+            .select("id,name,status,visibility,starts_at,ends_at,organization_id")
+            .is("deleted_at", null)
+            .order("created_at", { ascending: false }),
+          supabase
+            .from("public_tournament")
+            .select("id,name,status,visibility,starts_at,ends_at,organization_id")
+            .eq("visibility", "PUBLIC")
+            .order("created_at", { ascending: false })
+            .limit(12),
+        ]);
 
-      if (cancelled) return;
-      const firstError = ownedResult.error ?? publicResult.error;
-      if (firstError) {
-        setError(firstError.message);
-      } else {
+        if (cancelled) return;
+        const firstError = ownedResult.error ?? publicResult.error;
+        if (firstError) {
+          setError(firstError.message);
+          return;
+        }
+
         setOwned((ownedResult.data ?? []) as TournamentCardData[]);
         setPublicTournaments((publicResult.data ?? []) as TournamentCardData[]);
+      } catch (cause) {
+        if (cancelled) return;
+        setError(cause instanceof Error ? cause.message : "Tournament data could not be loaded.");
+      } finally {
+        if (!cancelled) setLoading(false);
       }
-      setLoading(false);
     }
 
     void load();
@@ -87,9 +94,14 @@ export function TournamentHub() {
 
       {loading ? <p className="text-body text-text-muted">Loading tournaments…</p> : null}
       {error ? (
-        <div className={`${TOURNAMENT_CARD} flex flex-col gap-space-2`} role="alert">
-          <p className="text-body-strong text-error-red">Tournament data could not be loaded.</p>
-          <p className="text-caption text-text-muted">{error}</p>
+        <div className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`} role="alert">
+          <div className="flex flex-col gap-space-1">
+            <p className="text-body-strong text-error-red">Tournament data could not be loaded.</p>
+            <p className="text-caption text-text-muted">{error}</p>
+          </div>
+          <button type="button" className={TOURNAMENT_PRIMARY_BUTTON} onClick={() => window.location.reload()}>
+            Try again
+          </button>
         </div>
       ) : null}
 


### PR DESCRIPTION
- Wraps the tournament hub's Supabase client/query path in explicit runtime exception handling so client construction/query failures degrade into a visible error card instead of a dead page.
- Adds a `/tournaments` route error boundary with retry and return-to-calendar actions.
- Keeps the shell visible even when tournament data cannot load.
- Independent of UI-002 registration work.

Runtime logs from the Vercel preview could not be inspected because the connected Vercel session lacks authorization for the `etdev2s-projects` team scope, so this fix hardens the known failure boundary without claiming an unobserved backend root cause.

Closes #105