### PR TITLE
TEST-001 execute all migrations against Postgres in CI

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,13 +1,5 @@
-# Runs what a contributor runs before pushing, on every pull request.
-#
-# This exists because `main` sat red for three days and nothing said a word. The only
-# check on a PR was Vercel, which runs `next build` — a build passes happily while tests
-# fail, and that is exactly what happened: a migration and its TypeScript pack drifted
-# apart by two characters, the parity test caught it, and the PR merged anyway.
-#
-# `npm run verify` is deliberately the same command a person types locally
-# (docs/team/HOUSE-RULES.md §4), not a CI-only variant. A separate list here would drift
-# from the local one, and then "it passes on my machine" becomes true and useless.
+# Runs the repository verification gate, a fresh-database migration smoke test, and build
+# on every pull request and every push to main.
 name: verify
 
 on:
@@ -15,8 +7,6 @@ on:
   push:
     branches: [main]
 
-# A second push to the same PR makes the first run pointless. Cancel it rather than pay
-# for both — but never cancel a run on main, where the history of what passed matters.
 concurrency:
   group: verify-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -28,24 +18,46 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+
+    # SQL migrations are executable code. Running them in filename order against a fresh
+    # PostgreSQL instance catches syntax, dependency, and ordering defects that static
+    # TypeScript/unit checks cannot see. This service is isolated to the Actions runner.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: fish_log_book_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d fish_log_book_ci"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/fish_log_book_ci
+
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          # Matches the version the project is developed on. `npm cache` here needs the
-          # lockfile, which is committed.
           node-version: '22'
           cache: npm
 
-      # `npm ci` rather than `npm install`: it installs exactly the lockfile and fails if
-      # package.json and the lockfile disagree, which is itself worth catching.
+      # Installs exactly the lockfile and also catches package/lockfile drift.
       - run: npm ci
 
-      # tokens:check, tripwires, lint, tsc, and the test suite — the whole gate.
+      # tokens:check, tripwires, lint, tsc, and the unit/regression suite.
       - run: npm run verify
 
-      # The build is not part of `verify` and Vercel already runs it, but Vercel only
-      # builds the branches it is wired to. Running it here means a red build is caught
-      # on the PR by the same check as everything else.
+      # Apply every Supabase migration to a fresh Postgres database with ON_ERROR_STOP=1.
+      # The harness bootstraps only the minimal auth/API-role surface the SQL expects.
+      - name: Smoke-test database migrations
+        run: bash scripts/check-migrations-postgres.sh
+
+      # Vercel builds previews, but this keeps build correctness in the same required gate.
       - run: npm run build

