### PR TITLE
DEV-DEMO local tournament fallback without Supabase

### DIFF
--- a/src/features/tournaments/components/create-tournament-form.tsx
+++ b/src/features/tournaments/components/create-tournament-form.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { createClient } from "@/lib/supabase/client";
+import { createDemoTournament, hasSupabaseBrowserConfig } from "../demo-store";
 import { TOURNAMENT_INPUT, TOURNAMENT_PRIMARY_BUTTON, TOURNAMENT_SECONDARY_BUTTON } from "../ui-classes";
 
 const VISIBILITIES = ["PRIVATE", "INVITE_ONLY", "UNLISTED", "PUBLIC"] as const;
@@ -20,32 +21,40 @@ export function CreateTournamentForm() {
   const [endsAt, setEndsAt] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const demoMode = !hasSupabaseBrowserConfig();
 
   async function submit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setSubmitting(true);
     setError(null);
 
-    const supabase = createClient();
-    const { data: authData, error: authError } = await supabase.auth.getUser();
-    if (authError || !authData.user) {
-      setError("Sign in before creating a tournament.");
-      setSubmitting(false);
+    if (demoMode) {
+      const tournament = createDemoTournament({
+        name: name.trim(),
+        visibility,
+        starts_at: toIsoOrNull(startsAt),
+        ends_at: toIsoOrNull(endsAt),
+      });
+      router.push(`/tournaments/${tournament.id}/overview`);
+      router.refresh();
       return;
     }
 
-    const { data: organizationId, error: organizationError } = await supabase.rpc(
-      "ensure_personal_organization",
-    );
-    if (organizationError || !organizationId) {
-      setError(organizationError?.message ?? "Your tournament workspace could not be prepared.");
-      setSubmitting(false);
-      return;
-    }
+    try {
+      const supabase = createClient();
+      const { data: authData, error: authError } = await supabase.auth.getUser();
+      if (authError || !authData.user) {
+        setError("Sign in before creating a tournament.");
+        return;
+      }
 
-    const { data, error: insertError } = await supabase
-      .from("tournament")
-      .insert({
+      const { data: organizationId, error: organizationError } = await supabase.rpc("ensure_personal_organization");
+      if (organizationError || !organizationId) {
+        setError(organizationError?.message ?? "Your tournament workspace could not be prepared.");
+        return;
+      }
+
+      const { data, error: insertError } = await supabase.from("tournament").insert({
         organization_id: organizationId,
         name: name.trim(),
         visibility,
@@ -53,45 +62,35 @@ export function CreateTournamentForm() {
         starts_at: toIsoOrNull(startsAt),
         ends_at: toIsoOrNull(endsAt),
         created_by: authData.user.id,
-      })
-      .select("id")
-      .single();
+      }).select("id").single();
 
-    if (insertError) {
-      setError(insertError.message);
+      if (insertError) {
+        setError(insertError.message);
+        return;
+      }
+
+      router.push(`/tournaments/${data.id}/overview`);
+      router.refresh();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Tournament could not be created.");
+    } finally {
       setSubmitting(false);
-      return;
     }
-
-    router.push(`/tournaments/${data.id}/overview`);
-    router.refresh();
   }
 
   return (
     <form onSubmit={submit} className="flex flex-col gap-space-5">
+      {demoMode ? <p className="text-caption text-text-muted">Demo mode · this tournament will be saved only on this device.</p> : null}
       <label className="flex flex-col gap-space-2">
         <span className="text-label text-text-primary">Tournament name</span>
-        <input
-          required
-          maxLength={120}
-          value={name}
-          onChange={(event) => setName(event.target.value)}
-          className={TOURNAMENT_INPUT}
-          placeholder="Saturday Yellowtail Challenge"
-        />
+        <input required maxLength={120} value={name} onChange={(event) => setName(event.target.value)} className={TOURNAMENT_INPUT} placeholder="Saturday Yellowtail Challenge" />
       </label>
 
       <fieldset className="flex flex-col gap-space-2">
         <legend className="text-label text-text-primary">Who can see it?</legend>
         <div className="grid grid-cols-2 gap-space-2">
           {VISIBILITIES.map((option) => (
-            <button
-              key={option}
-              type="button"
-              onClick={() => setVisibility(option)}
-              aria-pressed={visibility === option}
-              className={visibility === option ? TOURNAMENT_PRIMARY_BUTTON : TOURNAMENT_SECONDARY_BUTTON}
-            >
+            <button key={option} type="button" onClick={() => setVisibility(option)} aria-pressed={visibility === option} className={visibility === option ? TOURNAMENT_PRIMARY_BUTTON : TOURNAMENT_SECONDARY_BUTTON}>
               {option.toLowerCase().replaceAll("_", " ")}
             </button>
           ))}
@@ -109,15 +108,9 @@ export function CreateTournamentForm() {
         </label>
       </div>
 
-      <p className="text-caption text-text-muted">
-        This starts as a draft. Rules, scoring, verification and boundaries can be configured before it goes live.
-      </p>
-
+      <p className="text-caption text-text-muted">This starts as a draft. Rules, scoring, verification and boundaries can be configured before it goes live.</p>
       {error ? <p className="text-body text-error-red" role="alert">{error}</p> : null}
-
-      <button type="submit" disabled={submitting || name.trim().length === 0} className={TOURNAMENT_PRIMARY_BUTTON}>
-        {submitting ? "Creating…" : "Create tournament"}
-      </button>
+      <button type="submit" disabled={submitting || name.trim().length === 0} className={TOURNAMENT_PRIMARY_BUTTON}>{submitting ? "Creating…" : "Create tournament"}</button>
     </form>
   );
 }

--- a/src/features/tournaments/components/tournament-hub.tsx
+++ b/src/features/tournaments/components/tournament-hub.tsx
@@ -4,17 +4,10 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { createClient } from "@/lib/supabase/client";
+import { getDemoTournaments, hasSupabaseBrowserConfig, type DemoTournament } from "../demo-store";
 import { TOURNAMENT_CARD, TOURNAMENT_PRIMARY_BUTTON } from "../ui-classes";
 
-type TournamentCardData = {
-  id: string;
-  name: string;
-  status: string;
-  visibility: string;
-  starts_at: string | null;
-  ends_at: string | null;
-  organization_id: string;
-};
+type TournamentCardData = Pick<DemoTournament, "id" | "name" | "status" | "visibility" | "starts_at" | "ends_at" | "organization_id">;
 
 function statusLabel(status: string) {
   return status.toLowerCase().replaceAll("_", " ");
@@ -22,9 +15,7 @@ function statusLabel(status: string) {
 
 function whenLabel(value: string | null) {
   if (!value) return "Date not set";
-  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", year: "numeric" }).format(
-    new Date(value),
-  );
+  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", year: "numeric" }).format(new Date(value));
 }
 
 export function TournamentHub() {
@@ -32,130 +23,91 @@ export function TournamentHub() {
   const [publicTournaments, setPublicTournaments] = useState<TournamentCardData[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [demoMode, setDemoMode] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
 
     async function load() {
+      if (!hasSupabaseBrowserConfig()) {
+        if (cancelled) return;
+        const demo = getDemoTournaments();
+        setDemoMode(true);
+        setOwned(demo);
+        setPublicTournaments(demo.filter((item) => item.visibility === "PUBLIC"));
+        setLoading(false);
+        return;
+      }
+
       try {
         const supabase = createClient();
         const [ownedResult, publicResult] = await Promise.all([
-          supabase
-            .from("tournament")
-            .select("id,name,status,visibility,starts_at,ends_at,organization_id")
-            .is("deleted_at", null)
-            .order("created_at", { ascending: false }),
-          supabase
-            .from("public_tournament")
-            .select("id,name,status,visibility,starts_at,ends_at,organization_id")
-            .eq("visibility", "PUBLIC")
-            .order("created_at", { ascending: false })
-            .limit(12),
+          supabase.from("tournament").select("id,name,status,visibility,starts_at,ends_at,organization_id").is("deleted_at", null).order("created_at", { ascending: false }),
+          supabase.from("public_tournament").select("id,name,status,visibility,starts_at,ends_at,organization_id").eq("visibility", "PUBLIC").order("created_at", { ascending: false }).limit(12),
         ]);
 
         if (cancelled) return;
         const firstError = ownedResult.error ?? publicResult.error;
-        if (firstError) {
-          setError(firstError.message);
-          return;
+        if (firstError) setError(firstError.message);
+        else {
+          setOwned((ownedResult.data ?? []) as TournamentCardData[]);
+          setPublicTournaments((publicResult.data ?? []) as TournamentCardData[]);
         }
-
-        setOwned((ownedResult.data ?? []) as TournamentCardData[]);
-        setPublicTournaments((publicResult.data ?? []) as TournamentCardData[]);
       } catch (cause) {
-        if (cancelled) return;
-        setError(cause instanceof Error ? cause.message : "Tournament data could not be loaded.");
+        if (!cancelled) setError(cause instanceof Error ? cause.message : "Tournament data could not be loaded.");
       } finally {
         if (!cancelled) setLoading(false);
       }
     }
 
     void load();
-    return () => {
-      cancelled = true;
-    };
+    return () => { cancelled = true; };
   }, []);
 
   return (
     <div className="mx-auto flex max-w-reading flex-col gap-space-6 px-space-4 py-space-5">
       <header className="flex flex-col gap-space-3">
-        <div className="flex items-start justify-between gap-space-4">
-          <div className="flex flex-col gap-space-1">
-            <h1 className="text-h1 text-text-primary">Tournaments</h1>
-            <p className="text-body text-text-muted">
-              Run a private trip competition or a full public event from the same tournament engine.
-            </p>
-          </div>
+        <div className="flex flex-col gap-space-1">
+          <h1 className="text-h1 text-text-primary">Tournaments</h1>
+          <p className="text-body text-text-muted">Run a private trip competition or a full public event from the same tournament engine.</p>
+          {demoMode ? <p className="text-caption text-text-muted">Demo mode · saved on this device until Supabase is connected.</p> : null}
         </div>
-        <Link href="/tournaments/new" className={TOURNAMENT_PRIMARY_BUTTON}>
-          Create tournament
-        </Link>
+        <Link href="/tournaments/new" className={TOURNAMENT_PRIMARY_BUTTON}>Create tournament</Link>
       </header>
 
       {loading ? <p className="text-body text-text-muted">Loading tournaments…</p> : null}
       {error ? (
         <div className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`} role="alert">
-          <div className="flex flex-col gap-space-1">
-            <p className="text-body-strong text-error-red">Tournament data could not be loaded.</p>
-            <p className="text-caption text-text-muted">{error}</p>
-          </div>
-          <button type="button" className={TOURNAMENT_PRIMARY_BUTTON} onClick={() => window.location.reload()}>
-            Try again
-          </button>
+          <p className="text-body-strong text-error-red">Tournament data could not be loaded.</p>
+          <p className="text-caption text-text-muted">{error}</p>
+          <button type="button" className={TOURNAMENT_PRIMARY_BUTTON} onClick={() => window.location.reload()}>Try again</button>
         </div>
       ) : null}
 
       {!loading && !error ? (
         <>
-          <TournamentSection
-            title="My tournaments"
-            empty="You have not created or joined a tournament yet."
-            tournaments={owned}
-          />
-          <TournamentSection
-            title="Public tournaments"
-            empty="No public tournaments are available right now."
-            tournaments={publicTournaments.filter((item) => !owned.some((own) => own.id === item.id))}
-          />
+          <TournamentSection title="My tournaments" empty="You have not created or joined a tournament yet." tournaments={owned} />
+          <TournamentSection title="Public tournaments" empty="No public tournaments are available right now." tournaments={publicTournaments.filter((item) => !owned.some((own) => own.id === item.id))} />
         </>
       ) : null}
     </div>
   );
 }
 
-function TournamentSection({
-  title,
-  empty,
-  tournaments,
-}: {
-  title: string;
-  empty: string;
-  tournaments: TournamentCardData[];
-}) {
+function TournamentSection({ title, empty, tournaments }: { title: string; empty: string; tournaments: TournamentCardData[] }) {
   return (
     <section className="flex flex-col gap-space-3" aria-labelledby={`${title.replaceAll(" ", "-").toLowerCase()}-heading`}>
-      <h2 id={`${title.replaceAll(" ", "-").toLowerCase()}-heading`} className="text-h3 text-text-primary">
-        {title}
-      </h2>
-      {tournaments.length === 0 ? (
-        <p className={`${TOURNAMENT_CARD} text-body text-text-muted`}>{empty}</p>
-      ) : (
+      <h2 id={`${title.replaceAll(" ", "-").toLowerCase()}-heading`} className="text-h3 text-text-primary">{title}</h2>
+      {tournaments.length === 0 ? <p className={`${TOURNAMENT_CARD} text-body text-text-muted`}>{empty}</p> : (
         <ul className="flex flex-col gap-space-3">
           {tournaments.map((tournament) => (
             <li key={tournament.id}>
-              <Link
-                href={`/tournaments/${tournament.id}/overview`}
-                className={`${TOURNAMENT_CARD} flex min-h-touch-floor flex-col gap-space-2`}
-              >
+              <Link href={`/tournaments/${tournament.id}/overview`} className={`${TOURNAMENT_CARD} flex min-h-touch-floor flex-col gap-space-2`}>
                 <span className="flex flex-wrap items-start justify-between gap-space-2">
                   <span className="text-body-strong text-text-primary">{tournament.name}</span>
-                  <span className="rounded-full border border-hairline px-space-2 py-space-1 text-caption capitalize text-text-muted">
-                    {statusLabel(tournament.status)}
-                  </span>
+                  <span className="rounded-full border border-hairline px-space-2 py-space-1 text-caption capitalize text-text-muted">{statusLabel(tournament.status)}</span>
                 </span>
-                <span className="text-caption text-text-muted">
-                  {whenLabel(tournament.starts_at)} · {tournament.visibility.toLowerCase().replaceAll("_", " ")}
-                </span>
+                <span className="text-caption text-text-muted">{whenLabel(tournament.starts_at)} · {tournament.visibility.toLowerCase().replaceAll("_", " ")}</span>
               </Link>
             </li>
           ))}

--- a/src/features/tournaments/components/tournament-overview.tsx
+++ b/src/features/tournaments/components/tournament-overview.tsx
@@ -5,21 +5,10 @@ import { useEffect, useState } from "react";
 
 import { createClient } from "@/lib/supabase/client";
 import type { TournamentStatus } from "@/core/tournaments/lifecycle";
+import { getDemoTournament, hasSupabaseBrowserConfig, type DemoTournament } from "../demo-store";
 import { TOURNAMENT_CARD, TOURNAMENT_SECONDARY_BUTTON } from "../ui-classes";
 
-type TournamentOverviewData = {
-  id: string;
-  name: string;
-  status: TournamentStatus;
-  visibility: string;
-  starts_at: string | null;
-  ends_at: string | null;
-  organization_id: string;
-  active_rule_set_version_id: string | null;
-  active_scoring_version_id: string | null;
-  active_verification_policy_version_id: string | null;
-  active_boundary_version_id: string | null;
-};
+type TournamentOverviewData = DemoTournament & { status: TournamentStatus };
 
 const NAV_ITEMS = [
   ["Overview", "overview"],
@@ -38,116 +27,78 @@ export function TournamentOverview({ tournamentId }: { tournamentId: string }) {
   const [tournament, setTournament] = useState<TournamentOverviewData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const demoMode = !hasSupabaseBrowserConfig();
 
   useEffect(() => {
     let cancelled = false;
-    const supabase = createClient();
 
     async function load() {
-      const { data, error: queryError } = await supabase
-        .from("tournament")
-        .select(
-          "id,name,status,visibility,starts_at,ends_at,organization_id,active_rule_set_version_id,active_scoring_version_id,active_verification_policy_version_id,active_boundary_version_id",
-        )
-        .eq("id", tournamentId)
-        .is("deleted_at", null)
-        .maybeSingle();
+      if (demoMode) {
+        const demo = getDemoTournament(tournamentId);
+        if (!cancelled) {
+          if (demo) setTournament(demo as TournamentOverviewData);
+          else setError("Demo tournament not found on this device.");
+          setLoading(false);
+        }
+        return;
+      }
 
-      if (cancelled) return;
-      if (queryError) setError(queryError.message);
-      else if (!data) setError("Tournament not found or you do not have access.");
-      else setTournament(data as TournamentOverviewData);
-      setLoading(false);
+      try {
+        const supabase = createClient();
+        const { data, error: queryError } = await supabase
+          .from("tournament")
+          .select("id,name,status,visibility,starts_at,ends_at,organization_id,active_rule_set_version_id,active_scoring_version_id,active_verification_policy_version_id,active_boundary_version_id")
+          .eq("id", tournamentId)
+          .is("deleted_at", null)
+          .maybeSingle();
+
+        if (cancelled) return;
+        if (queryError) setError(queryError.message);
+        else if (!data) setError("Tournament not found or you do not have access.");
+        else setTournament(data as TournamentOverviewData);
+      } catch (cause) {
+        if (!cancelled) setError(cause instanceof Error ? cause.message : "Tournament unavailable.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
     }
 
     void load();
-    return () => {
-      cancelled = true;
-    };
-  }, [tournamentId]);
+    return () => { cancelled = true; };
+  }, [demoMode, tournamentId]);
 
-  if (loading) {
-    return <div className="mx-auto max-w-reading px-space-4 py-space-5 text-body text-text-muted">Loading tournament…</div>;
-  }
-
+  if (loading) return <div className="mx-auto max-w-reading px-space-4 py-space-5 text-body text-text-muted">Loading tournament…</div>;
   if (error || !tournament) {
-    return (
-      <div className="mx-auto flex max-w-reading flex-col gap-space-4 px-space-4 py-space-5">
-        <p className={`${TOURNAMENT_CARD} text-body text-error-red`} role="alert">{error ?? "Tournament unavailable."}</p>
-        <Link href="/tournaments" className={TOURNAMENT_SECONDARY_BUTTON}>Back to tournaments</Link>
-      </div>
-    );
+    return <div className="mx-auto flex max-w-reading flex-col gap-space-4 px-space-4 py-space-5"><p className={`${TOURNAMENT_CARD} text-body text-error-red`} role="alert">{error ?? "Tournament unavailable."}</p><Link href="/tournaments" className={TOURNAMENT_SECONDARY_BUTTON}>Back to tournaments</Link></div>;
   }
 
-  const versionsReady = [
-    tournament.active_rule_set_version_id,
-    tournament.active_scoring_version_id,
-    tournament.active_verification_policy_version_id,
-    tournament.active_boundary_version_id,
-  ].filter(Boolean).length;
+  const versionsReady = [tournament.active_rule_set_version_id, tournament.active_scoring_version_id, tournament.active_verification_policy_version_id, tournament.active_boundary_version_id].filter(Boolean).length;
 
   return (
     <div className="mx-auto flex max-w-reading flex-col gap-space-5 px-space-4 py-space-5">
       <header className="flex flex-col gap-space-3">
         <Link href="/tournaments" className="text-caption text-text-link">← Tournaments</Link>
         <div className="flex flex-col gap-space-1">
-          <div className="flex flex-wrap items-center justify-between gap-space-2">
-            <h1 className="text-h1 text-text-primary">{tournament.name}</h1>
-            <span className="rounded-full border border-hairline px-space-3 py-space-1 text-caption capitalize text-text-muted">
-              {tournament.status.toLowerCase().replaceAll("_", " ")}
-            </span>
-          </div>
-          <p className="text-body text-text-muted">
-            {formatDate(tournament.starts_at)} · {tournament.visibility.toLowerCase().replaceAll("_", " ")}
-          </p>
+          <div className="flex flex-wrap items-center justify-between gap-space-2"><h1 className="text-h1 text-text-primary">{tournament.name}</h1><span className="rounded-full border border-hairline px-space-3 py-space-1 text-caption capitalize text-text-muted">{tournament.status.toLowerCase().replaceAll("_", " ")}</span></div>
+          <p className="text-body text-text-muted">{formatDate(tournament.starts_at)} · {tournament.visibility.toLowerCase().replaceAll("_", " ")}</p>
+          {demoMode ? <p className="text-caption text-text-muted">Demo mode · local device data.</p> : null}
         </div>
       </header>
 
-      <nav aria-label="Tournament sections" className="overflow-x-auto">
-        <ul className="flex min-w-max gap-space-2 pb-space-1">
-          {NAV_ITEMS.map(([label, route]) => (
-            <li key={route}>
-              <Link
-                href={`/tournaments/${tournament.id}/${route}`}
-                className="inline-flex min-h-touch-floor items-center rounded-full border border-hairline bg-surface px-space-3 text-label text-text-primary"
-              >
-                {label}
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </nav>
+      <nav aria-label="Tournament sections" className="overflow-x-auto"><ul className="flex min-w-max gap-space-2 pb-space-1">{NAV_ITEMS.map(([label, route]) => <li key={route}><Link href={`/tournaments/${tournament.id}/${route}`} className="inline-flex min-h-touch-floor items-center rounded-full border border-hairline bg-surface px-space-3 text-label text-text-primary">{label}</Link></li>)}</ul></nav>
 
       <section className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`} aria-labelledby="readiness-heading">
-        <div className="flex items-center justify-between gap-space-3">
-          <h2 id="readiness-heading" className="text-h3 text-text-primary">Competition readiness</h2>
-          <span className="text-caption text-text-muted">{versionsReady}/4 locked inputs selected</span>
-        </div>
-        <div className="h-space-2 overflow-hidden rounded-full bg-surface-muted" aria-hidden="true">
-          <div className="h-full bg-action" style={{ width: `${versionsReady * 25}%` }} />
-        </div>
-        <p className="text-caption text-text-muted">
-          Rules, scoring, verification policy and tournament boundaries must all be frozen before READY can move to LIVE.
-        </p>
+        <div className="flex items-center justify-between gap-space-3"><h2 id="readiness-heading" className="text-h3 text-text-primary">Competition readiness</h2><span className="text-caption text-text-muted">{versionsReady}/4 locked inputs selected</span></div>
+        <div className="h-space-2 overflow-hidden rounded-full bg-surface-muted" aria-hidden="true"><div className="h-full bg-action" style={{ width: `${versionsReady * 25}%` }} /></div>
+        <p className="text-caption text-text-muted">Rules, scoring, verification policy and tournament boundaries must all be frozen before READY can move to LIVE.</p>
       </section>
 
       <section className="grid gap-space-3 sm:grid-cols-2" aria-label="Tournament summary">
-        <article className={`${TOURNAMENT_CARD} flex flex-col gap-space-1`}>
-          <span className="text-caption text-text-muted">Starts</span>
-          <span className="text-body-strong text-text-primary">{formatDate(tournament.starts_at)}</span>
-        </article>
-        <article className={`${TOURNAMENT_CARD} flex flex-col gap-space-1`}>
-          <span className="text-caption text-text-muted">Ends</span>
-          <span className="text-body-strong text-text-primary">{formatDate(tournament.ends_at)}</span>
-        </article>
+        <article className={`${TOURNAMENT_CARD} flex flex-col gap-space-1`}><span className="text-caption text-text-muted">Starts</span><span className="text-body-strong text-text-primary">{formatDate(tournament.starts_at)}</span></article>
+        <article className={`${TOURNAMENT_CARD} flex flex-col gap-space-1`}><span className="text-caption text-text-muted">Ends</span><span className="text-body-strong text-text-primary">{formatDate(tournament.ends_at)}</span></article>
       </section>
 
-      <section className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`}>
-        <h2 className="text-h3 text-text-primary">Next actions</h2>
-        <p className="text-body text-text-muted">
-          Registration, live catch logging, judging, operations and finance screens are being added in the next UI lanes without changing this tournament contract.
-        </p>
-      </section>
+      <section className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`}><h2 className="text-h3 text-text-primary">Next actions</h2><p className="text-body text-text-muted">Registration, live catch logging, judging, operations and finance screens are being added in the next UI lanes without changing this tournament contract.</p></section>
     </div>
   );
 }

--- a/src/features/tournaments/components/tournament-registration.tsx
+++ b/src/features/tournaments/components/tournament-registration.tsx
@@ -4,22 +4,11 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { createClient } from "@/lib/supabase/client";
+import { getDemoEntry, getDemoTournament, hasSupabaseBrowserConfig, registerDemoEntry, type DemoEntry } from "../demo-store";
 import { TOURNAMENT_CARD, TOURNAMENT_INPUT, TOURNAMENT_PRIMARY_BUTTON, TOURNAMENT_SECONDARY_BUTTON } from "../ui-classes";
 
-type TournamentRegistrationState = {
-  id: string;
-  name: string;
-  status: string;
-  visibility: string;
-};
-
-type ExistingEntry = {
-  id: string;
-  registration_status: string;
-  eligibility_status: string;
-  check_in_status: string;
-  competition_status: string;
-};
+type TournamentRegistrationState = { id: string; name: string; status: string; visibility: string };
+type ExistingEntry = Pick<DemoEntry, "id" | "registration_status" | "eligibility_status" | "check_in_status" | "competition_status">;
 
 export function TournamentRegistration({ tournamentId }: { tournamentId: string }) {
   const [tournament, setTournament] = useState<TournamentRegistrationState | null>(null);
@@ -28,80 +17,79 @@ export function TournamentRegistration({ tournamentId }: { tournamentId: string 
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const demoMode = !hasSupabaseBrowserConfig();
 
   async function refresh() {
-    const supabase = createClient();
-    const { data: authData } = await supabase.auth.getUser();
-    const { data: tournamentData, error: tournamentError } = await supabase
-      .from("tournament")
-      .select("id,name,status,visibility")
-      .eq("id", tournamentId)
-      .maybeSingle();
-
-    if (tournamentError || !tournamentData) {
-      setError(tournamentError?.message ?? "Tournament unavailable.");
+    if (demoMode) {
+      const demoTournament = getDemoTournament(tournamentId);
+      if (!demoTournament) {
+        setError("Demo tournament unavailable on this device.");
+        setLoading(false);
+        return;
+      }
+      setTournament({ id: demoTournament.id, name: demoTournament.name, status: demoTournament.status, visibility: demoTournament.visibility });
+      setEntry(getDemoEntry(tournamentId));
       setLoading(false);
       return;
     }
 
-    setTournament(tournamentData as TournamentRegistrationState);
-
-    if (authData.user) {
-      const { data: identityRows } = await supabase
-        .from("tournament_entry_identity")
-        .select("tournament_entry_id")
-        .eq("claimed_angler_id", authData.user.id);
-
-      const candidateIds = (identityRows ?? []).map((row) => row.tournament_entry_id);
-      if (candidateIds.length > 0) {
-        const { data: entryData } = await supabase
-          .from("tournament_entry")
-          .select("id,registration_status,eligibility_status,check_in_status,competition_status")
-          .eq("tournament_id", tournamentId)
-          .in("id", candidateIds)
-          .is("deleted_at", null)
-          .maybeSingle();
-        setEntry((entryData as ExistingEntry | null) ?? null);
+    try {
+      const supabase = createClient();
+      const { data: authData } = await supabase.auth.getUser();
+      const { data: tournamentData, error: tournamentError } = await supabase.from("tournament").select("id,name,status,visibility").eq("id", tournamentId).maybeSingle();
+      if (tournamentError || !tournamentData) {
+        setError(tournamentError?.message ?? "Tournament unavailable.");
+        setLoading(false);
+        return;
       }
-    }
 
-    setLoading(false);
+      setTournament(tournamentData as TournamentRegistrationState);
+      if (authData.user) {
+        const { data: identityRows } = await supabase.from("tournament_entry_identity").select("tournament_entry_id").eq("claimed_angler_id", authData.user.id);
+        const candidateIds = (identityRows ?? []).map((row) => row.tournament_entry_id);
+        if (candidateIds.length > 0) {
+          const { data: entryData } = await supabase.from("tournament_entry").select("id,registration_status,eligibility_status,check_in_status,competition_status").eq("tournament_id", tournamentId).in("id", candidateIds).is("deleted_at", null).maybeSingle();
+          setEntry((entryData as ExistingEntry | null) ?? null);
+        }
+      }
+      setLoading(false);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Tournament registration could not be loaded.");
+      setLoading(false);
+    }
   }
 
   useEffect(() => {
     void Promise.resolve().then(refresh);
-    // tournamentId is the only external input; refresh intentionally owns the client instance.
+    // refresh depends only on tournamentId/demoMode and intentionally owns the client instance.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tournamentId]);
+  }, [demoMode, tournamentId]);
 
   async function register(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setSubmitting(true);
     setError(null);
 
-    const supabase = createClient();
-    const { error: registrationError } = await supabase.rpc("register_self_for_tournament", {
-      target_tournament_id: tournamentId,
-      participant_display_name: displayName.trim(),
-    });
-
-    if (registrationError) {
-      setError(registrationError.message);
+    if (demoMode) {
+      setEntry(registerDemoEntry(tournamentId, displayName.trim()));
       setSubmitting(false);
       return;
     }
 
-    await refresh();
-    setSubmitting(false);
+    try {
+      const supabase = createClient();
+      const { error: registrationError } = await supabase.rpc("register_self_for_tournament", { target_tournament_id: tournamentId, participant_display_name: displayName.trim() });
+      if (registrationError) setError(registrationError.message);
+      else await refresh();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Registration failed.");
+    } finally {
+      setSubmitting(false);
+    }
   }
 
-  if (loading) {
-    return <div className="mx-auto max-w-reading px-space-4 py-space-5 text-body text-text-muted">Loading registration…</div>;
-  }
-
-  if (!tournament) {
-    return <div className="mx-auto max-w-reading px-space-4 py-space-5 text-body text-error-red">{error ?? "Tournament unavailable."}</div>;
-  }
+  if (loading) return <div className="mx-auto max-w-reading px-space-4 py-space-5 text-body text-text-muted">Loading registration…</div>;
+  if (!tournament) return <div className="mx-auto max-w-reading px-space-4 py-space-5 text-body text-error-red">{error ?? "Tournament unavailable."}</div>;
 
   return (
     <div className="mx-auto flex max-w-reading flex-col gap-space-5 px-space-4 py-space-5">
@@ -109,6 +97,7 @@ export function TournamentRegistration({ tournamentId }: { tournamentId: string 
         <Link href={`/tournaments/${tournament.id}/overview`} className="text-caption text-text-link">← Overview</Link>
         <h1 className="text-h1 text-text-primary">Register</h1>
         <p className="text-body text-text-muted">{tournament.name}</p>
+        {demoMode ? <p className="text-caption text-text-muted">Demo mode · registration is saved only on this device.</p> : null}
       </header>
 
       {entry ? (
@@ -124,25 +113,13 @@ export function TournamentRegistration({ tournamentId }: { tournamentId: string 
         </section>
       ) : tournament.status === "REGISTRATION_OPEN" ? (
         <form onSubmit={register} className={`${TOURNAMENT_CARD} flex flex-col gap-space-4`}>
-          <div className="flex flex-col gap-space-1">
-            <h2 className="text-h3 text-text-primary">Enter tournament</h2>
-            <p className="text-caption text-text-muted">Your account is linked to this entry, while the tournament keeps its own historical participant identity.</p>
-          </div>
-          <label className="flex flex-col gap-space-2">
-            <span className="text-label text-text-primary">Display name</span>
-            <input required maxLength={80} value={displayName} onChange={(event) => setDisplayName(event.target.value)} className={TOURNAMENT_INPUT} placeholder="Name shown in the tournament" />
-          </label>
+          <div className="flex flex-col gap-space-1"><h2 className="text-h3 text-text-primary">Enter tournament</h2><p className="text-caption text-text-muted">Your account is linked to this entry, while the tournament keeps its own historical participant identity.</p></div>
+          <label className="flex flex-col gap-space-2"><span className="text-label text-text-primary">Display name</span><input required maxLength={80} value={displayName} onChange={(event) => setDisplayName(event.target.value)} className={TOURNAMENT_INPUT} placeholder="Name shown in the tournament" /></label>
           {error ? <p role="alert" className="text-body text-error-red">{error}</p> : null}
-          <button type="submit" className={TOURNAMENT_PRIMARY_BUTTON} disabled={submitting || displayName.trim().length === 0}>
-            {submitting ? "Registering…" : "Register"}
-          </button>
+          <button type="submit" className={TOURNAMENT_PRIMARY_BUTTON} disabled={submitting || displayName.trim().length === 0}>{submitting ? "Registering…" : "Register"}</button>
         </form>
       ) : (
-        <section className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`}>
-          <h2 className="text-h3 text-text-primary">Registration is not open</h2>
-          <p className="text-body text-text-muted">Current tournament state: {tournament.status.toLowerCase().replaceAll("_", " ")}.</p>
-          <Link href={`/tournaments/${tournament.id}/overview`} className={TOURNAMENT_SECONDARY_BUTTON}>Back to overview</Link>
-        </section>
+        <section className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`}><h2 className="text-h3 text-text-primary">Registration is not open</h2><p className="text-body text-text-muted">Current tournament state: {tournament.status.toLowerCase().replaceAll("_", " ")}.</p><Link href={`/tournaments/${tournament.id}/overview`} className={TOURNAMENT_SECONDARY_BUTTON}>Back to overview</Link></section>
       )}
     </div>
   );

--- a/src/features/tournaments/demo-store.ts
+++ b/src/features/tournaments/demo-store.ts
@@ -1,0 +1,118 @@
+export type DemoTournament = {
+  id: string;
+  name: string;
+  status: string;
+  visibility: string;
+  starts_at: string | null;
+  ends_at: string | null;
+  organization_id: string;
+  active_rule_set_version_id: string | null;
+  active_scoring_version_id: string | null;
+  active_verification_policy_version_id: string | null;
+  active_boundary_version_id: string | null;
+};
+
+export type DemoEntry = {
+  id: string;
+  tournament_id: string;
+  registration_status: string;
+  eligibility_status: string;
+  check_in_status: string;
+  competition_status: string;
+  display_name: string;
+};
+
+const TOURNAMENTS_KEY = "fish-log-book:demo-tournaments";
+const ENTRIES_KEY = "fish-log-book:demo-tournament-entries";
+
+const SEED: DemoTournament[] = [
+  {
+    id: "demo-yellowtail-open",
+    name: "Saturday Yellowtail Challenge",
+    status: "REGISTRATION_OPEN",
+    visibility: "PUBLIC",
+    starts_at: "2026-09-12T14:00:00.000Z",
+    ends_at: "2026-09-12T23:00:00.000Z",
+    organization_id: "demo-personal-organization",
+    active_rule_set_version_id: "demo-rules-v1",
+    active_scoring_version_id: "demo-scoring-v1",
+    active_verification_policy_version_id: null,
+    active_boundary_version_id: null,
+  },
+];
+
+export function hasSupabaseBrowserConfig(): boolean {
+  return Boolean(
+    process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  );
+}
+
+function readJson<T>(key: string, fallback: T): T {
+  if (typeof window === "undefined") return fallback;
+  try {
+    const value = window.localStorage.getItem(key);
+    return value ? (JSON.parse(value) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJson(key: string, value: unknown) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(key, JSON.stringify(value));
+}
+
+export function getDemoTournaments(): DemoTournament[] {
+  const stored = readJson<DemoTournament[]>(TOURNAMENTS_KEY, []);
+  return [...stored, ...SEED.filter((seed) => !stored.some((item) => item.id === seed.id))];
+}
+
+export function getDemoTournament(id: string): DemoTournament | null {
+  return getDemoTournaments().find((item) => item.id === id) ?? null;
+}
+
+export function createDemoTournament(input: {
+  name: string;
+  visibility: string;
+  starts_at: string | null;
+  ends_at: string | null;
+}): DemoTournament {
+  const item: DemoTournament = {
+    id: `demo-${Date.now()}`,
+    name: input.name,
+    status: "DRAFT",
+    visibility: input.visibility,
+    starts_at: input.starts_at,
+    ends_at: input.ends_at,
+    organization_id: "demo-personal-organization",
+    active_rule_set_version_id: null,
+    active_scoring_version_id: null,
+    active_verification_policy_version_id: null,
+    active_boundary_version_id: null,
+  };
+  const stored = readJson<DemoTournament[]>(TOURNAMENTS_KEY, []);
+  writeJson(TOURNAMENTS_KEY, [item, ...stored]);
+  return item;
+}
+
+export function getDemoEntry(tournamentId: string): DemoEntry | null {
+  return readJson<DemoEntry[]>(ENTRIES_KEY, []).find((item) => item.tournament_id === tournamentId) ?? null;
+}
+
+export function registerDemoEntry(tournamentId: string, displayName: string): DemoEntry {
+  const existing = getDemoEntry(tournamentId);
+  if (existing) return existing;
+
+  const entry: DemoEntry = {
+    id: `demo-entry-${Date.now()}`,
+    tournament_id: tournamentId,
+    registration_status: "PENDING",
+    eligibility_status: "UNKNOWN",
+    check_in_status: "NOT_CHECKED_IN",
+    competition_status: "NOT_STARTED",
+    display_name: displayName,
+  };
+  const entries = readJson<DemoEntry[]>(ENTRIES_KEY, []);
+  writeJson(ENTRIES_KEY, [entry, ...entries]);
+  return entry;
+}


### PR DESCRIPTION
- Adds a localStorage-backed tournament demo mode that activates only when `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` are missing.
- Keeps the real Supabase path unchanged whenever configuration exists.
- Makes the current evaluable flow work without a database: tournament hub → create tournament → overview → register.
- Seeds one public Yellowtail tournament so the UX is immediately testable on mobile.
- Clearly labels demo mode and keeps demo data local to the device.

This is a development bridge so UI work can continue before Vercel/Supabase configuration is completed. It should not be treated as production persistence.