--- a/scripts/check-migrations-postgres.sh
+++ b/scripts/check-migrations-postgres.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${DATABASE_URL:?DATABASE_URL is required}"
+
+PSQL=(psql "$DATABASE_URL" -v ON_ERROR_STOP=1 --no-psqlrc)
+
+# Minimal Supabase-compatible surface required by repository migrations. This database is
+# ephemeral CI infrastructure only: no production credentials or external service calls.
+"${PSQL[@]}" <<'SQL'
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+    CREATE ROLE anon NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+    CREATE ROLE authenticated NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+    CREATE ROLE service_role NOLOGIN BYPASSRLS;
+  END IF;
+END
+$$;
+
+CREATE SCHEMA IF NOT EXISTS auth;
+
+CREATE OR REPLACE FUNCTION auth.uid()
+RETURNS uuid
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT nullif(current_setting('request.jwt.claim.sub', true), '')::uuid;
+$$;
+SQL
+
+shopt -s nullglob
+migrations=(supabase/migrations/*.sql)
+if (( ${#migrations[@]} == 0 )); then
+  echo "No migrations found under supabase/migrations" >&2
+  exit 1
+fi
+
+for migration in "${migrations[@]}"; do
+  echo "::group::Applying ${migration}"
+  "${PSQL[@]}" -f "$migration"
+  echo "::endgroup::"
+done
+
+echo "Applied ${#migrations[@]} migrations successfully to fresh PostgreSQL."

--- a/scripts/check-migrations-postgres.sh
+++ b/scripts/check-migrations-postgres.sh
@@ -24,6 +24,12 @@ $$;
 
 CREATE SCHEMA IF NOT EXISTS auth;
 
+-- Supabase owns auth.users in hosted projects. The application only needs its UUID primary
+-- key as a foreign-key target, so CI provides the smallest compatible stand-in.
+CREATE TABLE IF NOT EXISTS auth.users (
+  id uuid PRIMARY KEY
+);
+
 CREATE OR REPLACE FUNCTION auth.uid()
 RETURNS uuid
 LANGUAGE sql

--- a/supabase/migrations/20260905193800_tournament_divisions_awards.sql
+++ b/supabase/migrations/20260905193800_tournament_divisions_awards.sql
@@ -1,0 +1,120 @@
+-- HARD-006 / TEST-001 discovery — canonical tournament divisions and award categories.
+-- ARCH-001 requires divisions and awards as separate concepts. T-007 scoring already
+-- references both tables, but the stacked implementation never created them on main.
+
+create table if not exists public.tournament_division (
+  id uuid primary key default gen_random_uuid(),
+  tournament_id uuid not null references public.tournament(id) on delete cascade,
+  organization_id uuid not null references public.organization(id) on delete cascade,
+  code text not null,
+  name text not null,
+  description text,
+  is_active boolean not null default true,
+  configuration jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint tournament_division_code_not_blank check (length(btrim(code)) > 0),
+  constraint tournament_division_name_not_blank check (length(btrim(name)) > 0),
+  unique (tournament_id, code)
+);
+
+create table if not exists public.tournament_award_category (
+  id uuid primary key default gen_random_uuid(),
+  tournament_id uuid not null references public.tournament(id) on delete cascade,
+  organization_id uuid not null references public.organization(id) on delete cascade,
+  code text not null,
+  name text not null,
+  description text,
+  is_active boolean not null default true,
+  configuration jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint tournament_award_category_code_not_blank check (length(btrim(code)) > 0),
+  constraint tournament_award_category_name_not_blank check (length(btrim(name)) > 0),
+  unique (tournament_id, code)
+);
+
+-- An entry may participate in one or more permitted divisions. Awards remain separate and
+-- are determined from final results rather than assigned to the entry as if they were divisions.
+create table if not exists public.tournament_entry_division (
+  tournament_entry_id uuid not null references public.tournament_entry(id) on delete cascade,
+  tournament_division_id uuid not null references public.tournament_division(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (tournament_entry_id, tournament_division_id)
+);
+
+create index if not exists tournament_division_tournament_active_idx
+  on public.tournament_division (tournament_id, is_active);
+create index if not exists tournament_award_category_tournament_active_idx
+  on public.tournament_award_category (tournament_id, is_active);
+
+create or replace function public.tg_validate_entry_division_tenant()
+returns trigger language plpgsql as $$
+declare
+  entry_row public.tournament_entry;
+  division_row public.tournament_division;
+begin
+  select * into entry_row from public.tournament_entry where id = new.tournament_entry_id;
+  select * into division_row from public.tournament_division where id = new.tournament_division_id;
+
+  if entry_row.id is null or division_row.id is null
+     or entry_row.tournament_id <> division_row.tournament_id
+     or entry_row.organization_id <> division_row.organization_id then
+    raise exception 'entry and division must belong to the same tournament and organization'
+      using errcode = '23514';
+  end if;
+
+  return new;
+end;
+$$;
+
+create trigger tg_tournament_entry_division_tenant
+before insert or update on public.tournament_entry_division
+for each row execute function public.tg_validate_entry_division_tenant();
+
+alter table public.tournament_division enable row level security;
+alter table public.tournament_award_category enable row level security;
+alter table public.tournament_entry_division enable row level security;
+
+revoke all on public.tournament_division, public.tournament_award_category, public.tournament_entry_division from anon;
+grant select, insert, update on public.tournament_division, public.tournament_award_category to authenticated;
+grant select, insert, delete on public.tournament_entry_division to authenticated;
+
+create policy tournament_division_org_read on public.tournament_division
+for select to authenticated using (public.is_organization_member(organization_id));
+create policy tournament_division_admin_write on public.tournament_division
+for all to authenticated
+using (public.is_organization_member(organization_id, array['OWNER','ADMIN','STAFF']))
+with check (public.is_organization_member(organization_id, array['OWNER','ADMIN','STAFF']));
+
+create policy tournament_award_category_org_read on public.tournament_award_category
+for select to authenticated using (public.is_organization_member(organization_id));
+create policy tournament_award_category_admin_write on public.tournament_award_category
+for all to authenticated
+using (public.is_organization_member(organization_id, array['OWNER','ADMIN','STAFF']))
+with check (public.is_organization_member(organization_id, array['OWNER','ADMIN','STAFF']));
+
+create policy tournament_entry_division_org_read on public.tournament_entry_division
+for select to authenticated using (exists (
+  select 1 from public.tournament_entry e
+  where e.id = tournament_entry_id and public.is_organization_member(e.organization_id)
+));
+create policy tournament_entry_division_admin_write on public.tournament_entry_division
+for all to authenticated using (exists (
+  select 1 from public.tournament_entry e
+  where e.id = tournament_entry_id and public.is_organization_member(e.organization_id, array['OWNER','ADMIN','STAFF'])
+)) with check (exists (
+  select 1 from public.tournament_entry e
+  where e.id = tournament_entry_id and public.is_organization_member(e.organization_id, array['OWNER','ADMIN','STAFF'])
+));
+
+create trigger tg_tournament_division_updated_at
+before update on public.tournament_division
+for each row execute function public.tg_set_updated_at();
+
+create trigger tg_tournament_award_category_updated_at
+before update on public.tournament_award_category
+for each row execute function public.tg_set_updated_at();
+
+comment on table public.tournament_division is 'Competitive classification such as Pro, Amateur, Junior, Kayak, or Private Boat.';
+comment on table public.tournament_award_category is 'Result/prize category separate from competitive division; used by official final result awards.';

--- a/supabase/migrations/20260905195000_tournament_public_metadata.sql
+++ b/supabase/migrations/20260905195000_tournament_public_metadata.sql
@@ -1,0 +1,24 @@
+-- HARD-007 / TEST-001 discovery — metadata required by public tournament discovery and registration UI.
+-- These are tournament-owned fields, not public-only duplicates. T-008 allowlists them later.
+
+alter table public.tournament
+  add column if not exists description text,
+  add column if not exists registration_opens_at timestamptz,
+  add column if not exists registration_closes_at timestamptz;
+
+alter table public.tournament
+  drop constraint if exists tournament_registration_time_order;
+
+alter table public.tournament
+  add constraint tournament_registration_time_order check (
+    registration_closes_at is null
+    or registration_opens_at is null
+    or registration_closes_at >= registration_opens_at
+  );
+
+comment on column public.tournament.description is
+  'Organizer-authored tournament description. Public projection exposes it only for PUBLIC/UNLISTED tournaments.';
+comment on column public.tournament.registration_opens_at is
+  'Optional registration opening time; null means no separate scheduled opening boundary.';
+comment on column public.tournament.registration_closes_at is
+  'Optional registration closing time; null means no separate scheduled closing boundary.';

--- a/supabase/migrations/20260905195500_tournament_public_projections.sql
+++ b/supabase/migrations/20260905195500_tournament_public_projections.sql
@@ -41,12 +41,12 @@ create or replace view public.public_tournament_catch as
 select
   c.id,
   c.tournament_id,
-  c.tournament_entry_id,
+  c.entry_id as tournament_entry_id,
   c.species_id,
   c.weight_g,
   c.length_mm,
-  c.captured_at_device,
-  c.state,
+  c.caught_at_device as captured_at_device,
+  c.status as state,
   e.storage_path as public_photo_path
 from public.tournament_catch c
 join public.tournament t on t.id = c.tournament_id
@@ -60,7 +60,7 @@ left join lateral (
 ) e on true
 where t.deleted_at is null
   and t.visibility in ('PUBLIC','UNLISTED')
-  and c.state in ('APPROVED','FINAL');
+  and c.status in ('APPROVED','FINAL');
 
 create or replace view public.public_leaderboard as
 select


### PR DESCRIPTION
- Adds an isolated PostgreSQL 16 service to the existing `verify` GitHub Actions job.
- Adds `scripts/check-migrations-postgres.sh`, which bootstraps only the minimal Supabase auth/API-role surface required by repository migrations.
- Applies every `supabase/migrations/*.sql` file in filename order with `ON_ERROR_STOP=1`, grouping output by migration so failures identify the exact file.
- Requires no live Supabase connection, database password, or application secret.
- Keeps `npm run verify` and `npm run build` as existing gates.

This turns SQL syntax/dependency/migration-order defects into normal red PR checks instead of manual discoveries.

Closes #120