### PR TITLE
Rebuild the tournament section's UI

### DIFF
--- a/docs/team/worklog/2026-09-05-92-ux-ui.md
+++ b/docs/team/worklog/2026-09-05-92-ux-ui.md
@@ -1,0 +1,43 @@
+### 2026-09-05 | ux-ui | ~3h
+- Rebuilt the tournament section's screens. The founder's words were "amateur" and
+  "barely functions", and both halves turned out to be literally true rather than a matter
+  of taste.
+- The section was styled with class names that do not exist in this app's design tokens
+  (`bg-action`, `text-on-action`, `rounded-card`, `shadow-card`, `bg-surface-muted`), so
+  Tailwind generated nothing for them: every primary button rendered as bare text and every
+  card as a square with no radius. That is most of why it looked unfinished next to the rest
+  of the app. Everything now uses the real tokens.
+- Two screens read the browser (`navigator.onLine`) and the phone's storage while
+  rendering, which throws during the server render — the live-catch screen was falling
+  straight into the error page before it drew a field. Both now load in an effect, through
+  one shared loader with one skeleton and one error card.
+- The "Rules" tab has linked to a page that does not exist since the section shipped.
+  Anyone who tapped it got a 404. That page now exists.
+- Standings were a tab inside "Tournament operations", so an angler had to open the
+  organizer's screen, next to the payout controls, to see whether they were winning. They
+  are their own screen now, and organizer tools moved off the angler's tab strip.
+- Screens now say things in English. "REGISTRATION_OPEN" is "Taking entries",
+  "not_checked_in" is "Not checked in — check in at the ramp before lines in", and every
+  tournament shows a real clock ("Starts in 6 days", "4h 30m left") instead of a bare date.
+- Two things were removed rather than restyled, both because they were untrue: the finance
+  panel showed $1,250 of entry money nobody had taken, and the judge queue showed an
+  invented catch. The finance panel now states the rule it enforces and shows no numbers;
+  the judge queue is built from real flagged catches.
+- Organizer lifecycle controls are now computed from `core/tournaments/lifecycle.ts`, so the
+  screen offers exactly the moves the server would allow and says which of the four frozen
+  inputs is blocking "Start fishing". They remain disabled — that half is not wired.
+- Create-a-tournament is three steps, one question at a time, and it now refuses a finish
+  time earlier than the start. It deliberately does not ask about scoring or verification:
+  there is nowhere to save that answer yet, and a step that quietly drops what you told it
+  is worse than no step.
+- Checked in a browser at phone width (390px), every screen, no console or page errors.
+  `npm run verify` and `npm run build` pass; 875 tests including 14 new ones for the
+  status/clock wording.
+- Files: `src/features/tournaments/**`, `src/app/(app)/tournaments/**`
+- Still broken, and not mine to fix here: nothing on these screens can change tournament
+  state, judge a catch, or take money — the server side of all three is unbuilt, so those
+  controls are visible and disabled with a line saying so. Real rule text, divisions, teams,
+  boats and invites have no UI yet either.
+- Next: whoever wires the lifecycle transitions should start from the organizer lane —
+  the confirmation copy for the three high-risk moves (start, finalize, cancel) is the only
+  part of UX-001 §6 still missing.

--- a/src/app/(app)/tournaments/[id]/leaderboard/page.tsx
+++ b/src/app/(app)/tournaments/[id]/leaderboard/page.tsx
@@ -1,10 +1,15 @@
 import type { Metadata } from "next";
 
-import { TournamentOperations } from "@/features/tournaments/components/tournament-operations";
+import { TournamentLeaderboard } from "@/features/tournaments/components/tournament-leaderboard";
 
-export const metadata: Metadata = { title: "Tournament Leaderboard | Fish Log Book" };
+export const metadata: Metadata = { title: "Tournament Standings | Fish Log Book" };
 
+/**
+ * Standings are their own screen now. They used to be a tab inside "Tournament operations",
+ * which put the one screen every competitor wants behind the one screen only the organizer
+ * should be reading.
+ */
 export default async function TournamentLeaderboardPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  return <TournamentOperations tournamentId={id} initialPanel="leaderboard" />;
+  return <TournamentLeaderboard tournamentId={id} />;
 }

--- a/src/app/(app)/tournaments/[id]/rules/page.tsx
+++ b/src/app/(app)/tournaments/[id]/rules/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+import { TournamentRules } from "@/features/tournaments/components/tournament-rules";
+
+export const metadata: Metadata = { title: "Tournament Rules | Fish Log Book" };
+
+/**
+ * The tab strip has linked here since the tournament section shipped, and there was no
+ * page behind it — every angler who tapped "Rules" got a 404.
+ */
+export default async function TournamentRulesPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <TournamentRules tournamentId={id} />;
+}

--- a/src/app/(app)/tournaments/error.tsx
+++ b/src/app/(app)/tournaments/error.tsx
@@ -2,27 +2,36 @@
 
 import Link from "next/link";
 
-import { TOURNAMENT_CARD, TOURNAMENT_PRIMARY_BUTTON, TOURNAMENT_SECONDARY_BUTTON } from "@/features/tournaments/ui-classes";
+import { CARD_PADDED, PAGE, PRIMARY_BUTTON, SECONDARY_BUTTON } from "@/features/tournaments/ui-classes";
 
+/**
+ * The tournament section's last line of defence.
+ *
+ * It matters more here than on most routes: a tournament screen is opened on a boat, often
+ * on one bar of signal, and the first thing the reader needs to know is that the rest of
+ * their app — their log, their catches — is untouched by whatever just failed.
+ */
 export default function TournamentError({ reset }: { error: Error & { digest?: string }; reset: () => void }) {
   return (
-    <div className="mx-auto flex max-w-reading flex-col gap-space-5 px-space-4 py-space-5">
+    <div className={PAGE}>
       <header className="flex flex-col gap-space-2">
         <h1 className="text-h1 text-text-primary">Tournaments</h1>
-        <p className="text-body text-text-muted">This tournament page hit an unexpected error.</p>
       </header>
 
-      <section className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`} role="alert">
-        <p className="text-body-strong text-error-red">The page could not finish loading.</p>
-        <p className="text-caption text-text-muted">
-          Your app is still available. Retry this page, or return to the calendar while the tournament data connection recovers.
+      <section className={`${CARD_PADDED} flex flex-col gap-space-3`} role="alert">
+        <p className="text-h3 text-error-red">This page stopped part-way</p>
+        <p className="text-body text-text-primary">
+          Nothing you have logged is affected. Your catches and your log are on this phone and are
+          untouched by this.
         </p>
-        <button type="button" className={TOURNAMENT_PRIMARY_BUTTON} onClick={reset}>
-          Try again
-        </button>
-        <Link href="/" className={TOURNAMENT_SECONDARY_BUTTON}>
-          Back to calendar
-        </Link>
+        <div className="flex flex-col gap-space-3 sm:flex-row">
+          <button type="button" className={PRIMARY_BUTTON} onClick={reset}>
+            Try again
+          </button>
+          <Link href="/" className={SECONDARY_BUTTON}>
+            Back to the calendar
+          </Link>
+        </div>
       </section>
     </div>
   );

--- a/src/app/(app)/tournaments/new/page.tsx
+++ b/src/app/(app)/tournaments/new/page.tsx
@@ -7,12 +7,14 @@ export const metadata: Metadata = { title: "Create Tournament | Fish Log Book" }
 
 export default function NewTournamentPage() {
   return (
-    <div className="mx-auto flex max-w-reading flex-col gap-space-5 px-space-4 py-space-5">
+    <div className="mx-auto flex w-full max-w-reading flex-col gap-space-6">
       <header className="flex flex-col gap-space-2">
-        <Link href="/tournaments" className="text-caption text-text-link">← Tournaments</Link>
-        <h1 className="text-h1 text-text-primary">Create tournament</h1>
+        <Link href="/tournaments" className="min-h-touch-floor text-caption text-text-link">
+          ← Tournaments
+        </Link>
+        <h1 className="text-h1 text-text-primary">Create a tournament</h1>
         <p className="text-body text-text-muted">
-          Start simple for friends or use the same tournament engine for an organization event.
+          Three questions. The rest waits until you need it.
         </p>
       </header>
       <CreateTournamentForm />

--- a/src/features/tournaments/components/create-tournament-form.tsx
+++ b/src/features/tournaments/components/create-tournament-form.tsx
@@ -1,13 +1,44 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useId, useState } from "react";
 
 import { createClient } from "@/lib/supabase/client";
 import { createDemoTournament, hasSupabaseBrowserConfig } from "../demo-store";
-import { TOURNAMENT_INPUT, TOURNAMENT_PRIMARY_BUTTON, TOURNAMENT_SECONDARY_BUTTON } from "../ui-classes";
+import { formatSchedule, visibilityPresentation } from "../format";
+import {
+  BIG_ACTION,
+  CARD_PADDED,
+  FOCUS_RING,
+  INPUT,
+  SECONDARY_BUTTON,
+  TERTIARY_BUTTON,
+} from "../ui-classes";
+import { CheckRow, DemoNote } from "./tournament-chrome";
+
+/**
+ * Create a tournament — three questions, one per screen.
+ *
+ * The old form asked all of it at once: name, four visibility buttons, two
+ * `datetime-local` fields, and a paragraph about drafts, in a single column with one
+ * validation rule (a non-empty name). UX-001 §4 asks for the opposite shape — a casual
+ * user creating a private tournament in a few steps, with everything else revealed only
+ * when it is wanted — and on a phone one question at a time is also simply easier to
+ * answer with one thumb.
+ *
+ * What this screen deliberately does **not** do is ask for scoring, verification, or
+ * boundaries. Those four frozen inputs are real objects with their own versioned
+ * lifecycle (`core/tournaments/lifecycle.ts`), the tables to hold a choice made here do
+ * not exist yet, and a wizard step that collects a preference and quietly drops it is
+ * worse than no step. The review names them as what comes next, and the overview's
+ * readiness checklist is where they get set.
+ */
 
 const VISIBILITIES = ["PRIVATE", "INVITE_ONLY", "UNLISTED", "PUBLIC"] as const;
+
+type Visibility = (typeof VISIBILITIES)[number];
+
+const STEPS = ["The basics", "Who can see it", "Check it over"] as const;
 
 function toIsoOrNull(value: string) {
   return value ? new Date(value).toISOString() : null;
@@ -15,16 +46,31 @@ function toIsoOrNull(value: string) {
 
 export function CreateTournamentForm() {
   const router = useRouter();
+  const fieldId = useId();
+
+  const [step, setStep] = useState(0);
   const [name, setName] = useState("");
-  const [visibility, setVisibility] = useState<(typeof VISIBILITIES)[number]>("PRIVATE");
+  const [visibility, setVisibility] = useState<Visibility>("PRIVATE");
   const [startsAt, setStartsAt] = useState("");
   const [endsAt, setEndsAt] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
   const demoMode = !hasSupabaseBrowserConfig();
 
-  async function submit(event: React.FormEvent<HTMLFormElement>) {
-    event.preventDefault();
+  /**
+   * The one rule worth enforcing here. Everything else about a tournament can be changed
+   * later; a window that ends before it starts produces a negative clock on every screen
+   * downstream, and the old form would happily create one.
+   */
+  const scheduleProblem =
+    startsAt && endsAt && new Date(endsAt).getTime() <= new Date(startsAt).getTime()
+      ? "The finish has to be after the start."
+      : null;
+
+  const stepReady = step === 0 ? name.trim().length > 0 && !scheduleProblem : true;
+
+  async function create() {
     setSubmitting(true);
     setError(null);
 
@@ -48,21 +94,27 @@ export function CreateTournamentForm() {
         return;
       }
 
-      const { data: organizationId, error: organizationError } = await supabase.rpc("ensure_personal_organization");
+      const { data: organizationId, error: organizationError } = await supabase.rpc(
+        "ensure_personal_organization",
+      );
       if (organizationError || !organizationId) {
         setError(organizationError?.message ?? "Your tournament workspace could not be prepared.");
         return;
       }
 
-      const { data, error: insertError } = await supabase.from("tournament").insert({
-        organization_id: organizationId,
-        name: name.trim(),
-        visibility,
-        status: "DRAFT",
-        starts_at: toIsoOrNull(startsAt),
-        ends_at: toIsoOrNull(endsAt),
-        created_by: authData.user.id,
-      }).select("id").single();
+      const { data, error: insertError } = await supabase
+        .from("tournament")
+        .insert({
+          organization_id: organizationId,
+          name: name.trim(),
+          visibility,
+          status: "DRAFT",
+          starts_at: toIsoOrNull(startsAt),
+          ends_at: toIsoOrNull(endsAt),
+          created_by: authData.user.id,
+        })
+        .select("id")
+        .single();
 
       if (insertError) {
         setError(insertError.message);
@@ -79,38 +131,191 @@ export function CreateTournamentForm() {
   }
 
   return (
-    <form onSubmit={submit} className="flex flex-col gap-space-5">
-      {demoMode ? <p className="text-caption text-text-muted">Demo mode · this tournament will be saved only on this device.</p> : null}
-      <label className="flex flex-col gap-space-2">
-        <span className="text-label text-text-primary">Tournament name</span>
-        <input required maxLength={120} value={name} onChange={(event) => setName(event.target.value)} className={TOURNAMENT_INPUT} placeholder="Saturday Yellowtail Challenge" />
-      </label>
+    <div className="flex flex-col gap-space-5">
+      <ol className="flex gap-space-2" aria-label={`Step ${step + 1} of ${STEPS.length}: ${STEPS[step]}`}>
+        {STEPS.map((label, index) => (
+          <li
+            key={label}
+            className={`h-space-2 flex-1 rounded-full transition-colors ${
+              index <= step ? "bg-signal-orange" : "bg-surface-raised"
+            }`}
+          >
+            <span className="sr-only">
+              {label}
+              {index === step ? " (current)" : ""}
+            </span>
+          </li>
+        ))}
+      </ol>
+      <p className="text-caption text-text-muted" aria-hidden="true">
+        Step {step + 1} of {STEPS.length} · {STEPS[step]}
+      </p>
 
-      <fieldset className="flex flex-col gap-space-2">
-        <legend className="text-label text-text-primary">Who can see it?</legend>
-        <div className="grid grid-cols-2 gap-space-2">
-          {VISIBILITIES.map((option) => (
-            <button key={option} type="button" onClick={() => setVisibility(option)} aria-pressed={visibility === option} className={visibility === option ? TOURNAMENT_PRIMARY_BUTTON : TOURNAMENT_SECONDARY_BUTTON}>
-              {option.toLowerCase().replaceAll("_", " ")}
-            </button>
-          ))}
-        </div>
-      </fieldset>
+      {step === 0 ? (
+        <section className={`${CARD_PADDED} flex flex-col gap-space-5`}>
+          <div className="flex flex-col gap-space-2">
+            <label htmlFor={`${fieldId}-name`} className="text-label text-text-primary">
+              What is it called?
+            </label>
+            <input
+              id={`${fieldId}-name`}
+              required
+              maxLength={120}
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              className={INPUT}
+              placeholder="Saturday Yellowtail Challenge"
+            />
+            <p className="text-caption text-text-muted">
+              Whatever you would call it out loud. You can change this later.
+            </p>
+          </div>
 
-      <div className="grid gap-space-4 sm:grid-cols-2">
-        <label className="flex flex-col gap-space-2">
-          <span className="text-label text-text-primary">Starts</span>
-          <input type="datetime-local" value={startsAt} onChange={(event) => setStartsAt(event.target.value)} className={TOURNAMENT_INPUT} />
-        </label>
-        <label className="flex flex-col gap-space-2">
-          <span className="text-label text-text-primary">Ends</span>
-          <input type="datetime-local" value={endsAt} onChange={(event) => setEndsAt(event.target.value)} className={TOURNAMENT_INPUT} />
-        </label>
+          <div className="flex flex-col gap-space-3">
+            <p className="text-label text-text-primary">When is it?</p>
+            <div className="grid gap-space-4 sm:grid-cols-2">
+              <label className="flex flex-col gap-space-2">
+                <span className="text-caption text-text-muted">Lines in</span>
+                <input
+                  type="datetime-local"
+                  value={startsAt}
+                  onChange={(event) => setStartsAt(event.target.value)}
+                  className={INPUT}
+                />
+              </label>
+              <label className="flex flex-col gap-space-2">
+                <span className="text-caption text-text-muted">Lines out</span>
+                <input
+                  type="datetime-local"
+                  value={endsAt}
+                  onChange={(event) => setEndsAt(event.target.value)}
+                  className={INPUT}
+                  aria-invalid={scheduleProblem ? true : undefined}
+                  aria-describedby={scheduleProblem ? `${fieldId}-schedule-error` : undefined}
+                />
+              </label>
+            </div>
+            {scheduleProblem ? (
+              <p id={`${fieldId}-schedule-error`} role="alert" className="text-body text-error-red">
+                {scheduleProblem}
+              </p>
+            ) : (
+              <p className="text-caption text-text-muted">
+                Leave these empty if you have not settled on a day yet.
+              </p>
+            )}
+          </div>
+        </section>
+      ) : null}
+
+      {step === 1 ? (
+        <fieldset className={`${CARD_PADDED} flex flex-col gap-space-3`}>
+          <legend className="text-label text-text-primary">Who can see it?</legend>
+          <p className="text-caption text-text-muted">
+            This is the only privacy decision you have to make now, and it can be changed while the
+            tournament is still a draft.
+          </p>
+          <div className="flex flex-col gap-space-2">
+            {VISIBILITIES.map((option) => {
+              const { label, blurb } = visibilityPresentation(option);
+              const selected = visibility === option;
+              return (
+                <button
+                  key={option}
+                  type="button"
+                  aria-pressed={selected}
+                  onClick={() => setVisibility(option)}
+                  className={`${FOCUS_RING} flex min-h-touch-floor flex-col items-start gap-space-1 rounded-md border p-space-3 text-left transition-colors active:scale-[0.995] motion-reduce:transition-none ${
+                    selected
+                      ? "border-signal-orange bg-signal-orange/10"
+                      : "border-border-interactive bg-surface hover:border-text-link"
+                  }`}
+                >
+                  <span className={`text-label ${selected ? "text-signal-orange" : "text-text-primary"}`}>
+                    {label}
+                  </span>
+                  <span className="text-caption text-text-muted">{blurb}</span>
+                </button>
+              );
+            })}
+          </div>
+        </fieldset>
+      ) : null}
+
+      {step === 2 ? (
+        <section className={`${CARD_PADDED} flex flex-col gap-space-4`}>
+          <div className="flex flex-col gap-space-2">
+            <h2 className="text-h3 text-text-primary">{name.trim() || "Untitled tournament"}</h2>
+            <p className="text-body text-text-muted">{formatSchedule(toIsoOrNull(startsAt), toIsoOrNull(endsAt))}</p>
+            <p className="text-caption text-text-muted">
+              {visibilityPresentation(visibility).label} · {visibilityPresentation(visibility).blurb}
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-space-3 border-t border-hairline pt-space-4">
+            <p className="text-label text-text-primary">What happens next</p>
+            <ul className="flex flex-col gap-space-3">
+              <CheckRow
+                state="done"
+                label="It is created as a draft"
+                detail="Nobody can enter until you open registration, so nothing is public by accident."
+              />
+              <CheckRow
+                state="pending"
+                label="Four things get locked before it can go live"
+                detail="Rules, how it is scored, what counts as proof of a catch, and where you can fish. The overview walks you through them."
+              />
+              <CheckRow
+                state="pending"
+                label="Then you invite people"
+                detail="Open registration when you are ready and share the tournament."
+              />
+            </ul>
+          </div>
+
+          {error ? (
+            <p role="alert" className="text-body text-error-red">
+              {error}
+            </p>
+          ) : null}
+
+          {demoMode ? <DemoNote>Demo mode — this tournament is saved on this phone only.</DemoNote> : null}
+        </section>
+      ) : null}
+
+      <div className="flex flex-col gap-space-3">
+        {step < STEPS.length - 1 ? (
+          <button
+            type="button"
+            className={BIG_ACTION}
+            disabled={!stepReady}
+            aria-describedby={!stepReady ? `${fieldId}-next-hint` : undefined}
+            onClick={() => setStep((current) => current + 1)}
+          >
+            Next
+          </button>
+        ) : (
+          <button type="button" className={BIG_ACTION} disabled={submitting} onClick={create}>
+            {submitting ? "Creating…" : "Create tournament"}
+          </button>
+        )}
+
+        {step === 0 && !stepReady ? (
+          <p id={`${fieldId}-next-hint`} className="text-caption text-text-muted">
+            {scheduleProblem ? "Fix the times to carry on." : "Give it a name to carry on."}
+          </p>
+        ) : null}
+
+        {step > 0 ? (
+          <button
+            type="button"
+            className={step === STEPS.length - 1 ? SECONDARY_BUTTON : TERTIARY_BUTTON}
+            onClick={() => setStep((current) => current - 1)}
+          >
+            Back
+          </button>
+        ) : null}
       </div>
-
-      <p className="text-caption text-text-muted">This starts as a draft. Rules, scoring, verification and boundaries can be configured before it goes live.</p>
-      {error ? <p className="text-body text-error-red" role="alert">{error}</p> : null}
-      <button type="submit" disabled={submitting || name.trim().length === 0} className={TOURNAMENT_PRIMARY_BUTTON}>{submitting ? "Creating…" : "Create tournament"}</button>
-    </form>
+    </div>
   );
 }

--- a/src/features/tournaments/components/icons.tsx
+++ b/src/features/tournaments/components/icons.tsx
@@ -1,0 +1,182 @@
+/**
+ * The tournament section's icons, inline (ADR 005 §6 — no icon package).
+ *
+ * Every one of them is decorative: `aria-hidden`, `currentColor`, sized by a spacing token
+ * on the element rather than a literal. The house rule from `docs/design/04-components.md`
+ * holds everywhere they are used — **an icon never ships without its word**. These are here
+ * to make a state findable at a glance in glare, not to replace the label that says what
+ * the state is.
+ */
+
+/**
+ * `size` and `className` are separate on purpose. Passing a size through `className` used
+ * to replace the default one, which is how a decorative chevron ended up rendered at 200px
+ * on the overview screen — the kind of mistake that only shows up in a screenshot.
+ */
+type IconProps = { readonly className?: string; readonly size?: string };
+
+const BASE = "shrink-0";
+
+/** Something is done, satisfied, present. */
+export function CheckIcon({ className = "", size = "h-space-5 w-space-5" }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.25"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={`${BASE} ${size} ${className}`}
+    >
+      <path d="M4 10.5 8 14.5 16 5.5" />
+    </svg>
+  );
+}
+
+/** Something a person needs to look at. Never "you did something wrong". */
+export function AlertIcon({ className = "", size = "h-space-5 w-space-5" }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={`${BASE} ${size} ${className}`}
+    >
+      <path d="M10 2.75 18.5 17.25H1.5Z" />
+      <path d="M10 8v3.5" />
+      <path d="M10 14.4h.01" />
+    </svg>
+  );
+}
+
+/** Not done yet, and nothing is wrong with that. */
+export function PendingIcon({ className = "", size = "h-space-5 w-space-5" }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      className={`${BASE} ${size} ${className}`}
+    >
+      <circle cx="10" cy="10" r="7.5" strokeDasharray="3 3.4" />
+    </svg>
+  );
+}
+
+/** A frozen competition input: rules, scoring, checks, boundaries. */
+export function LockIcon({ className = "", size = "h-space-5 w-space-5" }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.9"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={`${BASE} ${size} ${className}`}
+    >
+      <rect x="3.75" y="8.5" width="12.5" height="8.75" rx="2" />
+      <path d="M6.75 8.5V6a3.25 3.25 0 0 1 6.5 0v2.5" />
+    </svg>
+  );
+}
+
+export function ClockIcon({ className = "", size = "h-space-5 w-space-5" }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.9"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={`${BASE} ${size} ${className}`}
+    >
+      <circle cx="10" cy="10" r="7.5" />
+      <path d="M10 5.75V10l3 2" />
+    </svg>
+  );
+}
+
+export function TrophyIcon({ className = "", size = "h-space-5 w-space-5" }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={`${BASE} ${size} ${className}`}
+    >
+      <path d="M6 2.75h8v4a4 4 0 0 1-8 0Z" />
+      <path d="M6 3.75H3.5v1.5a3 3 0 0 0 2.6 2.97" />
+      <path d="M14 3.75h2.5v1.5a3 3 0 0 1-2.6 2.97" />
+      <path d="M10 10.75v3.5" />
+      <path d="M6.75 17.25h6.5l-.75-3h-5Z" />
+    </svg>
+  );
+}
+
+/** The "there is more this way" arrow on a card that is a link. */
+export function ChevronIcon({ className = "", size = "h-space-5 w-space-5" }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={`${BASE} ${size} ${className}`}
+    >
+      <path d="M7.5 4.5 13 10l-5.5 5.5" />
+    </svg>
+  );
+}
+
+export function BackIcon({ className = "", size = "h-space-4 w-space-4" }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={`${BASE} ${size} ${className}`}
+    >
+      <path d="M12.5 4.5 7 10l5.5 5.5" />
+    </svg>
+  );
+}
+
+export function PlusIcon({ className = "", size = "h-space-5 w-space-5" }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.25"
+      strokeLinecap="round"
+      className={`${BASE} ${size} ${className}`}
+    >
+      <path d="M10 4.25v11.5M4.25 10h11.5" />
+    </svg>
+  );
+}

--- a/src/features/tournaments/components/tournament-chrome.tsx
+++ b/src/features/tournaments/components/tournament-chrome.tsx
@@ -1,0 +1,374 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import {
+  countdown,
+  formatSchedule,
+  statusPresentation,
+  TONE_CLASSES,
+  visibilityLabel,
+  type StatusTone,
+} from "../format";
+import { useNow, useOnline } from "../use-now";
+import { BACK_LINK, CARD, CARD_PADDED, FOCUS_RING, PAGE, SECONDARY_BUTTON, TABULAR } from "../ui-classes";
+import { AlertIcon, BackIcon, CheckIcon, ClockIcon, PendingIcon } from "./icons";
+
+/**
+ * The furniture every tournament screen shares: the page frame, the hero header, the tab
+ * strip, status pills, stat tiles, empty and error states, and the loading skeleton.
+ *
+ * It lives in one file on purpose. The old section had six screens that each rolled their
+ * own header, their own "← Overview" link, their own status pill and their own sentence
+ * for "loading", and the result read as six half-finished screens rather than one product.
+ * A tournament should feel like a place you are inside of, and that only happens if the
+ * chrome is literally the same object on every screen.
+ */
+
+/* -------------------------------------------------------------------------- */
+/* Frame                                                                       */
+/* -------------------------------------------------------------------------- */
+
+export function TournamentPage({ children }: { children: React.ReactNode }) {
+  return <div className={PAGE}>{children}</div>;
+}
+
+/** The eyebrow link back up the hierarchy. 48px of tap target, not a 16px word. */
+export function BackLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <Link href={href} className={BACK_LINK}>
+      <BackIcon />
+      {children}
+    </Link>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Status                                                                      */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A lifecycle state, as a pill.
+ *
+ * Colour is never the only signal (`docs/design/01-foundations.md` §1.3): the pill always
+ * carries the word, and the dot gives it a second, non-hue channel. The live state is the
+ * one that pulses, because "is this thing running right now" is the single question the
+ * screen most often has to answer from across a cockpit.
+ */
+export function StatusPill({ status, className = "" }: { status: string; className?: string }) {
+  const { label, tone } = statusPresentation(status);
+  const classes = TONE_CLASSES[tone];
+  const live = tone === "live";
+
+  return (
+    <span
+      className={`inline-flex items-center gap-space-2 rounded-full border px-space-3 py-space-1 text-caption ${classes.pill} ${classes.text} ${className}`}
+    >
+      <span
+        aria-hidden="true"
+        className={`h-space-2 w-space-2 rounded-full ${classes.dot} ${live ? "animate-pulse motion-reduce:animate-none" : ""}`}
+      />
+      {label}
+    </span>
+  );
+}
+
+/** The same pill shape for anything that is not a lifecycle state — sync, QR, eligibility. */
+export function TonePill({ tone, children }: { tone: StatusTone; children: React.ReactNode }) {
+  const classes = TONE_CLASSES[tone];
+  return (
+    <span
+      className={`inline-flex items-center gap-space-2 rounded-full border px-space-3 py-space-1 text-caption ${classes.pill} ${classes.text}`}
+    >
+      <span aria-hidden="true" className={`h-space-2 w-space-2 rounded-full ${classes.dot}`} />
+      {children}
+    </span>
+  );
+}
+
+/**
+ * One requirement or check, as a row: icon, what it is, and what it means right now.
+ *
+ * `state` drives both the glyph and the colour, and the label is always present, so this
+ * row survives being read by someone who cannot separate green from amber.
+ */
+export function CheckRow({
+  state,
+  label,
+  detail,
+}: {
+  state: "done" | "pending" | "attention";
+  label: string;
+  detail?: string;
+}) {
+  const tone: StatusTone = state === "done" ? "open" : state === "attention" ? "attention" : "neutral";
+  const classes = TONE_CLASSES[tone];
+  const Icon = state === "done" ? CheckIcon : state === "attention" ? AlertIcon : PendingIcon;
+
+  return (
+    <li className="flex items-start gap-space-3">
+      <span className={`mt-space-1 ${classes.text}`}>
+        <Icon />
+      </span>
+      <span className="flex flex-col gap-space-1">
+        <span className="text-body text-text-primary">{label}</span>
+        {detail ? <span className="text-caption text-text-muted">{detail}</span> : null}
+      </span>
+    </li>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Hero header                                                                 */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The tournament's identity, at the top of every screen inside it: name, what state it is
+ * in, when it runs, and how long is left.
+ *
+ * The clock is the part that earns its space. "Starts in 6 days" and "4h 30m left" are the
+ * two things a competitor actually wants from a tournament header, and neither was
+ * anywhere in the old design — it printed an ISO date through `Intl` and stopped.
+ */
+export function TournamentHero({
+  tournament,
+  eyebrow,
+  children,
+}: {
+  tournament: {
+    readonly id: string;
+    readonly name: string;
+    readonly status: string;
+    readonly visibility: string;
+    readonly starts_at: string | null;
+    readonly ends_at: string | null;
+  };
+  /** Overridden on sub-screens so the back link points one level up, not to the list. */
+  eyebrow?: React.ReactNode;
+  /** The screen's primary action, if it has one. */
+  children?: React.ReactNode;
+}) {
+  const now = useNow();
+  const clock = now === 0 ? null : countdown(now, { status: tournament.status, startsAt: tournament.starts_at, endsAt: tournament.ends_at });
+  const { blurb } = statusPresentation(tournament.status);
+
+  return (
+    <header className="flex flex-col gap-space-4">
+      {eyebrow ?? <BackLink href="/tournaments">All tournaments</BackLink>}
+
+      <div className="overflow-hidden rounded-lg border border-hairline bg-linear-to-b from-surface-raised to-surface">
+        <div className="flex flex-col gap-space-4 p-space-5">
+          <div className="flex flex-wrap items-start justify-between gap-space-3">
+            <h1 className="text-h1 text-text-primary">{tournament.name}</h1>
+            <StatusPill status={tournament.status} />
+          </div>
+
+          <div className="flex flex-col gap-space-1">
+            <p className="text-body text-text-primary">{formatSchedule(tournament.starts_at, tournament.ends_at)}</p>
+            <p className="text-caption text-text-muted">
+              {visibilityLabel(tournament.visibility)} · {blurb}
+            </p>
+          </div>
+
+          {clock ? (
+            <p
+              className={`inline-flex items-center gap-space-2 text-body-strong ${clock.urgent ? "text-signal-orange" : "text-text-muted"}`}
+            >
+              <ClockIcon />
+              <span className={TABULAR}>{clock.label}</span>
+            </p>
+          ) : null}
+
+          {children}
+        </div>
+      </div>
+    </header>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Tabs                                                                        */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The five places a competitor goes inside a tournament.
+ *
+ * Organizer tools are deliberately not in this row. UX-001 §7 is blunt about it — do not
+ * make an angler hunt through administrative navigation while on the water — so "Run the
+ * event" is a card on the overview for the person who owns the event, and everyone else
+ * never sees the word "operations" at all.
+ */
+const TABS = [
+  ["Overview", "overview"],
+  ["Enter", "register"],
+  ["Catches", "catches"],
+  ["Standings", "leaderboard"],
+  ["Rules", "rules"],
+] as const;
+
+export function TournamentTabs({ tournamentId }: { tournamentId: string }) {
+  const pathname = usePathname();
+
+  return (
+    <nav aria-label="Tournament sections">
+      {/*
+        Wrapped, not scrolled. A horizontal scroller put "Standings" half off the right
+        edge of a 390px phone, and a tab you cannot see is a tab you do not know exists —
+        the same finding that put the nav drawer in the app shell. Two rows of five costs
+        24px and hides nothing.
+      */}
+      <ul className="flex flex-wrap gap-space-2">
+        {TABS.map(([label, route]) => {
+          const href = `/tournaments/${tournamentId}/${route}`;
+          const active = pathname === href;
+          return (
+            <li key={route}>
+              <Link
+                href={href}
+                aria-current={active ? "page" : undefined}
+                className={`inline-flex min-h-touch-floor items-center rounded-full border px-space-4 text-label transition-colors ${FOCUS_RING} ${
+                  active
+                    ? "border-signal-orange bg-signal-orange text-ink-on-orange"
+                    : "border-border-interactive bg-surface text-text-link hover:border-text-link"
+                }`}
+              >
+                {label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Small parts                                                                 */
+/* -------------------------------------------------------------------------- */
+
+export function SectionHeading({ children, aside }: { children: React.ReactNode; aside?: React.ReactNode }) {
+  return (
+    <div className="flex flex-wrap items-baseline justify-between gap-space-2">
+      <h2 className="text-h3 text-text-primary">{children}</h2>
+      {aside ? <span className="text-caption text-text-muted">{aside}</span> : null}
+    </div>
+  );
+}
+
+/** A number worth looking at, with the word for what it counts underneath it. */
+export function StatTile({
+  label,
+  value,
+  tone = "neutral",
+}: {
+  label: string;
+  value: string;
+  tone?: StatusTone;
+}) {
+  return (
+    <article className={`${CARD} flex flex-col gap-space-1 p-space-4`}>
+      <span className="text-caption text-text-muted">{label}</span>
+      <span className={`text-h2 ${TABULAR} ${tone === "neutral" ? "text-text-primary" : TONE_CLASSES[tone].text}`}>
+        {value}
+      </span>
+    </article>
+  );
+}
+
+export function EmptyState({
+  title,
+  body,
+  action,
+}: {
+  title: string;
+  body: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className={`${CARD} flex flex-col items-start gap-space-3 border-dashed p-space-5`}>
+      <p className="text-body-strong text-text-primary">{title}</p>
+      <p className="text-body text-text-muted">{body}</p>
+      {action}
+    </div>
+  );
+}
+
+/**
+ * The demo-mode note.
+ *
+ * Said once, quietly, at the bottom of a screen rather than shouted at the top of five of
+ * them. It is a truthful caveat, not a feature, and the old design gave it the same
+ * prominence as the tournament's name.
+ */
+export function DemoNote({ children }: { children?: React.ReactNode }) {
+  return (
+    <p className="text-caption text-text-muted">
+      {children ?? "Demo mode — this is saved on this phone only, until the tournament server is connected."}
+    </p>
+  );
+}
+
+/** The radio state, for the one screen where being offline changes what the app promises. */
+export function ConnectionPill() {
+  const online = useOnline();
+  return (
+    <TonePill tone={online ? "open" : "attention"}>{online ? "Online" : "No service"}</TonePill>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Loading and failure                                                         */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A skeleton rather than the word "Loading…".
+ *
+ * On a boat, a cold load can take a while, and a blank screen with one grey word looks
+ * broken. Blocks in the shape of the content that is coming look like the app working.
+ */
+export function LoadingScreen({ label = "Loading tournament" }: { label?: string }) {
+  return (
+    <div className={PAGE} aria-busy="true">
+      <span className="sr-only" role="status">
+        {label}
+      </span>
+      <div className="h-space-12 w-full animate-pulse rounded-lg bg-surface motion-reduce:animate-none" aria-hidden="true" />
+      <div className="h-space-16 w-full animate-pulse rounded-lg bg-surface motion-reduce:animate-none" aria-hidden="true" />
+      <div className="h-space-16 w-full animate-pulse rounded-lg bg-surface motion-reduce:animate-none" aria-hidden="true" />
+    </div>
+  );
+}
+
+/**
+ * A failure the person can act on: what happened, in a sentence, and a way out of it.
+ * Never a bare error string on a blank page.
+ */
+export function ErrorScreen({
+  title = "That did not load",
+  message,
+  onRetry,
+}: {
+  title?: string;
+  message: string;
+  onRetry?: () => void;
+}) {
+  return (
+    <div className={PAGE}>
+      <section className={`${CARD_PADDED} flex flex-col gap-space-3`} role="alert">
+        <p className="text-h3 text-error-red">{title}</p>
+        <p className="text-body text-text-primary">{message}</p>
+        <div className="flex flex-wrap gap-space-3">
+          {onRetry ? (
+            <button type="button" className={SECONDARY_BUTTON} onClick={onRetry}>
+              Try again
+            </button>
+          ) : null}
+          <Link href="/tournaments" className={SECONDARY_BUTTON}>
+            All tournaments
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/features/tournaments/components/tournament-hub.tsx
+++ b/src/features/tournaments/components/tournament-hub.tsx
@@ -1,118 +1,265 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { createClient } from "@/lib/supabase/client";
 import { getDemoTournaments, hasSupabaseBrowserConfig, type DemoTournament } from "../demo-store";
-import { TOURNAMENT_CARD, TOURNAMENT_PRIMARY_BUTTON } from "../ui-classes";
+import { countdown, formatSchedule, tournamentPhase, visibilityLabel } from "../format";
+import { useNow } from "../use-now";
+import { BIG_ACTION, CARD, FOCUS_RING, PAGE, PRIMARY_BUTTON, TABULAR } from "../ui-classes";
+import { DemoNote, EmptyState, ErrorScreen, LoadingScreen, SectionHeading, StatusPill } from "./tournament-chrome";
+import { ChevronIcon, ClockIcon, PlusIcon } from "./icons";
 
-type TournamentCardData = Pick<DemoTournament, "id" | "name" | "status" | "visibility" | "starts_at" | "ends_at" | "organization_id">;
+/**
+ * /tournaments — the way in.
+ *
+ * The old version was two flat lists titled "My tournaments" and "Public tournaments",
+ * sorted by creation date, with a tournament being fished *right now* sitting below one
+ * created yesterday that starts in March. The fix is to sort by what a person is about to
+ * do rather than by when a row was written: what is happening now, then what is yours,
+ * then what you could enter.
+ */
 
-function statusLabel(status: string) {
-  return status.toLowerCase().replaceAll("_", " ");
-}
+type TournamentCard = Pick<
+  DemoTournament,
+  "id" | "name" | "status" | "visibility" | "starts_at" | "ends_at"
+>;
 
-function whenLabel(value: string | null) {
-  if (!value) return "Date not set";
-  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", year: "numeric" }).format(new Date(value));
-}
+const LIST_COLUMNS = "id,name,status,visibility,starts_at,ends_at,created_at";
+
+type Load =
+  | { readonly state: "loading" }
+  | { readonly state: "error"; readonly message: string }
+  | { readonly state: "ready"; readonly owned: TournamentCard[]; readonly open: TournamentCard[] };
 
 export function TournamentHub() {
-  const [owned, setOwned] = useState<TournamentCardData[]>([]);
-  const [publicTournaments, setPublicTournaments] = useState<TournamentCardData[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [demoMode, setDemoMode] = useState(false);
+  const [load, setLoad] = useState<Load>({ state: "loading" });
+  const [reloadToken, setReloadToken] = useState(0);
+  const demoMode = !hasSupabaseBrowserConfig();
+
+  const retry = useCallback(() => setReloadToken((token) => token + 1), []);
 
   useEffect(() => {
     let cancelled = false;
 
-    async function load() {
+    void (async () => {
+      // Yield before the first `setState` so nothing is set synchronously inside the
+      // effect body — see `use-tournament.ts` for the full reason.
+      await Promise.resolve();
+      if (cancelled) return;
+      setLoad({ state: "loading" });
+
       if (!hasSupabaseBrowserConfig()) {
-        if (cancelled) return;
         const demo = getDemoTournaments();
-        setDemoMode(true);
-        setOwned(demo);
-        setPublicTournaments(demo.filter((item) => item.visibility === "PUBLIC"));
-        setLoading(false);
+        setLoad({ state: "ready", owned: demo, open: [] });
         return;
       }
 
       try {
         const supabase = createClient();
         const [ownedResult, publicResult] = await Promise.all([
-          supabase.from("tournament").select("id,name,status,visibility,starts_at,ends_at,organization_id").is("deleted_at", null).order("created_at", { ascending: false }),
-          supabase.from("public_tournament").select("id,name,status,visibility,starts_at,ends_at,organization_id").eq("visibility", "PUBLIC").order("created_at", { ascending: false }).limit(12),
+          supabase
+            .from("tournament")
+            .select(LIST_COLUMNS)
+            .is("deleted_at", null)
+            .order("created_at", { ascending: false }),
+          supabase
+            .from("public_tournament")
+            .select(LIST_COLUMNS)
+            .eq("visibility", "PUBLIC")
+            .order("created_at", { ascending: false })
+            .limit(24),
         ]);
 
         if (cancelled) return;
-        const firstError = ownedResult.error ?? publicResult.error;
-        if (firstError) setError(firstError.message);
-        else {
-          setOwned((ownedResult.data ?? []) as TournamentCardData[]);
-          setPublicTournaments((publicResult.data ?? []) as TournamentCardData[]);
+        const failure = ownedResult.error ?? publicResult.error;
+        if (failure) {
+          setLoad({ state: "error", message: failure.message });
+          return;
         }
-      } catch (cause) {
-        if (!cancelled) setError(cause instanceof Error ? cause.message : "Tournament data could not be loaded.");
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
 
-    void load();
-    return () => { cancelled = true; };
-  }, []);
+        const owned = (ownedResult.data ?? []) as TournamentCard[];
+        const open = ((publicResult.data ?? []) as TournamentCard[]).filter(
+          (item) => !owned.some((own) => own.id === item.id),
+        );
+        setLoad({ state: "ready", owned, open });
+      } catch (cause) {
+        if (cancelled) return;
+        setLoad({
+          state: "error",
+          message: cause instanceof Error ? cause.message : "Tournaments could not be loaded.",
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadToken]);
+
+  if (load.state === "loading") return <LoadingScreen label="Loading tournaments" />;
+  if (load.state === "error") {
+    return (
+      <ErrorScreen
+        title="Tournaments did not load"
+        message={`${load.message} Everything else in the app still works — this is the tournament connection only.`}
+        onRetry={retry}
+      />
+    );
+  }
+
+  const all = [...load.owned, ...load.open];
+  const live = all.filter((item) => tournamentPhase(item.status) === "during");
+  const liveIds = new Set(live.map((item) => item.id));
+  const yours = sortForReading(load.owned.filter((item) => !liveIds.has(item.id)));
+  const toEnter = sortForReading(load.open.filter((item) => !liveIds.has(item.id)));
 
   return (
-    <div className="mx-auto flex max-w-reading flex-col gap-space-6 px-space-4 py-space-5">
-      <header className="flex flex-col gap-space-3">
-        <div className="flex flex-col gap-space-1">
+    <div className={PAGE}>
+      <header className="flex flex-col gap-space-4">
+        <div className="flex flex-col gap-space-2">
           <h1 className="text-h1 text-text-primary">Tournaments</h1>
-          <p className="text-body text-text-muted">Run a private trip competition or a full public event from the same tournament engine.</p>
-          {demoMode ? <p className="text-caption text-text-muted">Demo mode · saved on this device until Supabase is connected.</p> : null}
+          <p className="text-body text-text-muted">
+            A Saturday bet with three friends, or a hundred boats and a payout. Same engine, and you
+            only meet the parts you need.
+          </p>
         </div>
-        <Link href="/tournaments/new" className={TOURNAMENT_PRIMARY_BUTTON}>Create tournament</Link>
+        <Link href="/tournaments/new" className={BIG_ACTION}>
+          <PlusIcon />
+          Create a tournament
+        </Link>
       </header>
 
-      {loading ? <p className="text-body text-text-muted">Loading tournaments…</p> : null}
-      {error ? (
-        <div className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`} role="alert">
-          <p className="text-body-strong text-error-red">Tournament data could not be loaded.</p>
-          <p className="text-caption text-text-muted">{error}</p>
-          <button type="button" className={TOURNAMENT_PRIMARY_BUTTON} onClick={() => window.location.reload()}>Try again</button>
-        </div>
+      {live.length > 0 ? (
+        <section className="flex flex-col gap-space-3" aria-labelledby="live-heading">
+          <SectionHeading aside={live.length > 1 ? `${live.length} running` : undefined}>
+            <span id="live-heading">Happening now</span>
+          </SectionHeading>
+          <ul className="flex flex-col gap-space-3">
+            {live.map((item) => (
+              <li key={item.id}>
+                <TournamentRow tournament={item} emphasis />
+              </li>
+            ))}
+          </ul>
+        </section>
       ) : null}
 
-      {!loading && !error ? (
-        <>
-          <TournamentSection title="My tournaments" empty="You have not created or joined a tournament yet." tournaments={owned} />
-          <TournamentSection title="Public tournaments" empty="No public tournaments are available right now." tournaments={publicTournaments.filter((item) => !owned.some((own) => own.id === item.id))} />
-        </>
+      <section className="flex flex-col gap-space-3" aria-labelledby="yours-heading">
+        <SectionHeading>
+          <span id="yours-heading">Your tournaments</span>
+        </SectionHeading>
+        {yours.length === 0 ? (
+          <EmptyState
+            title="You have not run one yet"
+            body="Name it, pick a day, decide who can see it. That is the whole setup — the rest can wait until you need it."
+            action={
+              <Link href="/tournaments/new" className={PRIMARY_BUTTON}>
+                Create a tournament
+              </Link>
+            }
+          />
+        ) : (
+          <ul className="flex flex-col gap-space-3">
+            {yours.map((item) => (
+              <li key={item.id}>
+                <TournamentRow tournament={item} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {toEnter.length > 0 ? (
+        <section className="flex flex-col gap-space-3" aria-labelledby="open-heading">
+          <SectionHeading>
+            <span id="open-heading">Open to enter</span>
+          </SectionHeading>
+          <ul className="flex flex-col gap-space-3">
+            {toEnter.map((item) => (
+              <li key={item.id}>
+                <TournamentRow tournament={item} />
+              </li>
+            ))}
+          </ul>
+        </section>
       ) : null}
+
+      {demoMode ? <DemoNote /> : null}
     </div>
   );
 }
 
-function TournamentSection({ title, empty, tournaments }: { title: string; empty: string; tournaments: TournamentCardData[] }) {
+/**
+ * Sorting a mixed list of dates so it reads the way a person expects: the next thing
+ * first, then the rest of the future, then anything undated, then the past most-recent
+ * first. Creation order — what the old list used — is the one order nobody is looking for.
+ */
+function sortForReading(items: readonly TournamentCard[]): TournamentCard[] {
+  const now = Date.now();
+  const key = (item: TournamentCard) => {
+    const start = item.starts_at ? Date.parse(item.starts_at) : Number.NaN;
+    if (Number.isNaN(start)) return { bucket: 1, order: 0 };
+    if (tournamentPhase(item.status) === "after" || start < now) return { bucket: 2, order: -start };
+    return { bucket: 0, order: start };
+  };
+
+  return [...items].sort((a, b) => {
+    const left = key(a);
+    const right = key(b);
+    return left.bucket - right.bucket || left.order - right.order;
+  });
+}
+
+/**
+ * One tournament, as a whole-card link.
+ *
+ * The card is the target, not a word inside it — design 04 allows a card to be tappable as
+ * a unit as long as it takes the button's pressed and focus behaviour, which it does here.
+ * On a phone that is the difference between a 300px target and a 90px one.
+ */
+function TournamentRow({ tournament, emphasis = false }: { tournament: TournamentCard; emphasis?: boolean }) {
+  const now = useNow();
+  const clock =
+    now === 0
+      ? null
+      : countdown(now, {
+          status: tournament.status,
+          startsAt: tournament.starts_at,
+          endsAt: tournament.ends_at,
+        });
+
   return (
-    <section className="flex flex-col gap-space-3" aria-labelledby={`${title.replaceAll(" ", "-").toLowerCase()}-heading`}>
-      <h2 id={`${title.replaceAll(" ", "-").toLowerCase()}-heading`} className="text-h3 text-text-primary">{title}</h2>
-      {tournaments.length === 0 ? <p className={`${TOURNAMENT_CARD} text-body text-text-muted`}>{empty}</p> : (
-        <ul className="flex flex-col gap-space-3">
-          {tournaments.map((tournament) => (
-            <li key={tournament.id}>
-              <Link href={`/tournaments/${tournament.id}/overview`} className={`${TOURNAMENT_CARD} flex min-h-touch-floor flex-col gap-space-2`}>
-                <span className="flex flex-wrap items-start justify-between gap-space-2">
-                  <span className="text-body-strong text-text-primary">{tournament.name}</span>
-                  <span className="rounded-full border border-hairline px-space-2 py-space-1 text-caption capitalize text-text-muted">{statusLabel(tournament.status)}</span>
-                </span>
-                <span className="text-caption text-text-muted">{whenLabel(tournament.starts_at)} · {tournament.visibility.toLowerCase().replaceAll("_", " ")}</span>
-              </Link>
-            </li>
-          ))}
-        </ul>
-      )}
-    </section>
+    <Link
+      href={`/tournaments/${tournament.id}/overview`}
+      className={`${CARD} ${FOCUS_RING} flex items-center gap-space-3 p-space-4 transition-colors hover:border-border-interactive active:scale-[0.995] motion-reduce:transition-none ${
+        emphasis ? "border-signal-orange/50 bg-linear-to-b from-surface-raised to-surface" : ""
+      }`}
+    >
+      {/*
+        Name on its own line, everything else under it. Putting the pill inline with the
+        name meant a short name kept it on the same row and a long one pushed it onto the
+        next, so a list of three tournaments had three different shapes.
+      */}
+      <span className="flex min-w-0 flex-1 flex-col gap-space-2">
+        <span className="text-body-strong text-text-primary">{tournament.name}</span>
+        <span className="flex flex-wrap items-center gap-space-2">
+          <StatusPill status={tournament.status} />
+        </span>
+        <span className="text-caption text-text-muted">
+          {formatSchedule(tournament.starts_at, tournament.ends_at)} · {visibilityLabel(tournament.visibility)}
+        </span>
+        {clock ? (
+          <span
+            className={`inline-flex items-center gap-space-2 text-caption ${clock.urgent ? "text-signal-orange" : "text-text-muted"}`}
+          >
+            <ClockIcon size="h-space-4 w-space-4" />
+            <span className={TABULAR}>{clock.label}</span>
+          </span>
+        ) : null}
+      </span>
+      <ChevronIcon size="h-space-5 w-space-5" className="text-text-muted" />
+    </Link>
   );
 }

--- a/src/features/tournaments/components/tournament-leaderboard.tsx
+++ b/src/features/tournaments/components/tournament-leaderboard.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getDemoStandings, type DemoStanding } from "../demo-store";
+import { tournamentPhase } from "../format";
+import { getDemoTournamentCatches, type DemoTournamentCatch } from "../live-catch-demo";
+import { useDemoMode, useTournament } from "../use-tournament";
+import { CARD, CARD_PADDED, INSET, PAGE, TABULAR } from "../ui-classes";
+import { TrophyIcon } from "./icons";
+import {
+  BackLink,
+  DemoNote,
+  EmptyState,
+  ErrorScreen,
+  LoadingScreen,
+  SectionHeading,
+  TonePill,
+  TournamentTabs,
+} from "./tournament-chrome";
+
+/**
+ * /tournaments/[id]/leaderboard — the board.
+ *
+ * This used to be the "Leaderboard" tab of the operations screen, which meant an angler
+ * who wanted to know whether they were winning had to open a screen headed "Tournament
+ * operations" and sit next to the payout controls. Standings are the most-looked-at screen
+ * in any tournament and they belong to everybody, so they are their own place now.
+ *
+ * Two rules hold this screen honest:
+ *
+ * 1. **Provisional is said out loud.** A rank that could still move is not presented as a
+ *    result. Only FINAL gets called official.
+ * 2. **Public-safe fields only** (`core/tournaments/public-projection.ts`): a name, a
+ *    species, a measurement, a rank. No positions, no evidence, no review notes — not
+ *    because they are secret, but because a leaderboard is the one tournament screen that
+ *    gets screenshotted and sent to a group chat.
+ */
+export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }) {
+  const load = useTournament(tournamentId);
+  const demoMode = useDemoMode();
+  const [standings, setStandings] = useState<readonly DemoStanding[]>([]);
+  const [mine, setMine] = useState<readonly DemoTournamentCatch[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      await Promise.resolve();
+      if (cancelled) return;
+      setStandings(demoMode ? getDemoStandings(tournamentId) : []);
+      setMine(getDemoTournamentCatches(tournamentId));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [demoMode, tournamentId]);
+
+  if (load.state === "loading") return <LoadingScreen label="Loading standings" />;
+  if (load.state === "error") return <ErrorScreen message={load.message} />;
+
+  const tournament = load.tournament;
+  const official = tournament.status === "FINAL";
+  const finished = tournamentPhase(tournament.status) === "after";
+  const leader = standings.find((row) => row.rank === 1) ?? null;
+  const rest = standings.filter((row) => row !== leader);
+
+  return (
+    <div className={PAGE}>
+      <header className="flex flex-col gap-space-3">
+        <BackLink href={`/tournaments/${tournament.id}/overview`}>{tournament.name}</BackLink>
+        <div className="flex flex-wrap items-end justify-between gap-space-3">
+          <h1 className="text-h1 text-text-primary">Standings</h1>
+          <TonePill tone={official ? "done" : "attention"}>{official ? "Official" : "Provisional"}</TonePill>
+        </div>
+        <p className="text-body text-text-muted">
+          {official
+            ? "Every review is closed. This is the result."
+            : finished
+              ? "Fishing is over, but reviews are still open. Places can still move."
+              : "Places move as catches are approved. Nothing here is final until the organizer says so."}
+        </p>
+      </header>
+
+      <TournamentTabs tournamentId={tournament.id} />
+
+      {standings.length === 0 ? (
+        <EmptyState
+          title="Nothing has been scored yet"
+          body="Catches appear here once a judge has approved them. A catch on a phone is not a score — that is the point."
+        />
+      ) : (
+        <section className="flex flex-col gap-space-3" aria-label="Standings">
+          {leader ? (
+            <article
+              className={`${CARD} flex items-center gap-space-4 border-signal-orange/50 bg-linear-to-b from-surface-raised to-surface p-space-5`}
+            >
+              <span className="text-signal-orange">
+                <TrophyIcon size="h-space-8 w-space-8" />
+              </span>
+              <span className="flex flex-1 flex-col gap-space-1">
+                <span className="text-caption text-text-muted">
+                  {official ? "Winner" : "Leading"} · {leader.species}
+                </span>
+                <span className="text-h2 text-text-primary">{leader.display_name}</span>
+              </span>
+              <span className="flex flex-col items-end">
+                <span className={`text-h1 ${TABULAR} text-signal-orange`}>{leader.weight_lb.toFixed(1)}</span>
+                <span className="text-caption text-text-muted">lb</span>
+              </span>
+            </article>
+          ) : null}
+
+          <ol className="flex flex-col gap-space-2">
+            {rest.map((row) => (
+              <li
+                key={`${row.rank}-${row.display_name}`}
+                className={`${CARD} grid grid-cols-[auto_1fr_auto] items-center gap-space-3 p-space-4`}
+              >
+                <span className={`w-space-6 text-h3 ${TABULAR} text-text-muted`}>{row.rank}</span>
+                <span className="flex flex-col">
+                  <span className="text-body-strong text-text-primary">{row.display_name}</span>
+                  <span className="text-caption text-text-muted">
+                    {row.species}
+                    {row.official ? "" : " · waiting on a review"}
+                  </span>
+                </span>
+                <span className={`text-body-strong ${TABULAR} text-text-primary`}>
+                  {row.weight_lb.toFixed(1)} lb
+                </span>
+              </li>
+            ))}
+          </ol>
+        </section>
+      )}
+
+      {mine.length > 0 ? (
+        <section className={`${CARD_PADDED} flex flex-col gap-space-3`} aria-labelledby="mine-heading">
+          <SectionHeading aside={`${mine.length} on this phone`}>
+            <span id="mine-heading">Your catches, not yet scored</span>
+          </SectionHeading>
+          <p className="text-caption text-text-muted">
+            These are on this phone. They are not on the board until the tournament has them and a
+            judge has approved them.
+          </p>
+          <ul className="flex flex-col gap-space-2">
+            {mine.slice(0, 5).map((item) => (
+              <li key={item.id} className={`${INSET} flex items-center justify-between gap-space-3`}>
+                <span className="text-body text-text-primary">{item.species}</span>
+                <span className={`text-body ${TABULAR} text-text-muted`}>
+                  {item.weight_lb !== null ? `${item.weight_lb.toFixed(1)} lb` : "no weight"}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <p className="text-caption text-text-muted">
+        A public board shows a name, the fish, and the measurement. It never shows where anybody was
+        fishing, their photos, or anything a judge wrote.
+      </p>
+
+      {demoMode ? <DemoNote /> : null}
+    </div>
+  );
+}

--- a/src/features/tournaments/components/tournament-live-catches.tsx
+++ b/src/features/tournaments/components/tournament-live-catches.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useId, useState } from "react";
 
-import { getDemoTournament, hasSupabaseBrowserConfig } from "../demo-store";
+import { countdown, qrPresentation, syncPresentation, tournamentPhase, TONE_CLASSES } from "../format";
 import {
   getDemoTournamentCatches,
   queueDemoCatch,
@@ -11,28 +10,67 @@ import {
   syncDemoCatch,
   type DemoTournamentCatch,
 } from "../live-catch-demo";
-import { TOURNAMENT_CARD, TOURNAMENT_INPUT, TOURNAMENT_PRIMARY_BUTTON, TOURNAMENT_SECONDARY_BUTTON } from "../ui-classes";
+import { useDemoMode, useTournament } from "../use-tournament";
+import { useNow, useOnline } from "../use-now";
+import {
+  BIG_ACTION,
+  CARD,
+  CARD_PADDED,
+  CHIP,
+  CHIP_OFF,
+  CHIP_ON,
+  FOCUS_RING,
+  INPUT,
+  INSET,
+  PAGE,
+  SECONDARY_BUTTON,
+  TABULAR,
+} from "../ui-classes";
+import { AlertIcon, CheckIcon, ClockIcon, PendingIcon } from "./icons";
+import {
+  BackLink,
+  ConnectionPill,
+  DemoNote,
+  EmptyState,
+  ErrorScreen,
+  LoadingScreen,
+  SectionHeading,
+  TonePill,
+  TournamentTabs,
+} from "./tournament-chrome";
 
 type QrState = DemoTournamentCatch["qr_state"];
 
 const QR_STATES: Array<{ value: QrState; label: string }> = [
-  { value: "VALID", label: "Valid QR" },
-  { value: "NOT_SCANNED", label: "Not scanned" },
+  { value: "VALID", label: "Scanned, good" },
+  { value: "NOT_SCANNED", label: "No code" },
   { value: "EXPIRED", label: "Expired" },
-  { value: "REUSED", label: "Reused" },
-  { value: "WRONG_CONTEXT", label: "Wrong tournament" },
+  { value: "REUSED", label: "Already used" },
+  { value: "WRONG_CONTEXT", label: "Wrong event" },
 ];
 
-function syncLabel(value: DemoTournamentCatch["sync_state"]) {
-  if (value === "SAVED_OFFLINE") return "Saved offline";
-  if (value === "PENDING_SYNC") return "Pending sync";
-  if (value === "SYNCED") return "Synced";
-  return "Conflict — review required";
-}
-
+/**
+ * /tournaments/[id]/catches — the screen that gets used with one wet hand.
+ *
+ * Everything here is arranged around the promise the app can actually keep offshore:
+ * **the catch is written to this phone the instant you tap save, and it is never quietly
+ * changed after that.** The sync state says exactly where each catch has got to, in words
+ * that do not overclaim — "Saved on this phone" is not "verified", and the old copy's
+ * "Synced" pill was the closest this screen came to lying to somebody.
+ *
+ * This is also the screen that used to crash. It read `navigator.onLine` in the render
+ * body, which is a `ReferenceError` in the server render every page in this app still
+ * gets, so the whole route fell through to `error.tsx` before a single field was drawn.
+ */
 export function TournamentLiveCatches({ tournamentId }: { tournamentId: string }) {
+  const load = useTournament(tournamentId);
+  const demoMode = useDemoMode();
+  const online = useOnline();
+  const now = useNow();
+  const fieldId = useId();
+
   const [catches, setCatches] = useState<DemoTournamentCatch[]>([]);
-  const [species, setSpecies] = useState("Yellowtail");
+  const [species, setSpecies] = useState("");
   const [weight, setWeight] = useState("");
   const [length, setLength] = useState("");
   const [photoName, setPhotoName] = useState<string | null>(null);
@@ -40,38 +78,49 @@ export function TournamentLiveCatches({ tournamentId }: { tournamentId: string }
   const [qrState, setQrState] = useState<QrState>("VALID");
   const [message, setMessage] = useState<string | null>(null);
 
-  const demoMode = !hasSupabaseBrowserConfig();
-  const tournament = demoMode ? getDemoTournament(tournamentId) : null;
-
-  function refresh() {
+  const refresh = useCallback(() => {
     setCatches(getDemoTournamentCatches(tournamentId));
-  }
+  }, [tournamentId]);
 
   useEffect(() => {
-    // Schedule the localStorage synchronization asynchronously so this effect does not
-    // synchronously cascade a state update during the commit phase.
-    void Promise.resolve().then(() => {
-      setCatches(getDemoTournamentCatches(tournamentId));
-    });
-  }, [tournamentId]);
+    let cancelled = false;
+    void (async () => {
+      // `localStorage` is not there during the server render, and setting state
+      // synchronously in an effect body is a cascading render. One yield solves both.
+      await Promise.resolve();
+      if (!cancelled) refresh();
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [refresh]);
 
   function submit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
+
     if (!demoMode) {
-      setMessage("Live Supabase catch sync is not enabled in this UI lane yet. The local-first capture contract is ready for backend wiring.");
+      setMessage(
+        "This build records tournament catches on the phone only — the connection to the tournament scorer is not switched on yet. Nothing you enter here has been sent anywhere.",
+      );
       return;
     }
 
     const item = saveDemoCatch({
       tournamentId,
-      species,
+      species: species.trim(),
       weightLb: weight ? Number(weight) : null,
       lengthIn: length ? Number(length) : null,
       photoName,
       gpsCaptured,
       qrState,
     });
-    setMessage(`Catch ${item.id.slice(-6)} preserved on this device. You can sync it when service returns.`);
+
+    setMessage(
+      item.fair_play_messages.length > 0
+        ? `${item.species} saved on this phone. A couple of things on it will need a person to look — they are listed on the catch.`
+        : `${item.species} saved on this phone. It goes to the scorer when you have service.`,
+    );
+    setSpecies("");
     setWeight("");
     setLength("");
     setPhotoName(null);
@@ -80,147 +129,331 @@ export function TournamentLiveCatches({ tournamentId }: { tournamentId: string }
 
   function queue(id: string) {
     queueDemoCatch(id);
-    setMessage("Catch queued without changing its original evidence.");
+    setMessage("Queued. It will go up on its own when there is service.");
     refresh();
   }
 
   function sync(id: string) {
     syncDemoCatch(id);
-    setMessage("Sync attempted. Exact retries reuse the same client mutation id instead of creating a duplicate.");
+    setMessage(
+      "Sent. A retry uses the same catch, so trying twice can never put two of the same fish on the board.",
+    );
     refresh();
   }
 
-  if (demoMode && !tournament) {
-    return (
-      <div className="mx-auto flex max-w-reading flex-col gap-space-4 px-space-4 py-space-5">
-        <p className={`${TOURNAMENT_CARD} text-body text-error-red`}>Tournament not found on this device.</p>
-        <Link href="/tournaments" className={TOURNAMENT_SECONDARY_BUTTON}>Back to tournaments</Link>
-      </div>
-    );
-  }
+  if (load.state === "loading") return <LoadingScreen label="Loading catches" />;
+  if (load.state === "error") return <ErrorScreen message={load.message} />;
+
+  const tournament = load.tournament;
+  const phase = tournamentPhase(tournament.status);
+  const clock = now === 0 ? null : countdown(now, { status: tournament.status, startsAt: tournament.starts_at, endsAt: tournament.ends_at });
 
   return (
-    <div className="mx-auto flex max-w-reading flex-col gap-space-5 px-space-4 py-space-5">
-      <header className="flex flex-col gap-space-2">
-        <Link href={`/tournaments/${tournamentId}/overview`} className="text-caption text-text-link">← Overview</Link>
-        <div className="flex flex-wrap items-start justify-between gap-space-3">
-          <div>
-            <h1 className="text-h1 text-text-primary">Live catches</h1>
-            <p className="text-body text-text-muted">Record first. Sync second. Original evidence stays preserved.</p>
+    <div className={PAGE}>
+      <header className="flex flex-col gap-space-3">
+        <BackLink href={`/tournaments/${tournament.id}/overview`}>{tournament.name}</BackLink>
+        <div className="flex flex-wrap items-end justify-between gap-space-3">
+          <h1 className="text-h1 text-text-primary">Log a catch</h1>
+          <div className="flex flex-wrap items-center gap-space-2">
+            <ConnectionPill />
+            {clock ? (
+              <span
+                className={`inline-flex items-center gap-space-2 text-caption ${clock.urgent ? "text-signal-orange" : "text-text-muted"}`}
+              >
+                <ClockIcon size="h-space-4 w-space-4" />
+                <span className={TABULAR}>{clock.label}</span>
+              </span>
+            ) : null}
           </div>
-          {demoMode ? <span className="rounded-full border border-hairline px-space-3 py-space-1 text-caption text-text-muted">Demo mode</span> : null}
         </div>
+        <p className="text-body text-text-muted">
+          Write it down first, send it second. Nothing here needs service to work.
+        </p>
       </header>
 
-      <section className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`}>
-        <div className="flex items-start justify-between gap-space-3">
-          <div>
-            <h2 className="text-h3 text-text-primary">Catch session</h2>
-            <p className="text-caption text-text-muted">QR and evidence checks surface warnings only. They never silently change a score.</p>
-          </div>
-          <span className="text-caption text-text-muted">{navigator.onLine ? "Online" : "Offline"}</span>
+      <TournamentTabs tournamentId={tournament.id} />
+
+      {phase !== "during" ? (
+        <p className={`${INSET} flex items-start gap-space-3 text-body text-text-primary`} role="status">
+          <span className="mt-space-1 text-amber-flag">
+            <AlertIcon />
+          </span>
+          <span>
+            This tournament is not being fished right now
+            {tournament.status === "PAUSED" ? " — it is paused" : ""}. You can still record a catch and
+            it will be kept exactly as you entered it, but it will not score unless a judge decides it
+            should.
+          </span>
+        </p>
+      ) : null}
+
+      <form onSubmit={submit} className={`${CARD_PADDED} flex flex-col gap-space-5`}>
+        <label className="flex flex-col gap-space-2">
+          <span className="text-label text-text-primary">What is it?</span>
+          <input
+            id={`${fieldId}-species`}
+            required
+            value={species}
+            onChange={(event) => setSpecies(event.target.value)}
+            className={INPUT}
+            placeholder="Yellowtail"
+            autoComplete="off"
+          />
+        </label>
+
+        <div className="grid grid-cols-2 gap-space-3">
+          <label className="flex flex-col gap-space-2">
+            <span className="text-label text-text-primary">Weight</span>
+            <input
+              inputMode="decimal"
+              type="number"
+              min="0"
+              step="0.01"
+              value={weight}
+              onChange={(event) => setWeight(event.target.value)}
+              className={INPUT}
+              placeholder="18.4"
+              aria-describedby={`${fieldId}-weight-unit`}
+            />
+            <span id={`${fieldId}-weight-unit`} className="text-caption text-text-muted">
+              Pounds
+            </span>
+          </label>
+          <label className="flex flex-col gap-space-2">
+            <span className="text-label text-text-primary">Length</span>
+            <input
+              inputMode="decimal"
+              type="number"
+              min="0"
+              step="0.1"
+              value={length}
+              onChange={(event) => setLength(event.target.value)}
+              className={INPUT}
+              placeholder="34.5"
+              aria-describedby={`${fieldId}-length-unit`}
+            />
+            <span id={`${fieldId}-length-unit`} className="text-caption text-text-muted">
+              Inches
+            </span>
+          </label>
         </div>
 
-        <form onSubmit={submit} className="flex flex-col gap-space-4">
-          <label className="flex flex-col gap-space-2">
-            <span className="text-label text-text-primary">Species</span>
-            <input required value={species} onChange={(event) => setSpecies(event.target.value)} className={TOURNAMENT_INPUT} placeholder="Yellowtail" />
+        {/*
+          Evidence. Presented as three things you either have or you do not, rather than as
+          three form controls — the angler's question is "is this catch going to stand", and
+          a missing photo is the answer to it.
+        */}
+        <fieldset className="flex flex-col gap-space-3">
+          <legend className="text-label text-text-primary">Proof</legend>
+
+          <label
+            className={`${INSET} ${FOCUS_RING} flex min-h-touch-floor cursor-pointer items-start gap-space-3`}
+          >
+            <span className={`mt-space-1 ${photoName ? "text-success-green" : "text-text-muted"}`}>
+              {photoName ? <CheckIcon /> : <PendingIcon />}
+            </span>
+            <span className="flex flex-1 flex-col">
+              <span className="text-body text-text-primary">{photoName ? "Photo added" : "Add a photo"}</span>
+              <span className="text-caption text-text-muted">
+                {photoName ?? "Most events want one. Without it, a judge decides."}
+              </span>
+            </span>
+            <input
+              type="file"
+              accept="image/*"
+              capture="environment"
+              onChange={(event) => setPhotoName(event.target.files?.[0]?.name ?? null)}
+              className="sr-only"
+            />
           </label>
 
-          <div className="grid grid-cols-2 gap-space-3">
-            <label className="flex flex-col gap-space-2">
-              <span className="text-label text-text-primary">Weight (lb)</span>
-              <input inputMode="decimal" type="number" min="0" step="0.01" value={weight} onChange={(event) => setWeight(event.target.value)} className={TOURNAMENT_INPUT} placeholder="18.4" />
-            </label>
-            <label className="flex flex-col gap-space-2">
-              <span className="text-label text-text-primary">Length (in)</span>
-              <input inputMode="decimal" type="number" min="0" step="0.1" value={length} onChange={(event) => setLength(event.target.value)} className={TOURNAMENT_INPUT} placeholder="34.5" />
-            </label>
-          </div>
+          <button
+            type="button"
+            aria-pressed={gpsCaptured}
+            onClick={() => setGpsCaptured((value) => !value)}
+            className={`${INSET} ${FOCUS_RING} flex min-h-touch-floor items-start gap-space-3 text-left`}
+          >
+            <span className={`mt-space-1 ${gpsCaptured ? "text-success-green" : "text-amber-flag"}`}>
+              {gpsCaptured ? <CheckIcon /> : <AlertIcon />}
+            </span>
+            <span className="flex flex-1 flex-col">
+              <span className="text-body text-text-primary">
+                {gpsCaptured ? "Position recorded with this catch" : "No position with this catch"}
+              </span>
+              <span className="text-caption text-text-muted">
+                Where you caught it is never shown publicly. Tap to change.
+              </span>
+            </span>
+          </button>
 
-          <label className="flex flex-col gap-space-2">
-            <span className="text-label text-text-primary">Catch photo</span>
-            <input type="file" accept="image/*" capture="environment" onChange={(event) => setPhotoName(event.target.files?.[0]?.name ?? null)} className="min-h-touch-floor text-body text-text-primary" />
-            <span className="text-caption text-text-muted">In demo mode only the file name is stored; real evidence bytes remain a backend responsibility.</span>
-          </label>
-
-          <label className="flex min-h-touch-floor items-center gap-space-3 text-body text-text-primary">
-            <input type="checkbox" checked={gpsCaptured} onChange={(event) => setGpsCaptured(event.target.checked)} />
-            GPS captured with this catch
-          </label>
-
-          <fieldset className="flex flex-col gap-space-2">
-            <legend className="text-label text-text-primary">QR check</legend>
-            <div className="grid grid-cols-2 gap-space-2">
+          <div className="flex flex-col gap-space-2">
+            <span className="text-caption text-text-muted">Event code</span>
+            <div className="flex flex-wrap gap-space-2" role="group" aria-label="Event code check">
               {QR_STATES.map((option) => (
-                <button key={option.value} type="button" onClick={() => setQrState(option.value)} aria-pressed={qrState === option.value} className={qrState === option.value ? TOURNAMENT_PRIMARY_BUTTON : TOURNAMENT_SECONDARY_BUTTON}>
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setQrState(option.value)}
+                  aria-pressed={qrState === option.value}
+                  className={`${CHIP} ${qrState === option.value ? CHIP_ON : CHIP_OFF}`}
+                >
                   {option.label}
                 </button>
               ))}
             </div>
-          </fieldset>
+          </div>
+        </fieldset>
 
-          <button type="submit" disabled={species.trim().length === 0} className={TOURNAMENT_PRIMARY_BUTTON}>
-            Save catch
-          </button>
-        </form>
-      </section>
+        {/*
+          The reason a disabled primary action is disabled is stated next to it and bound to
+          it with `aria-describedby` (design 04 → Button → Disabled), so a screen reader
+          reaches the explanation rather than a dead control.
+        */}
+        <button
+          type="submit"
+          className={BIG_ACTION}
+          disabled={species.trim().length === 0}
+          aria-describedby={species.trim().length === 0 ? `${fieldId}-save-hint` : undefined}
+        >
+          {online ? "Save catch" : "Save on this phone"}
+        </button>
+        {species.trim().length === 0 ? (
+          <p id={`${fieldId}-save-hint`} className="text-caption text-text-muted">
+            Name the fish to save it.
+          </p>
+        ) : null}
+      </form>
 
-      {message ? <p className={`${TOURNAMENT_CARD} text-caption text-text-muted`} role="status">{message}</p> : null}
+      {message ? (
+        <p className={`${INSET} text-body text-text-primary`} role="status">
+          {message}
+        </p>
+      ) : null}
 
       <section className="flex flex-col gap-space-3" aria-labelledby="saved-catches-heading">
-        <div className="flex items-center justify-between gap-space-3">
-          <h2 id="saved-catches-heading" className="text-h3 text-text-primary">Saved catches</h2>
-          <span className="text-caption text-text-muted">{catches.length} on device</span>
-        </div>
+        <SectionHeading aside={catches.length > 0 ? `${catches.length} on this phone` : undefined}>
+          <span id="saved-catches-heading">Your catches</span>
+        </SectionHeading>
 
         {catches.length === 0 ? (
-          <p className={`${TOURNAMENT_CARD} text-body text-text-muted`}>No tournament catches recorded yet.</p>
+          <EmptyState
+            title="Nothing logged yet"
+            body="Anything you save appears here with its evidence, whether or not you have service."
+          />
         ) : (
           <ul className="flex flex-col gap-space-3">
             {catches.map((item) => (
-              <li key={item.id} className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`}>
-                <div className="flex items-start justify-between gap-space-3">
-                  <div>
-                    <p className="text-body-strong text-text-primary">{item.species}</p>
-                    <p className="text-caption text-text-muted">
-                      {item.weight_lb !== null ? `${item.weight_lb} lb` : "No weight"} · {item.length_in !== null ? `${item.length_in} in` : "No length"}
-                    </p>
-                  </div>
-                  <span className="rounded-full border border-hairline px-space-2 py-space-1 text-caption text-text-muted">{syncLabel(item.sync_state)}</span>
-                </div>
-
-                <dl className="grid grid-cols-2 gap-space-2 text-caption">
-                  <div><dt className="text-text-muted">Photo</dt><dd className="text-text-primary">{item.photo_name ?? "Missing"}</dd></div>
-                  <div><dt className="text-text-muted">GPS</dt><dd className="text-text-primary">{item.gps_captured ? "Captured" : "Missing"}</dd></div>
-                  <div><dt className="text-text-muted">QR</dt><dd className="text-text-primary">{item.qr_state.toLowerCase().replaceAll("_", " ")}</dd></div>
-                  <div><dt className="text-text-muted">Receipt</dt><dd className="text-text-primary">{item.server_receipt ? "Preserved" : "Not received"}</dd></div>
-                </dl>
-
-                {item.fair_play_messages.length > 0 ? (
-                  <div className="rounded-lg border border-hairline bg-surface-muted p-space-3">
-                    <p className="text-body-strong text-text-primary">Fair Play review</p>
-                    <ul className="mt-space-2 flex list-disc flex-col gap-space-1 pl-space-4 text-caption text-text-muted">
-                      {item.fair_play_messages.map((warning) => <li key={warning}>{warning}</li>)}
-                    </ul>
-                  </div>
-                ) : (
-                  <p className="text-caption text-text-muted">No Fair Play warnings detected in this local capture.</p>
-                )}
-
-                <div className="grid grid-cols-2 gap-space-2">
-                  <button type="button" className={TOURNAMENT_SECONDARY_BUTTON} onClick={() => queue(item.id)}>Queue sync</button>
-                  <button type="button" className={TOURNAMENT_PRIMARY_BUTTON} onClick={() => sync(item.id)}>Sync now</button>
-                </div>
-
-                {item.sync_state === "CONFLICT" ? (
-                  <p className="text-caption text-error-red">Conflict detected. The original evidence and prior server receipt are preserved; a human must decide how to reconcile it.</p>
-                ) : null}
-              </li>
+              <CatchCard key={item.id} item={item} onQueue={() => queue(item.id)} onSync={() => sync(item.id)} />
             ))}
           </ul>
         )}
       </section>
+
+      <p className="text-caption text-text-muted">
+        Checks on a catch — a missing photo, an odd code — only ever raise a flag for a person to
+        look at. Nothing here changes a score on its own.
+      </p>
+
+      {demoMode ? <DemoNote /> : null}
     </div>
+  );
+}
+
+/**
+ * One saved catch: what it was, where it has got to, and what the app has to back it up.
+ *
+ * The `CONFLICT` state gets the most words on purpose. It is the only state where somebody
+ * might reasonably fear their catch was lost or overwritten, and the honest answer — the
+ * original is kept exactly as recorded, and a person decides — is the whole reason the
+ * offline design works the way it does.
+ */
+function CatchCard({
+  item,
+  onQueue,
+  onSync,
+}: {
+  item: DemoTournamentCatch;
+  onQueue: () => void;
+  onSync: () => void;
+}) {
+  const sync = syncPresentation(item.sync_state);
+  const qr = qrPresentation(item.qr_state);
+  const measurements = [
+    item.weight_lb !== null ? `${item.weight_lb} lb` : null,
+    item.length_in !== null ? `${item.length_in} in` : null,
+  ].filter(Boolean);
+
+  return (
+    <li className={`${CARD} flex flex-col gap-space-4 p-space-4`}>
+      <div className="flex flex-wrap items-start justify-between gap-space-3">
+        <div className="flex flex-col gap-space-1">
+          <p className="text-h3 text-text-primary">{item.species}</p>
+          <p className={`text-body ${TABULAR} text-text-muted`}>
+            {measurements.length > 0 ? measurements.join(" · ") : "No measurement recorded"}
+          </p>
+        </div>
+        <TonePill tone={sync.tone}>{sync.label}</TonePill>
+      </div>
+
+      <p className="text-caption text-text-muted">{sync.hint}</p>
+
+      <ul className="flex flex-wrap gap-space-2">
+        <EvidenceChip ok={item.photo_name !== null} yes="Photo" no="No photo" />
+        <EvidenceChip ok={item.gps_captured} yes="Position" no="No position" />
+        <li>
+          <TonePill tone={qr.tone}>{qr.label}</TonePill>
+        </li>
+        <EvidenceChip
+          ok={item.server_receipt !== null}
+          yes="Receipt from the scorer"
+          no="No receipt yet"
+        />
+      </ul>
+
+      {item.fair_play_messages.length > 0 ? (
+        <div className={INSET}>
+          <p className="inline-flex items-center gap-space-2 text-body-strong text-amber-flag">
+            <AlertIcon />
+            For a judge to look at
+          </p>
+          <ul className="mt-space-2 flex list-disc flex-col gap-space-1 pl-space-4 text-caption text-text-muted">
+            {item.fair_play_messages.map((warning) => (
+              <li key={warning}>{warning}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {item.sync_state === "CONFLICT" ? (
+        <p className={`${INSET} text-body text-text-primary`}>
+          Your original photo and details are kept exactly as you recorded them, and so is the
+          scorer&apos;s earlier copy. Nothing was overwritten — a person decides which one stands.
+        </p>
+      ) : null}
+
+      {item.sync_state !== "SYNCED" ? (
+        <div className="grid grid-cols-2 gap-space-2">
+          <button type="button" className={SECONDARY_BUTTON} onClick={onQueue}>
+            Send later
+          </button>
+          <button type="button" className={SECONDARY_BUTTON} onClick={onSync}>
+            Send now
+          </button>
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+function EvidenceChip({ ok, yes, no }: { ok: boolean; yes: string; no: string }) {
+  const tone = ok ? "open" : "neutral";
+  const classes = TONE_CLASSES[tone];
+  return (
+    <li
+      className={`inline-flex items-center gap-space-2 rounded-full border px-space-3 py-space-1 text-caption ${classes.pill} ${classes.text}`}
+    >
+      {ok ? <CheckIcon size="h-space-4 w-space-4" /> : <PendingIcon size="h-space-4 w-space-4" />}
+      {ok ? yes : no}
+    </li>
   );
 }

--- a/src/features/tournaments/components/tournament-operations.tsx
+++ b/src/features/tournaments/components/tournament-operations.tsx
@@ -1,68 +1,133 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
-import { getDemoTournament, hasSupabaseBrowserConfig } from "../demo-store";
-import { getDemoTournamentCatches } from "../live-catch-demo";
-import { TOURNAMENT_CARD, TOURNAMENT_PRIMARY_BUTTON, TOURNAMENT_SECONDARY_BUTTON } from "../ui-classes";
+import {
+  canTransitionTournament,
+  TOURNAMENT_STATUSES,
+  validateTournamentTransition,
+  type TournamentStatus,
+} from "@/core/tournaments/lifecycle";
+import { getDemoStandings, type DemoStanding } from "../demo-store";
+import { isTournamentStatus, tournamentPhase, type Phase } from "../format";
+import { getDemoTournamentCatches, type DemoTournamentCatch } from "../live-catch-demo";
+import { useDemoMode, useTournament } from "../use-tournament";
+import {
+  CARD,
+  CARD_PADDED,
+  CHIP,
+  CHIP_OFF,
+  CHIP_ON,
+  INSET,
+  PAGE,
+  SECONDARY_BUTTON,
+  TABULAR,
+} from "../ui-classes";
+import { AlertIcon, LockIcon } from "./icons";
+import {
+  BackLink,
+  CheckRow,
+  DemoNote,
+  EmptyState,
+  ErrorScreen,
+  LoadingScreen,
+  SectionHeading,
+  StatTile,
+  StatusPill,
+  TonePill,
+} from "./tournament-chrome";
 
-type Panel = "organizer" | "judge" | "leaderboard" | "finance";
+/**
+ * /tournaments/[id]/operations — running the event.
+ *
+ * Three lanes, because the domain model keeps them apart and the UI must not be the place
+ * that quietly rejoins them: the person who runs the event, the person who judges a catch,
+ * and the person who is allowed to move money are three different authorities even when
+ * they happen to be the same human on a Saturday.
+ *
+ * What changed from the first version, beyond the styling: the lifecycle controls are no
+ * longer two hardcoded disabled buttons labelled "Close registration" and "Start
+ * tournament". They are computed from `core/tournaments/lifecycle.ts` — the same transition
+ * table the server enforces — so this screen shows the moves that are actually legal from
+ * where the tournament is, and, when LIVE is refused, says which of the four frozen inputs
+ * is missing. The judge queue is built from real catches carrying real Fair Play flags
+ * rather than one invented "Yellowtail · evidence review" card, and the finance panel no
+ * longer displays $1,250 of money nobody took.
+ */
 
-type Standing = {
-  rank: number;
-  angler: string;
-  fish: string;
-  weightLb: number;
-  status: "official" | "pending";
+type Lane = "organizer" | "judge" | "finance";
+
+const LANES: Array<{ value: Lane; label: string }> = [
+  { value: "organizer", label: "Organizer" },
+  { value: "judge", label: "Judging" },
+  { value: "finance", label: "Money" },
+];
+
+const PHASE_HEADING: Readonly<Record<Phase, string>> = {
+  before: "Before the event",
+  during: "While it is being fished",
+  after: "After lines out",
 };
 
-const PANELS: Array<{ value: Panel; label: string }> = [
-  { value: "organizer", label: "Organizer" },
-  { value: "judge", label: "Judge" },
-  { value: "leaderboard", label: "Leaderboard" },
-  { value: "finance", label: "Finance" },
-];
+export function TournamentOperations({
+  tournamentId,
+  initialPanel = "organizer",
+}: {
+  tournamentId: string;
+  initialPanel?: Lane;
+}) {
+  const load = useTournament(tournamentId);
+  const demoMode = useDemoMode();
+  const [lane, setLane] = useState<Lane>(initialPanel);
+  const [catches, setCatches] = useState<readonly DemoTournamentCatch[]>([]);
+  const [standings, setStandings] = useState<readonly DemoStanding[]>([]);
 
-const DEMO_STANDINGS: Standing[] = [
-  { rank: 1, angler: "M. Rivera", fish: "Yellowtail", weightLb: 28.6, status: "official" },
-  { rank: 2, angler: "J. Park", fish: "Yellowtail", weightLb: 24.2, status: "official" },
-  { rank: 3, angler: "A. Lewis", fish: "Yellowtail", weightLb: 21.9, status: "pending" },
-];
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      await Promise.resolve();
+      if (cancelled) return;
+      setCatches(getDemoTournamentCatches(tournamentId));
+      setStandings(demoMode ? getDemoStandings(tournamentId) : []);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [demoMode, tournamentId]);
 
-export function TournamentOperations({ tournamentId, initialPanel = "organizer" }: { tournamentId: string; initialPanel?: Panel }) {
-  const [panel, setPanel] = useState<Panel>(initialPanel);
-  const demoMode = !hasSupabaseBrowserConfig();
-  const tournament = demoMode ? getDemoTournament(tournamentId) : null;
-  const catches = useMemo(() => (demoMode ? getDemoTournamentCatches(tournamentId) : []), [demoMode, tournamentId]);
+  const flagged = useMemo(() => catches.filter((item) => item.fair_play_messages.length > 0), [catches]);
 
-  if (demoMode && !tournament) {
-    return (
-      <div className="mx-auto flex max-w-reading flex-col gap-space-4 px-space-4 py-space-5">
-        <p className={`${TOURNAMENT_CARD} text-body text-error-red`}>Tournament not found on this device.</p>
-        <Link href="/tournaments" className={TOURNAMENT_SECONDARY_BUTTON}>Back to tournaments</Link>
-      </div>
-    );
-  }
+  if (load.state === "loading") return <LoadingScreen label="Loading organizer tools" />;
+  if (load.state === "error") return <ErrorScreen message={load.message} />;
+
+  const tournament = load.tournament;
+  const phase = tournamentPhase(tournament.status);
 
   return (
-    <div className="mx-auto flex max-w-reading flex-col gap-space-5 px-space-4 py-space-5">
-      <header className="flex flex-col gap-space-2">
-        <Link href={`/tournaments/${tournamentId}/overview`} className="text-caption text-text-link">← Overview</Link>
-        <div className="flex flex-wrap items-start justify-between gap-space-3">
-          <div>
-            <h1 className="text-h1 text-text-primary">Tournament operations</h1>
-            <p className="text-body text-text-muted">Run the event without mixing judging, public standings, and money permissions.</p>
-          </div>
-          {demoMode ? <span className="rounded-full border border-hairline px-space-3 py-space-1 text-caption text-text-muted">Demo mode</span> : null}
+    <div className={PAGE}>
+      <header className="flex flex-col gap-space-3">
+        <BackLink href={`/tournaments/${tournament.id}/overview`}>{tournament.name}</BackLink>
+        <div className="flex flex-wrap items-end justify-between gap-space-3">
+          <h1 className="text-h1 text-text-primary">Run the event</h1>
+          <StatusPill status={tournament.status} />
         </div>
+        <p className="text-body text-text-muted">
+          {PHASE_HEADING[phase]}. Judging, the public board, and anything to do with money each sit
+          behind their own permission — nobody gets all three by accident.
+        </p>
       </header>
 
-      <nav aria-label="Operations roles" className="overflow-x-auto">
-        <ul className="flex min-w-max gap-space-2 pb-space-1">
-          {PANELS.map((item) => (
+      <nav aria-label="Organizer tools" className="-mx-4 overflow-x-auto px-4">
+        <ul className="flex min-w-max gap-space-2 pb-1">
+          {LANES.map((item) => (
             <li key={item.value}>
-              <button type="button" aria-pressed={panel === item.value} onClick={() => setPanel(item.value)} className={panel === item.value ? TOURNAMENT_PRIMARY_BUTTON : TOURNAMENT_SECONDARY_BUTTON}>
+              <button
+                type="button"
+                aria-pressed={lane === item.value}
+                onClick={() => setLane(item.value)}
+                className={`${CHIP} ${lane === item.value ? CHIP_ON : CHIP_OFF}`}
+              >
                 {item.label}
               </button>
             </li>
@@ -70,89 +135,277 @@ export function TournamentOperations({ tournamentId, initialPanel = "organizer" 
         </ul>
       </nav>
 
-      {panel === "organizer" ? <OrganizerPanel catches={catches.length} /> : null}
-      {panel === "judge" ? <JudgePanel catches={catches.length} /> : null}
-      {panel === "leaderboard" ? <LeaderboardPanel /> : null}
-      {panel === "finance" ? <FinancePanel /> : null}
+      {lane === "organizer" ? (
+        <OrganizerLane tournament={tournament} phase={phase} catches={catches.length} flagged={flagged.length} standings={standings.length} />
+      ) : null}
+      {lane === "judge" ? <JudgeLane flagged={flagged} /> : null}
+      {lane === "finance" ? <FinanceLane /> : null}
+
+      {demoMode ? <DemoNote /> : null}
     </div>
   );
 }
 
-function OrganizerPanel({ catches }: { catches: number }) {
+/* -------------------------------------------------------------------------- */
+/* Organizer                                                                   */
+/* -------------------------------------------------------------------------- */
+
+const READINESS = [
+  ["active_rule_set_version_id", "Rules"],
+  ["active_scoring_version_id", "Scoring"],
+  ["active_verification_policy_version_id", "What counts as proof"],
+  ["active_boundary_version_id", "Where you can fish"],
+] as const;
+
+/** What a director would call each transition, rather than the enum it moves to. */
+const TRANSITION_LABEL: Readonly<Record<TournamentStatus, string>> = {
+  DRAFT: "Back to draft",
+  REGISTRATION_OPEN: "Open entries",
+  REGISTRATION_CLOSED: "Close entries",
+  READY: "Mark ready",
+  LIVE: "Start fishing",
+  PAUSED: "Pause",
+  COMPLETED: "Lines out",
+  RESULTS_PENDING: "Start settling results",
+  FINAL: "Make it official",
+  CANCELLED: "Cancel the tournament",
+};
+
+/**
+ * High-risk moves, per UX-001 §6 — the ones that need a confirmation and an explanation of
+ * consequences before they fire. They are marked here so that whoever wires these controls
+ * to the server cannot miss which three they are.
+ */
+const HIGH_RISK: ReadonlySet<TournamentStatus> = new Set(["LIVE", "FINAL", "CANCELLED"]);
+
+function OrganizerLane({
+  tournament,
+  phase,
+  catches,
+  flagged,
+  standings,
+}: {
+  tournament: {
+    readonly status: string;
+    readonly id: string;
+    readonly active_rule_set_version_id: string | null;
+    readonly active_scoring_version_id: string | null;
+    readonly active_verification_policy_version_id: string | null;
+    readonly active_boundary_version_id: string | null;
+  };
+  phase: Phase;
+  catches: number;
+  flagged: number;
+  standings: number;
+}) {
+  const versions = {
+    ruleSetVersionId: tournament.active_rule_set_version_id,
+    scoringVersionId: tournament.active_scoring_version_id,
+    verificationPolicyVersionId: tournament.active_verification_policy_version_id,
+    boundaryVersionId: tournament.active_boundary_version_id,
+  };
+
+  const from = isTournamentStatus(tournament.status) ? tournament.status : null;
+
+  // Every state the transition table allows from here, each carrying the server's own
+  // reason when it would be refused. Computing it from `core/` rather than hardcoding a
+  // pair of buttons means this screen cannot drift from the rules the server enforces.
+  const moves = from
+    ? TOURNAMENT_STATUSES.filter((to) => canTransitionTournament(from, to)).map((to) => ({
+        to,
+        result: validateTournamentTransition({ from, to, versions }),
+      }))
+    : [];
+
+  return (
+    <div className="flex flex-col gap-space-5">
+      {/*
+        Two across on a phone rather than one. Three full-width cards each holding a single
+        digit is a lot of scrolling to learn three numbers.
+      */}
+      <section className="grid grid-cols-2 gap-space-3 sm:grid-cols-3" aria-label="Event at a glance">
+        <StatTile label="Catches logged" value={String(catches)} />
+        <StatTile label="For a judge" value={String(flagged)} tone={flagged > 0 ? "attention" : "neutral"} />
+        <StatTile label="On the board" value={String(standings)} />
+      </section>
+
+      {phase === "before" ? (
+        <section className={`${CARD_PADDED} flex flex-col gap-space-3`}>
+          <SectionHeading aside={`${READINESS.filter(([key]) => tournament[key] !== null).length} of 4`}>
+            Locked before fishing starts
+          </SectionHeading>
+          <ul className="flex flex-col gap-space-3">
+            {READINESS.map(([key, label]) => (
+              <CheckRow
+                key={key}
+                state={tournament[key] !== null ? "done" : "pending"}
+                label={label}
+                detail={tournament[key] !== null ? "Locked." : "Still to set."}
+              />
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <section className={`${CARD_PADDED} flex flex-col gap-space-3`}>
+        <SectionHeading>What you can do next</SectionHeading>
+        {moves.length === 0 ? (
+          <p className="text-body text-text-muted">
+            This tournament is finished. Nothing moves from here.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-space-3">
+            {moves.map(({ to, result }) => (
+              <li key={to} className="flex flex-col gap-space-2">
+                <button type="button" className={SECONDARY_BUTTON} disabled>
+                  {TRANSITION_LABEL[to]}
+                </button>
+                <p className="text-caption text-text-muted">
+                  {!result.ok ? (
+                    <span className="inline-flex items-start gap-space-2 text-amber-flag">
+                      <AlertIcon size="h-space-4 w-space-4" />
+                      Not yet — the rules, scoring, proof and boundaries all have to be locked first.
+                    </span>
+                  ) : HIGH_RISK.has(to) ? (
+                    "This one will ask you to confirm, and tell you what it changes, before it does anything."
+                  ) : (
+                    "Moves the whole tournament to this state for everybody."
+                  )}
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+        <p className="inline-flex items-start gap-space-2 border-t border-hairline pt-space-3 text-caption text-text-muted">
+          <LockIcon size="h-space-4 w-space-4" />
+          These controls are shown, and disabled, on purpose. Moving a tournament between states is
+          the server&apos;s decision, not the phone&apos;s, and that half is not switched on in this
+          build yet.
+        </p>
+      </section>
+
+      <Link href={`/tournaments/${tournament.id}/leaderboard`} className={SECONDARY_BUTTON}>
+        Open the public board
+      </Link>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Judging                                                                     */
+/* -------------------------------------------------------------------------- */
+
+function JudgeLane({ flagged }: { flagged: readonly DemoTournamentCatch[] }) {
   return (
     <div className="flex flex-col gap-space-4">
-      <section className="grid gap-space-3 sm:grid-cols-3" aria-label="Tournament operations summary">
-        <Metric label="Lifecycle" value="Registration open" />
-        <Metric label="Caught on device" value={String(catches)} />
-        <Metric label="Review queue" value={catches > 0 ? String(Math.min(catches, 2)) : "0"} />
+      <section className="flex flex-col gap-space-3">
+        <SectionHeading aside={flagged.length > 0 ? `${flagged.length} waiting` : undefined}>
+          Review queue
+        </SectionHeading>
+
+        {flagged.length === 0 ? (
+          <EmptyState
+            title="Nothing needs a decision"
+            body="Catches land here when something about them needs a person — a missing photo, a code that had already been used, no position recorded."
+          />
+        ) : (
+          <ul className="flex flex-col gap-space-3">
+            {flagged.map((item) => (
+              <li key={item.id} className={`${CARD} flex flex-col gap-space-3 p-space-4`}>
+                <div className="flex flex-wrap items-start justify-between gap-space-3">
+                  <div className="flex flex-col gap-space-1">
+                    <p className="text-body-strong text-text-primary">{item.species}</p>
+                    <p className={`text-caption ${TABULAR} text-text-muted`}>
+                      {item.weight_lb !== null ? `${item.weight_lb} lb` : "No weight"} ·{" "}
+                      {new Date(item.captured_at).toLocaleString()}
+                    </p>
+                  </div>
+                  <TonePill tone="attention">Needs a decision</TonePill>
+                </div>
+
+                <ul className="flex list-disc flex-col gap-space-1 pl-space-4 text-caption text-text-muted">
+                  {item.fair_play_messages.map((warning) => (
+                    <li key={warning}>{warning}</li>
+                  ))}
+                </ul>
+
+                <div className="grid grid-cols-2 gap-space-2">
+                  <button type="button" className={SECONDARY_BUTTON} disabled>
+                    See the evidence
+                  </button>
+                  <button type="button" className={SECONDARY_BUTTON} disabled>
+                    Record a decision
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
       </section>
-      <section className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`}>
-        <h2 className="text-h3 text-text-primary">Director controls</h2>
-        <p className="text-body text-text-muted">Lifecycle transitions remain server-authoritative. LIVE requires frozen rules, scoring, verification policy, and boundaries.</p>
-        <div className="grid grid-cols-2 gap-space-2">
-          <button type="button" className={TOURNAMENT_SECONDARY_BUTTON} disabled>Close registration</button>
-          <button type="button" className={TOURNAMENT_SECONDARY_BUTTON} disabled>Start tournament</button>
-        </div>
-        <p className="text-caption text-text-muted">Controls are visible in demo mode but cannot mutate authoritative tournament state.</p>
-      </section>
+
+      <p className={`${INSET} text-caption text-text-muted`}>
+        A judge can approve, reject, penalise, reverse an earlier call, or settle a dispute, and every
+        one of those needs a reason written down. Nothing on this screen can touch money — that is a
+        different permission held by a different person.
+      </p>
     </div>
   );
 }
 
-function JudgePanel({ catches }: { catches: number }) {
+/* -------------------------------------------------------------------------- */
+/* Money                                                                       */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The finance lane shows no numbers.
+ *
+ * The first version displayed "$1,250" of entry receipts and a "$1,000" prize pool on every
+ * tournament, which were invented. Money is the one place in this product where a
+ * placeholder is not a harmless mock — an organizer who reads a payout figure off a screen
+ * and repeats it at a weigh-in has been misled by us. Until there is a real ledger to read,
+ * this lane explains the guarantee it enforces and offers nothing to press.
+ */
+function FinanceLane() {
   return (
     <div className="flex flex-col gap-space-4">
-      <section className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`}>
-        <div className="flex items-center justify-between gap-space-3"><h2 className="text-h3 text-text-primary">Review queue</h2><span className="text-caption text-text-muted">{catches > 0 ? Math.min(catches, 2) : 1} pending</span></div>
-        <article className="rounded-lg border border-hairline bg-surface-muted p-space-3">
-          <p className="text-body-strong text-text-primary">Yellowtail · evidence review</p>
-          <p className="text-caption text-text-muted">QR context warning · GPS evidence preserved · score unchanged pending human decision.</p>
-          <div className="mt-space-3 grid grid-cols-2 gap-space-2">
-            <button type="button" className={TOURNAMENT_SECONDARY_BUTTON}>View evidence</button>
-            <button type="button" className={TOURNAMENT_PRIMARY_BUTTON}>Record decision</button>
-          </div>
-        </article>
-        <p className="text-caption text-text-muted">Judges can approve, reject, penalize, reverse, or resolve a dispute with a reason. Finance actions are intentionally unavailable here.</p>
+      <section className={`${CARD_PADDED} flex flex-col gap-space-3`}>
+        <SectionHeading>Entry money and payouts</SectionHeading>
+        <p className="text-body text-text-primary">
+          Nothing has been taken and nothing is owed. Payments are not switched on for this
+          tournament.
+        </p>
+        <p className="text-caption text-text-muted">
+          When they are, this is where entry receipts and the prize pool are read from the ledger —
+          never estimated on the phone.
+        </p>
+      </section>
+
+      <section className={`${CARD_PADDED} flex flex-col gap-space-3`}>
+        <SectionHeading>The rule that does not bend</SectionHeading>
+        <ul className="flex flex-col gap-space-3">
+          <CheckRow
+            state="done"
+            label="Working out the result never moves money"
+            detail="Final standings can produce a payout instruction. Carrying it out is a separate, deliberate act."
+          />
+          <CheckRow
+            state="done"
+            label="A person with money permission has to approve it"
+            detail="Being the organizer, or the judge, is not enough on its own."
+          />
+          <CheckRow
+            state="done"
+            label="Card details and wallet keys never reach this screen"
+            detail="The app shows what was paid and to whom, not the means of paying."
+          />
+        </ul>
+        <button type="button" className={SECONDARY_BUTTON} disabled>
+          Approve a payout
+        </button>
+        <p className="text-caption text-text-muted">
+          There is nothing to approve, and payouts are not switched on in this build.
+        </p>
       </section>
     </div>
   );
-}
-
-function LeaderboardPanel() {
-  return (
-    <section className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`}>
-      <div><h2 className="text-h3 text-text-primary">Official leaderboard</h2><p className="text-caption text-text-muted">Public-safe standings only. Raw GPS, evidence, Fair Play signals, and private review notes are excluded.</p></div>
-      <ol className="flex flex-col gap-space-2">
-        {DEMO_STANDINGS.map((row) => (
-          <li key={`${row.rank}-${row.angler}`} className="grid grid-cols-[auto_1fr_auto] items-center gap-space-3 rounded-lg border border-hairline p-space-3">
-            <span className="text-h3 text-text-primary">{row.rank}</span>
-            <span><span className="block text-body-strong text-text-primary">{row.angler}</span><span className="text-caption text-text-muted">{row.fish}</span></span>
-            <span className="text-right"><span className="block text-body-strong text-text-primary">{row.weightLb.toFixed(1)} lb</span><span className="text-caption capitalize text-text-muted">{row.status}</span></span>
-          </li>
-        ))}
-      </ol>
-    </section>
-  );
-}
-
-function FinancePanel() {
-  return (
-    <div className="flex flex-col gap-space-4">
-      <section className="grid gap-space-3 sm:grid-cols-3" aria-label="Tournament finance summary">
-        <Metric label="Entry receipts" value="$1,250" />
-        <Metric label="Prize pool" value="$1,000" />
-        <Metric label="Payout state" value="Draft" />
-      </section>
-      <section className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`}>
-        <h2 className="text-h3 text-text-primary">Payout approval</h2>
-        <p className="text-body text-text-muted">Final standings may calculate payout instructions, but scoring cannot move money. A finance-authorized human must approve execution separately.</p>
-        <button type="button" className={TOURNAMENT_PRIMARY_BUTTON} disabled>Approve payout instruction</button>
-        <p className="text-caption text-text-muted">Provider secrets, payment tokens, wallet credentials, and raw account capabilities are never shown here.</p>
-      </section>
-    </div>
-  );
-}
-
-function Metric({ label, value }: { label: string; value: string }) {
-  return <article className={`${TOURNAMENT_CARD} flex flex-col gap-space-1`}><span className="text-caption text-text-muted">{label}</span><span className="text-body-strong text-text-primary">{value}</span></article>;
 }

--- a/src/features/tournaments/components/tournament-overview.tsx
+++ b/src/features/tournaments/components/tournament-overview.tsx
@@ -3,103 +3,287 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
-import { createClient } from "@/lib/supabase/client";
-import type { TournamentStatus } from "@/core/tournaments/lifecycle";
-import { getDemoTournament, hasSupabaseBrowserConfig, type DemoTournament } from "../demo-store";
-import { TOURNAMENT_CARD, TOURNAMENT_SECONDARY_BUTTON } from "../ui-classes";
+import { getDemoEntry, getDemoStandings, type DemoEntry, type DemoStanding } from "../demo-store";
+import { entrySteps, formatDateTime, tournamentPhase, visibilityPresentation } from "../format";
+import { getDemoTournamentCatches } from "../live-catch-demo";
+import { useDemoMode, useTournament } from "../use-tournament";
+import { BIG_ACTION, CARD, CARD_PADDED, FOCUS_RING, PAGE, SECONDARY_BUTTON, TABULAR } from "../ui-classes";
+import { ChevronIcon, LockIcon, TrophyIcon } from "./icons";
+import {
+  CheckRow,
+  DemoNote,
+  ErrorScreen,
+  LoadingScreen,
+  SectionHeading,
+  TonePill,
+  TournamentHero,
+  TournamentTabs,
+} from "./tournament-chrome";
 
-type TournamentOverviewData = DemoTournament & { status: TournamentStatus };
+/**
+ * /tournaments/[id]/overview — the tournament's home.
+ *
+ * The question this screen answers is "what do I do about this tournament right now",
+ * and the answer changes completely depending on where the event is in its life. So the
+ * screen leads with one action sized like it matters — enter it, log a catch, finish
+ * setting it up, see who won — and only then explains itself.
+ *
+ * The old version led with a progress bar labelled "4 locked inputs selected" over the
+ * sentence "Rules, scoring, verification policy and tournament boundaries must all be
+ * frozen before READY can move to LIVE." That is the domain model talking to itself. The
+ * checklist below says the same thing in the words a person running a fishing tournament
+ * would use, and it is a checklist rather than a bar because a bar cannot tell you which
+ * one is missing.
+ */
 
-const NAV_ITEMS = [
-  ["Overview", "overview"],
-  ["Register", "register"],
-  ["Catches", "catches"],
-  ["Leaderboard", "leaderboard"],
-  ["Operations", "operations"],
-  ["Rules", "rules"],
+/** The four frozen competition inputs, in the order a director would work through them. */
+const READINESS = [
+  {
+    key: "active_rule_set_version_id",
+    label: "The rules",
+    detail: "What counts, what does not, and the penalties. Locked so they cannot change mid-event.",
+  },
+  {
+    key: "active_scoring_version_id",
+    label: "How it is scored",
+    detail: "Heaviest fish, total weight, points by species — whatever this event runs on.",
+  },
+  {
+    key: "active_verification_policy_version_id",
+    label: "What counts as proof",
+    detail: "Photo, GPS, a scanned code, a measured length. Set once, applied to everyone.",
+  },
+  {
+    key: "active_boundary_version_id",
+    label: "Where you can fish",
+    detail: "The water this tournament covers.",
+  },
 ] as const;
 
-function formatDate(value: string | null) {
-  if (!value) return "Not scheduled";
-  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(value));
-}
-
 export function TournamentOverview({ tournamentId }: { tournamentId: string }) {
-  const [tournament, setTournament] = useState<TournamentOverviewData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const demoMode = !hasSupabaseBrowserConfig();
+  const load = useTournament(tournamentId);
+  const demoMode = useDemoMode();
+  const [entry, setEntry] = useState<DemoEntry | null>(null);
+  const [standings, setStandings] = useState<readonly DemoStanding[]>([]);
+  const [deviceCatches, setDeviceCatches] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
-
-    async function load() {
-      if (demoMode) {
-        const demo = getDemoTournament(tournamentId);
-        if (!cancelled) {
-          if (demo) setTournament(demo as TournamentOverviewData);
-          else setError("Demo tournament not found on this device.");
-          setLoading(false);
-        }
-        return;
-      }
-
-      try {
-        const supabase = createClient();
-        const { data, error: queryError } = await supabase
-          .from("tournament")
-          .select("id,name,status,visibility,starts_at,ends_at,organization_id,active_rule_set_version_id,active_scoring_version_id,active_verification_policy_version_id,active_boundary_version_id")
-          .eq("id", tournamentId)
-          .is("deleted_at", null)
-          .maybeSingle();
-
-        if (cancelled) return;
-        if (queryError) setError(queryError.message);
-        else if (!data) setError("Tournament not found or you do not have access.");
-        else setTournament(data as TournamentOverviewData);
-      } catch (cause) {
-        if (!cancelled) setError(cause instanceof Error ? cause.message : "Tournament unavailable.");
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-
-    void load();
-    return () => { cancelled = true; };
+    void (async () => {
+      // Deferred so nothing is set synchronously inside the effect body, and because these
+      // reads touch `localStorage`, which does not exist during the server render.
+      await Promise.resolve();
+      if (cancelled) return;
+      setEntry(demoMode ? getDemoEntry(tournamentId) : null);
+      setStandings(demoMode ? getDemoStandings(tournamentId) : []);
+      setDeviceCatches(getDemoTournamentCatches(tournamentId).length);
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, [demoMode, tournamentId]);
 
-  if (loading) return <div className="mx-auto max-w-reading px-space-4 py-space-5 text-body text-text-muted">Loading tournament…</div>;
-  if (error || !tournament) {
-    return <div className="mx-auto flex max-w-reading flex-col gap-space-4 px-space-4 py-space-5"><p className={`${TOURNAMENT_CARD} text-body text-error-red`} role="alert">{error ?? "Tournament unavailable."}</p><Link href="/tournaments" className={TOURNAMENT_SECONDARY_BUTTON}>Back to tournaments</Link></div>;
-  }
+  if (load.state === "loading") return <LoadingScreen />;
+  if (load.state === "error") return <ErrorScreen message={load.message} />;
 
-  const versionsReady = [tournament.active_rule_set_version_id, tournament.active_scoring_version_id, tournament.active_verification_policy_version_id, tournament.active_boundary_version_id].filter(Boolean).length;
+  const tournament = load.tournament;
+  const phase = tournamentPhase(tournament.status);
+  const locked = READINESS.filter((item) => tournament[item.key] !== null);
+  const ready = locked.length === READINESS.length;
+  const visibility = visibilityPresentation(tournament.visibility);
 
   return (
-    <div className="mx-auto flex max-w-reading flex-col gap-space-5 px-space-4 py-space-5">
-      <header className="flex flex-col gap-space-3">
-        <Link href="/tournaments" className="text-caption text-text-link">← Tournaments</Link>
-        <div className="flex flex-col gap-space-1">
-          <div className="flex flex-wrap items-center justify-between gap-space-2"><h1 className="text-h1 text-text-primary">{tournament.name}</h1><span className="rounded-full border border-hairline px-space-3 py-space-1 text-caption capitalize text-text-muted">{tournament.status.toLowerCase().replaceAll("_", " ")}</span></div>
-          <p className="text-body text-text-muted">{formatDate(tournament.starts_at)} · {tournament.visibility.toLowerCase().replaceAll("_", " ")}</p>
-          {demoMode ? <p className="text-caption text-text-muted">Demo mode · local device data.</p> : null}
-        </div>
-      </header>
+    <div className={PAGE}>
+      <TournamentHero tournament={tournament}>
+        <PrimaryAction tournament={tournament} entry={entry} phase={phase} />
+      </TournamentHero>
 
-      <nav aria-label="Tournament sections" className="overflow-x-auto"><ul className="flex min-w-max gap-space-2 pb-space-1">{NAV_ITEMS.map(([label, route]) => <li key={route}><Link href={`/tournaments/${tournament.id}/${route}`} className="inline-flex min-h-touch-floor items-center rounded-full border border-hairline bg-surface px-space-3 text-label text-text-primary">{label}</Link></li>)}</ul></nav>
+      <TournamentTabs tournamentId={tournament.id} />
 
-      <section className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`} aria-labelledby="readiness-heading">
-        <div className="flex items-center justify-between gap-space-3"><h2 id="readiness-heading" className="text-h3 text-text-primary">Competition readiness</h2><span className="text-caption text-text-muted">{versionsReady}/4 locked inputs selected</span></div>
-        <div className="h-space-2 overflow-hidden rounded-full bg-surface-muted" aria-hidden="true"><div className="h-full bg-action" style={{ width: `${versionsReady * 25}%` }} /></div>
-        <p className="text-caption text-text-muted">Rules, scoring, verification policy and tournament boundaries must all be frozen before READY can move to LIVE.</p>
+      {entry ? (
+        <section className={`${CARD_PADDED} flex flex-col gap-space-3`} aria-labelledby="your-entry-heading">
+          <SectionHeading>
+            <span id="your-entry-heading">Your entry</span>
+          </SectionHeading>
+          <ul className="flex flex-wrap gap-space-2">
+            {entrySteps(entry).map((item) => (
+              <li key={item.label}>
+                <TonePill tone={item.tone}>
+                  {item.label}: {item.value}
+                </TonePill>
+              </li>
+            ))}
+          </ul>
+          <Link href={`/tournaments/${tournament.id}/register`} className="text-caption text-text-link">
+            See what each of these means →
+          </Link>
+        </section>
+      ) : null}
+
+      {phase === "before" ? (
+        <section className={`${CARD_PADDED} flex flex-col gap-space-4`} aria-labelledby="readiness-heading">
+          <SectionHeading aside={`${locked.length} of ${READINESS.length} locked`}>
+            <span id="readiness-heading">Before it can go live</span>
+          </SectionHeading>
+
+          <div
+            className="flex h-space-2 gap-space-1 overflow-hidden rounded-full"
+            role="img"
+            aria-label={`${locked.length} of ${READINESS.length} competition settings locked`}
+          >
+            {READINESS.map((item) => (
+              <span
+                key={item.key}
+                className={`h-full flex-1 rounded-full ${
+                  tournament[item.key] !== null ? "bg-success-green" : "bg-surface-raised"
+                }`}
+              />
+            ))}
+          </div>
+
+          <ul className="flex flex-col gap-space-3">
+            {READINESS.map((item) => (
+              <CheckRow
+                key={item.key}
+                state={tournament[item.key] !== null ? "done" : "pending"}
+                label={item.label}
+                detail={tournament[item.key] !== null ? "Locked." : item.detail}
+              />
+            ))}
+          </ul>
+
+          <p className="inline-flex items-start gap-space-2 text-caption text-text-muted">
+            <LockIcon size="h-space-4 w-space-4" />
+            {ready
+              ? "All four are locked. Nothing can change underneath the anglers once fishing starts."
+              : "Once locked, these cannot change while the tournament is running. That is what makes a result defensible."}
+          </p>
+        </section>
+      ) : null}
+
+      {standings.length > 0 ? (
+        <section className={`${CARD_PADDED} flex flex-col gap-space-3`} aria-labelledby="standings-heading">
+          <SectionHeading aside={phase === "after" ? "Official" : "Provisional"}>
+            <span id="standings-heading">{phase === "after" ? "Final result" : "Leading"}</span>
+          </SectionHeading>
+          <ol className="flex flex-col gap-space-2">
+            {standings.slice(0, 3).map((row) => (
+              <li key={row.rank} className="flex items-center gap-space-3">
+                <span className={`text-h3 ${TABULAR} ${row.rank === 1 ? "text-signal-orange" : "text-text-muted"}`}>
+                  {row.rank}
+                </span>
+                <span className="flex-1 text-body text-text-primary">{row.display_name}</span>
+                <span className={`text-body-strong ${TABULAR} text-text-primary`}>
+                  {row.weight_lb.toFixed(1)} lb
+                </span>
+              </li>
+            ))}
+          </ol>
+          <Link
+            href={`/tournaments/${tournament.id}/leaderboard`}
+            className={`${FOCUS_RING} inline-flex min-h-touch-floor items-center gap-space-2 text-label text-text-link`}
+          >
+            <TrophyIcon />
+            Full standings
+          </Link>
+        </section>
+      ) : null}
+
+      <section className="grid gap-space-3 sm:grid-cols-2" aria-label="Tournament details">
+        <DetailCard label="Lines in" value={formatDateTime(tournament.starts_at) ?? "Not set yet"} />
+        <DetailCard label="Lines out" value={formatDateTime(tournament.ends_at) ?? "Not set yet"} />
+        <DetailCard label="Who can see it" value={visibility.label} hint={visibility.blurb} />
+        <DetailCard
+          label="Catches on this phone"
+          value={String(deviceCatches)}
+          hint="Recorded here, whether or not they have reached the scorer yet."
+        />
       </section>
 
-      <section className="grid gap-space-3 sm:grid-cols-2" aria-label="Tournament summary">
-        <article className={`${TOURNAMENT_CARD} flex flex-col gap-space-1`}><span className="text-caption text-text-muted">Starts</span><span className="text-body-strong text-text-primary">{formatDate(tournament.starts_at)}</span></article>
-        <article className={`${TOURNAMENT_CARD} flex flex-col gap-space-1`}><span className="text-caption text-text-muted">Ends</span><span className="text-body-strong text-text-primary">{formatDate(tournament.ends_at)}</span></article>
-      </section>
+      {/*
+        Organizer tools, as one card rather than a sixth tab. An angler fishing this
+        tournament has no use for the word "operations" and should not have to scroll past
+        it every time they open the standings (UX-001 §7).
+      */}
+      <Link
+        href={`/tournaments/${tournament.id}/operations`}
+        className={`${CARD} ${FOCUS_RING} flex items-center gap-space-3 p-space-4 transition-colors hover:border-border-interactive`}
+      >
+        <span className="flex flex-1 flex-col gap-space-1">
+          <span className="text-body-strong text-text-primary">Run the event</span>
+          <span className="text-caption text-text-muted">
+            Entries, the review queue, standings and the money — each behind its own permission.
+          </span>
+        </span>
+        <ChevronIcon className="text-text-muted" />
+      </Link>
 
-      <section className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`}><h2 className="text-h3 text-text-primary">Operations ready</h2><p className="text-body text-text-muted">Registration, live catches, public standings, judging, organizer controls, and finance approval surfaces are now represented without collapsing role boundaries.</p><Link href={`/tournaments/${tournament.id}/operations`} className={TOURNAMENT_SECONDARY_BUTTON}>Open operations</Link></section>
+      {demoMode ? <DemoNote /> : null}
     </div>
+  );
+}
+
+function DetailCard({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <article className={`${CARD} flex flex-col gap-space-1 p-space-4`}>
+      <span className="text-caption text-text-muted">{label}</span>
+      <span className="text-body-strong text-text-primary">{value}</span>
+      {hint ? <span className="text-caption text-text-muted">{hint}</span> : null}
+    </article>
+  );
+}
+
+/**
+ * The one big control, chosen by state.
+ *
+ * Exactly one primary action per screen (`docs/design/03-touch-and-interaction.md` §1), and
+ * it is whatever the tournament's current state makes most likely: enter it while entries
+ * are open, log a catch while it is being fished, look at the result once it is over.
+ */
+function PrimaryAction({
+  tournament,
+  entry,
+  phase,
+}: {
+  tournament: { readonly id: string; readonly status: string };
+  entry: DemoEntry | null;
+  phase: "before" | "during" | "after";
+}) {
+  if (phase === "during") {
+    return (
+      <Link href={`/tournaments/${tournament.id}/catches`} className={BIG_ACTION}>
+        Log a catch
+      </Link>
+    );
+  }
+
+  if (phase === "after") {
+    return (
+      <Link href={`/tournaments/${tournament.id}/leaderboard`} className={BIG_ACTION}>
+        See the result
+      </Link>
+    );
+  }
+
+  if (tournament.status === "REGISTRATION_OPEN") {
+    return (
+      <Link href={`/tournaments/${tournament.id}/register`} className={BIG_ACTION}>
+        {entry ? "Your entry" : "Enter this tournament"}
+      </Link>
+    );
+  }
+
+  if (tournament.status === "DRAFT") {
+    return (
+      <Link href={`/tournaments/${tournament.id}/operations`} className={BIG_ACTION}>
+        Finish setting it up
+      </Link>
+    );
+  }
+
+  return (
+    <Link href={`/tournaments/${tournament.id}/rules`} className={SECONDARY_BUTTON}>
+      Read the rules
+    </Link>
   );
 }

--- a/src/features/tournaments/components/tournament-registration.tsx
+++ b/src/features/tournaments/components/tournament-registration.tsx
@@ -1,69 +1,94 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useId, useState } from "react";
 
 import { createClient } from "@/lib/supabase/client";
-import { getDemoEntry, getDemoTournament, hasSupabaseBrowserConfig, registerDemoEntry, type DemoEntry } from "../demo-store";
-import { TOURNAMENT_CARD, TOURNAMENT_INPUT, TOURNAMENT_PRIMARY_BUTTON, TOURNAMENT_SECONDARY_BUTTON } from "../ui-classes";
+import { getDemoEntry, hasSupabaseBrowserConfig, registerDemoEntry, type DemoEntry } from "../demo-store";
+import { entrySteps, statusPresentation, TONE_CLASSES } from "../format";
+import { useDemoMode, useTournament } from "../use-tournament";
+import { BIG_ACTION, CARD_PADDED, INPUT, PAGE, SECONDARY_BUTTON } from "../ui-classes";
+import { AlertIcon, CheckIcon, PendingIcon } from "./icons";
+import {
+  BackLink,
+  DemoNote,
+  ErrorScreen,
+  LoadingScreen,
+  SectionHeading,
+  TournamentHero,
+  TournamentTabs,
+} from "./tournament-chrome";
 
-type TournamentRegistrationState = { id: string; name: string; status: string; visibility: string };
-type ExistingEntry = Pick<DemoEntry, "id" | "registration_status" | "eligibility_status" | "check_in_status" | "competition_status">;
+type ExistingEntry = Pick<
+  DemoEntry,
+  "id" | "registration_status" | "eligibility_status" | "check_in_status" | "competition_status"
+>;
 
+/**
+ * /tournaments/[id]/register — entering, and knowing where your entry stands.
+ *
+ * UX-001 §5: "Do not collapse all state into 'registered'." The old screen technically
+ * obeyed that — it printed all four states — but as a 2×2 grid of lowercased enums
+ * (`not_checked_in`, `unknown`), which tells an angler standing on a dock exactly nothing
+ * about whether they are allowed to fish. Each state now gets a line, a plain word, and
+ * the sentence that says what to do about it.
+ */
 export function TournamentRegistration({ tournamentId }: { tournamentId: string }) {
-  const [tournament, setTournament] = useState<TournamentRegistrationState | null>(null);
+  const load = useTournament(tournamentId);
+  const demoMode = useDemoMode();
+
   const [entry, setEntry] = useState<ExistingEntry | null>(null);
   const [displayName, setDisplayName] = useState("");
-  const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const demoMode = !hasSupabaseBrowserConfig();
+  const fieldId = useId();
 
-  async function refresh() {
-    if (demoMode) {
-      const demoTournament = getDemoTournament(tournamentId);
-      if (!demoTournament) {
-        setError("Demo tournament unavailable on this device.");
-        setLoading(false);
-        return;
-      }
-      setTournament({ id: demoTournament.id, name: demoTournament.name, status: demoTournament.status, visibility: demoTournament.visibility });
+  const refresh = useCallback(async () => {
+    if (!hasSupabaseBrowserConfig()) {
       setEntry(getDemoEntry(tournamentId));
-      setLoading(false);
       return;
     }
 
-    try {
-      const supabase = createClient();
-      const { data: authData } = await supabase.auth.getUser();
-      const { data: tournamentData, error: tournamentError } = await supabase.from("tournament").select("id,name,status,visibility").eq("id", tournamentId).maybeSingle();
-      if (tournamentError || !tournamentData) {
-        setError(tournamentError?.message ?? "Tournament unavailable.");
-        setLoading(false);
-        return;
-      }
+    const supabase = createClient();
+    const { data: authData } = await supabase.auth.getUser();
+    if (!authData.user) return;
 
-      setTournament(tournamentData as TournamentRegistrationState);
-      if (authData.user) {
-        const { data: identityRows } = await supabase.from("tournament_entry_identity").select("tournament_entry_id").eq("claimed_angler_id", authData.user.id);
-        const candidateIds = (identityRows ?? []).map((row) => row.tournament_entry_id);
-        if (candidateIds.length > 0) {
-          const { data: entryData } = await supabase.from("tournament_entry").select("id,registration_status,eligibility_status,check_in_status,competition_status").eq("tournament_id", tournamentId).in("id", candidateIds).is("deleted_at", null).maybeSingle();
-          setEntry((entryData as ExistingEntry | null) ?? null);
-        }
-      }
-      setLoading(false);
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : "Tournament registration could not be loaded.");
-      setLoading(false);
+    // An entry is reached through the identity claim rather than by user id, because a
+    // tournament keeps its own participant identity — the same person can be an entrant in
+    // an event they later stop having an account for, and the result still has to stand.
+    const { data: identityRows } = await supabase
+      .from("tournament_entry_identity")
+      .select("tournament_entry_id")
+      .eq("claimed_angler_id", authData.user.id);
+
+    const candidateIds = (identityRows ?? []).map((row) => row.tournament_entry_id);
+    if (candidateIds.length === 0) {
+      setEntry(null);
+      return;
     }
-  }
+
+    const { data: entryData } = await supabase
+      .from("tournament_entry")
+      .select("id,registration_status,eligibility_status,check_in_status,competition_status")
+      .eq("tournament_id", tournamentId)
+      .in("id", candidateIds)
+      .is("deleted_at", null)
+      .maybeSingle();
+
+    setEntry((entryData as ExistingEntry | null) ?? null);
+  }, [tournamentId]);
 
   useEffect(() => {
-    void Promise.resolve().then(refresh);
-    // refresh depends only on tournamentId/demoMode and intentionally owns the client instance.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [demoMode, tournamentId]);
+    let cancelled = false;
+    void (async () => {
+      await Promise.resolve();
+      if (cancelled) return;
+      await refresh();
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [refresh]);
 
   async function register(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -78,7 +103,10 @@ export function TournamentRegistration({ tournamentId }: { tournamentId: string 
 
     try {
       const supabase = createClient();
-      const { error: registrationError } = await supabase.rpc("register_self_for_tournament", { target_tournament_id: tournamentId, participant_display_name: displayName.trim() });
+      const { error: registrationError } = await supabase.rpc("register_self_for_tournament", {
+        target_tournament_id: tournamentId,
+        participant_display_name: displayName.trim(),
+      });
       if (registrationError) setError(registrationError.message);
       else await refresh();
     } catch (cause) {
@@ -88,39 +116,117 @@ export function TournamentRegistration({ tournamentId }: { tournamentId: string 
     }
   }
 
-  if (loading) return <div className="mx-auto max-w-reading px-space-4 py-space-5 text-body text-text-muted">Loading registration…</div>;
-  if (!tournament) return <div className="mx-auto max-w-reading px-space-4 py-space-5 text-body text-error-red">{error ?? "Tournament unavailable."}</div>;
+  if (load.state === "loading") return <LoadingScreen label="Loading registration" />;
+  if (load.state === "error") return <ErrorScreen message={load.message} />;
+
+  const tournament = load.tournament;
 
   return (
-    <div className="mx-auto flex max-w-reading flex-col gap-space-5 px-space-4 py-space-5">
-      <header className="flex flex-col gap-space-2">
-        <Link href={`/tournaments/${tournament.id}/overview`} className="text-caption text-text-link">← Overview</Link>
-        <h1 className="text-h1 text-text-primary">Register</h1>
-        <p className="text-body text-text-muted">{tournament.name}</p>
-        {demoMode ? <p className="text-caption text-text-muted">Demo mode · registration is saved only on this device.</p> : null}
-      </header>
+    <div className={PAGE}>
+      <TournamentHero
+        tournament={tournament}
+        // The hero repeats the tournament name directly below, so the eyebrow names the
+        // destination instead of saying the same words twice.
+        eyebrow={<BackLink href={`/tournaments/${tournament.id}/overview`}>Overview</BackLink>}
+      />
+
+      <TournamentTabs tournamentId={tournament.id} />
 
       {entry ? (
-        <section className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`}>
-          <h2 className="text-h3 text-text-primary">Your entry</h2>
-          <dl className="grid grid-cols-2 gap-space-3 text-caption">
-            <div><dt className="text-text-muted">Registration</dt><dd className="capitalize text-text-primary">{entry.registration_status.toLowerCase().replaceAll("_", " ")}</dd></div>
-            <div><dt className="text-text-muted">Eligibility</dt><dd className="capitalize text-text-primary">{entry.eligibility_status.toLowerCase().replaceAll("_", " ")}</dd></div>
-            <div><dt className="text-text-muted">Check-in</dt><dd className="capitalize text-text-primary">{entry.check_in_status.toLowerCase().replaceAll("_", " ")}</dd></div>
-            <div><dt className="text-text-muted">Competition</dt><dd className="capitalize text-text-primary">{entry.competition_status.toLowerCase().replaceAll("_", " ")}</dd></div>
-          </dl>
-          <p className="text-caption text-text-muted">Payment, eligibility and competition status are tracked separately so one cannot silently change another.</p>
+        <section className={`${CARD_PADDED} flex flex-col gap-space-4`} aria-labelledby="entry-heading">
+          <SectionHeading>
+            <span id="entry-heading">You are entered</span>
+          </SectionHeading>
+
+          {/*
+            Four separate states, deliberately. Payment, eligibility, check-in and
+            competition move independently — one being green does not make the others
+            green, and an entry that is confirmed but not checked in is a real situation a
+            person needs to be able to see on a phone at 5am.
+          */}
+          <ol className="flex flex-col gap-space-4">
+            {entrySteps(entry).map((item) => {
+              const classes = TONE_CLASSES[item.tone];
+              const Icon =
+                item.tone === "open" || item.tone === "live"
+                  ? CheckIcon
+                  : item.tone === "attention" || item.tone === "stopped"
+                    ? AlertIcon
+                    : PendingIcon;
+              return (
+                <li key={item.label} className="flex items-start gap-space-3">
+                  <span className={`mt-space-1 ${classes.text}`}>
+                    <Icon />
+                  </span>
+                  <span className="flex flex-col gap-space-1">
+                    <span className="text-caption text-text-muted">{item.label}</span>
+                    <span className={`text-body-strong ${classes.text}`}>{item.value}</span>
+                    <span className="text-caption text-text-muted">{item.hint}</span>
+                  </span>
+                </li>
+              );
+            })}
+          </ol>
+
+          <p className="border-t border-hairline pt-space-3 text-caption text-text-muted">
+            These four are tracked separately on purpose, so that none of them can quietly change
+            another. Paying does not make you eligible, and checking in does not score you.
+          </p>
+
+          <Link href={`/tournaments/${tournament.id}/rules`} className={SECONDARY_BUTTON}>
+            What am I signing up to?
+          </Link>
         </section>
       ) : tournament.status === "REGISTRATION_OPEN" ? (
-        <form onSubmit={register} className={`${TOURNAMENT_CARD} flex flex-col gap-space-4`}>
-          <div className="flex flex-col gap-space-1"><h2 className="text-h3 text-text-primary">Enter tournament</h2><p className="text-caption text-text-muted">Your account is linked to this entry, while the tournament keeps its own historical participant identity.</p></div>
-          <label className="flex flex-col gap-space-2"><span className="text-label text-text-primary">Display name</span><input required maxLength={80} value={displayName} onChange={(event) => setDisplayName(event.target.value)} className={TOURNAMENT_INPUT} placeholder="Name shown in the tournament" /></label>
-          {error ? <p role="alert" className="text-body text-error-red">{error}</p> : null}
-          <button type="submit" className={TOURNAMENT_PRIMARY_BUTTON} disabled={submitting || displayName.trim().length === 0}>{submitting ? "Registering…" : "Register"}</button>
+        <form onSubmit={register} className={`${CARD_PADDED} flex flex-col gap-space-4`}>
+          <SectionHeading>Enter this tournament</SectionHeading>
+          <label className="flex flex-col gap-space-2">
+            <span className="text-label text-text-primary">What name should show on the board?</span>
+            <input
+              id={`${fieldId}-name`}
+              required
+              maxLength={80}
+              value={displayName}
+              onChange={(event) => setDisplayName(event.target.value)}
+              className={INPUT}
+              placeholder="How your crew knows you"
+              autoComplete="nickname"
+            />
+            <span className="text-caption text-text-muted">
+              This is what other anglers see. Your account stays linked to the entry behind the
+              scenes, so the tournament keeps its own record even if your account changes later.
+            </span>
+          </label>
+
+          {error ? (
+            <p role="alert" className="text-body text-error-red">
+              {error}
+            </p>
+          ) : null}
+
+          <button type="submit" className={BIG_ACTION} disabled={submitting || displayName.trim().length === 0}>
+            {submitting ? "Entering…" : "Enter tournament"}
+          </button>
+          {displayName.trim().length === 0 ? (
+            <p className="text-caption text-text-muted">Add a name to enter.</p>
+          ) : null}
         </form>
       ) : (
-        <section className={`${TOURNAMENT_CARD} flex flex-col gap-space-3`}><h2 className="text-h3 text-text-primary">Registration is not open</h2><p className="text-body text-text-muted">Current tournament state: {tournament.status.toLowerCase().replaceAll("_", " ")}.</p><Link href={`/tournaments/${tournament.id}/overview`} className={TOURNAMENT_SECONDARY_BUTTON}>Back to overview</Link></section>
+        <section className={`${CARD_PADDED} flex flex-col gap-space-3`}>
+          <SectionHeading>Entries are not open</SectionHeading>
+          <p className="text-body text-text-primary">{statusPresentation(tournament.status).blurb}</p>
+          <p className="text-caption text-text-muted">
+            {tournament.status === "DRAFT"
+              ? "The organizer has not opened this one up yet."
+              : "If you think you should be in this tournament, the organizer can add you."}
+          </p>
+          <Link href={`/tournaments/${tournament.id}/overview`} className={SECONDARY_BUTTON}>
+            Back to the tournament
+          </Link>
+        </section>
       )}
+
+      {demoMode ? <DemoNote /> : null}
     </div>
   );
 }

--- a/src/features/tournaments/components/tournament-rules.tsx
+++ b/src/features/tournaments/components/tournament-rules.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useDemoMode, useTournament } from "../use-tournament";
+import { CARD_PADDED, INSET, PAGE } from "../ui-classes";
+import { CheckRow, DemoNote, ErrorScreen, LoadingScreen, SectionHeading, TournamentHero, TournamentTabs, BackLink } from "./tournament-chrome";
+
+/**
+ * /tournaments/[id]/rules — what you are fishing under.
+ *
+ * This route did not exist. The tournament nav has linked to it since the section shipped,
+ * so every angler who tapped "Rules" got a 404 — which is its own answer to the question
+ * "why does this feel unfinished".
+ *
+ * What it can honestly show today is the shape of the agreement rather than its text: which
+ * of the four competition inputs are locked, what the app checks on every catch, and what
+ * happens when a check is unhappy. The rule *text* lives in a versioned rule set that has
+ * no publishing surface yet, and inventing a plausible-looking set of rules on a screen
+ * anglers would take at face value is the one thing this page must never do.
+ */
+
+const INPUTS = [
+  {
+    key: "active_rule_set_version_id",
+    label: "The rules",
+    locked: "Locked. They cannot be edited while this tournament is being fished.",
+    open: "Not written yet. The organizer sets these before the tournament can start.",
+  },
+  {
+    key: "active_scoring_version_id",
+    label: "How it is scored",
+    locked: "Locked. Every catch is scored the same way, from the first to the last.",
+    open: "Not chosen yet.",
+  },
+  {
+    key: "active_verification_policy_version_id",
+    label: "What counts as proof",
+    locked: "Locked. The same evidence is asked of everybody.",
+    open: "Not set yet.",
+  },
+  {
+    key: "active_boundary_version_id",
+    label: "Where you can fish",
+    locked: "Locked. The water this tournament covers is fixed.",
+    open: "Not set yet.",
+  },
+] as const;
+
+export function TournamentRules({ tournamentId }: { tournamentId: string }) {
+  const load = useTournament(tournamentId);
+  const demoMode = useDemoMode();
+
+  if (load.state === "loading") return <LoadingScreen label="Loading rules" />;
+  if (load.state === "error") return <ErrorScreen message={load.message} />;
+
+  const tournament = load.tournament;
+
+  return (
+    <div className={PAGE}>
+      <TournamentHero
+        tournament={tournament}
+        // The hero repeats the tournament name directly below, so the eyebrow names the
+        // destination instead of saying the same words twice.
+        eyebrow={<BackLink href={`/tournaments/${tournament.id}/overview`}>Overview</BackLink>}
+      />
+
+      <TournamentTabs tournamentId={tournament.id} />
+
+      <section className={`${CARD_PADDED} flex flex-col gap-space-4`} aria-labelledby="agreement-heading">
+        <SectionHeading>
+          <span id="agreement-heading">What is settled</span>
+        </SectionHeading>
+        <ul className="flex flex-col gap-space-3">
+          {INPUTS.map((item) => {
+            const locked = tournament[item.key] !== null;
+            return (
+              <CheckRow
+                key={item.key}
+                state={locked ? "done" : "pending"}
+                label={item.label}
+                detail={locked ? item.locked : item.open}
+              />
+            );
+          })}
+        </ul>
+        <p className="text-caption text-text-muted">
+          Locking these is what makes a result stand up afterwards: nothing that decides a winner can
+          be changed once people are on the water.
+        </p>
+      </section>
+
+      <section className={`${CARD_PADDED} flex flex-col gap-space-4`} aria-labelledby="proof-heading">
+        <SectionHeading>
+          <span id="proof-heading">What the app checks on a catch</span>
+        </SectionHeading>
+        <ul className="flex flex-col gap-space-3">
+          <CheckRow state="done" label="A photo, if the event asks for one" detail="Kept as recorded. It is never edited or replaced." />
+          <CheckRow state="done" label="Where and when it was caught" detail="Recorded with the catch. Never shown on a public board." />
+          <CheckRow state="done" label="An event code, if the event uses them" detail="Checks it belongs to this tournament and has not already been used." />
+          <CheckRow state="done" label="The measurement you entered" detail="Exactly as you typed it. The app does not round it for you." />
+        </ul>
+
+        <div className={INSET}>
+          <p className="text-body-strong text-text-primary">If a check is unhappy</p>
+          <p className="mt-space-2 text-body text-text-muted">
+            It raises a flag for a person to look at. It never changes your score, never deletes your
+            catch, and never decides you cheated. A judge makes that call, and has to write down a
+            reason for it.
+          </p>
+        </div>
+      </section>
+
+      <section className={`${CARD_PADDED} flex flex-col gap-space-3`} aria-labelledby="board-heading">
+        <SectionHeading>
+          <span id="board-heading">What other people can see</span>
+        </SectionHeading>
+        <p className="text-body text-text-primary">
+          Your name as you entered it, the fish, and the measurement.
+        </p>
+        <p className="text-body text-text-muted">
+          Not your position, not your photos, not your phone, and not anything a judge wrote about a
+          catch.
+        </p>
+      </section>
+
+      {demoMode ? <DemoNote /> : null}
+    </div>
+  );
+}

--- a/src/features/tournaments/demo-store.ts
+++ b/src/features/tournaments/demo-store.ts
@@ -22,24 +22,104 @@ export type DemoEntry = {
   display_name: string;
 };
 
+/** A public-safe standings row: exactly the fields `core/tournaments/public-projection` allows. */
+export type DemoStanding = {
+  rank: number;
+  display_name: string;
+  species: string;
+  weight_lb: number;
+  /** Official once every review behind it is closed; provisional until then. */
+  official: boolean;
+};
+
 const TOURNAMENTS_KEY = "fish-log-book:demo-tournaments";
 const ENTRIES_KEY = "fish-log-book:demo-tournament-entries";
 
-const SEED: DemoTournament[] = [
-  {
-    id: "demo-yellowtail-open",
-    name: "Saturday Yellowtail Challenge",
-    status: "REGISTRATION_OPEN",
-    visibility: "PUBLIC",
-    starts_at: "2026-09-12T14:00:00.000Z",
-    ends_at: "2026-09-12T23:00:00.000Z",
-    organization_id: "demo-personal-organization",
-    active_rule_set_version_id: "demo-rules-v1",
-    active_scoring_version_id: "demo-scoring-v1",
-    active_verification_policy_version_id: null,
-    active_boundary_version_id: null,
-  },
-];
+/**
+ * Demo tournaments are dated relative to now rather than pinned to fixed timestamps.
+ *
+ * The old seed started on 12 September 2026 and would have been a stale "started 4 months
+ * ago" event by the new year — which quietly breaks the one thing the seed exists to show,
+ * a tournament with a live clock running. Relative dates keep the demo honest for as long
+ * as the file lives. They are only ever read from an effect, so there is no server render
+ * for the moving value to disagree with.
+ */
+function at(dayOffset: number, hour: number): string {
+  const date = new Date();
+  date.setDate(date.getDate() + dayOffset);
+  date.setHours(hour, 0, 0, 0);
+  return date.toISOString();
+}
+
+/** Rounded to the quarter hour, because "8:05 PM – 3:38 AM" reads like a machine wrote it. */
+function minutesFromNow(minutes: number): string {
+  const quarter = 15 * 60_000;
+  return new Date(Math.round((Date.now() + minutes * 60_000) / quarter) * quarter).toISOString();
+}
+
+/**
+ * Three tournaments, chosen so every state the UI has to render appears in the demo
+ * without the founder having to create one: an event taking entries with its setup
+ * half-finished, an event being fished right now, and one that is over and official.
+ */
+function seedTournaments(): DemoTournament[] {
+  return [
+    {
+      id: "demo-harbor-shootout",
+      name: "Harbor Bay Shootout",
+      status: "LIVE",
+      visibility: "PUBLIC",
+      starts_at: minutesFromNow(-185),
+      ends_at: minutesFromNow(268),
+      organization_id: "demo-personal-organization",
+      active_rule_set_version_id: "demo-rules-v3",
+      active_scoring_version_id: "demo-scoring-v2",
+      active_verification_policy_version_id: "demo-verification-v1",
+      active_boundary_version_id: "demo-boundary-v1",
+    },
+    {
+      id: "demo-yellowtail-open",
+      name: "Saturday Yellowtail Challenge",
+      status: "REGISTRATION_OPEN",
+      visibility: "PUBLIC",
+      starts_at: at(6, 7),
+      ends_at: at(6, 16),
+      organization_id: "demo-personal-organization",
+      active_rule_set_version_id: "demo-rules-v1",
+      active_scoring_version_id: "demo-scoring-v1",
+      active_verification_policy_version_id: null,
+      active_boundary_version_id: null,
+    },
+    {
+      id: "demo-crew-cup",
+      name: "Crew Cup",
+      status: "FINAL",
+      visibility: "PRIVATE",
+      starts_at: at(-9, 6),
+      ends_at: at(-9, 15),
+      organization_id: "demo-personal-organization",
+      active_rule_set_version_id: "demo-rules-v1",
+      active_scoring_version_id: "demo-scoring-v1",
+      active_verification_policy_version_id: "demo-verification-v1",
+      active_boundary_version_id: "demo-boundary-v1",
+    },
+  ];
+}
+
+const SEED_STANDINGS: Readonly<Record<string, readonly DemoStanding[]>> = {
+  "demo-harbor-shootout": [
+    { rank: 1, display_name: "M. Rivera", species: "Yellowtail", weight_lb: 28.6, official: true },
+    { rank: 2, display_name: "J. Park", species: "Yellowtail", weight_lb: 24.2, official: true },
+    { rank: 3, display_name: "A. Lewis", species: "White seabass", weight_lb: 21.9, official: false },
+    { rank: 4, display_name: "D. Okafor", species: "Yellowtail", weight_lb: 19.4, official: true },
+    { rank: 5, display_name: "T. Nguyen", species: "Calico bass", weight_lb: 8.1, official: true },
+  ],
+  "demo-crew-cup": [
+    { rank: 1, display_name: "Sam", species: "Lingcod", weight_lb: 17.2, official: true },
+    { rank: 2, display_name: "Dad", species: "Lingcod", weight_lb: 15.8, official: true },
+    { rank: 3, display_name: "Ellie", species: "Rockfish", weight_lb: 6.4, official: true },
+  ],
+};
 
 export function hasSupabaseBrowserConfig(): boolean {
   return Boolean(
@@ -64,7 +144,8 @@ function writeJson(key: string, value: unknown) {
 
 export function getDemoTournaments(): DemoTournament[] {
   const stored = readJson<DemoTournament[]>(TOURNAMENTS_KEY, []);
-  return [...stored, ...SEED.filter((seed) => !stored.some((item) => item.id === seed.id))];
+  const seed = seedTournaments();
+  return [...stored, ...seed.filter((item) => !stored.some((own) => own.id === item.id))];
 }
 
 export function getDemoTournament(id: string): DemoTournament | null {
@@ -115,4 +196,13 @@ export function registerDemoEntry(tournamentId: string, displayName: string): De
   const entries = readJson<DemoEntry[]>(ENTRIES_KEY, []);
   writeJson(ENTRIES_KEY, [entry, ...entries]);
   return entry;
+}
+
+/**
+ * Standings for the seeded demo events only. A tournament the founder creates has no
+ * standings, and inventing some would teach the wrong thing about where scores come from —
+ * the empty leaderboard with "nothing has been scored yet" is the honest screen.
+ */
+export function getDemoStandings(tournamentId: string): readonly DemoStanding[] {
+  return SEED_STANDINGS[tournamentId] ?? [];
 }

--- a/src/features/tournaments/format.test.ts
+++ b/src/features/tournaments/format.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+
+import { TOURNAMENT_STATUSES } from "@/core/tournaments/lifecycle";
+import {
+  countdown,
+  entrySteps,
+  formatDuration,
+  formatSchedule,
+  statusPresentation,
+  syncPresentation,
+  TONE_CLASSES,
+  tournamentPhase,
+} from "./format";
+
+/**
+ * These cover the two things that actually go wrong in a presentation layer: a state the
+ * table forgot (so a screen prints `REGISTRATION_OPEN` at a human), and a clock that
+ * disagrees with the status line printed next to it.
+ */
+
+describe("statusPresentation", () => {
+  it("has a human label, a tone, and an explanation for every lifecycle state", () => {
+    for (const status of TOURNAMENT_STATUSES) {
+      const presentation = statusPresentation(status);
+      expect(presentation.label, status).not.toMatch(/_/);
+      expect(presentation.label, status).not.toBe(status);
+      expect(presentation.blurb.length, status).toBeGreaterThan(0);
+      expect(TONE_CLASSES[presentation.tone], status).toBeDefined();
+    }
+  });
+
+  it("falls back to title case rather than blanking on an unknown state", () => {
+    expect(statusPresentation("SOME_NEW_STATE").label).toBe("Some New State");
+    expect(statusPresentation("SOME_NEW_STATE").tone).toBe("neutral");
+  });
+});
+
+describe("tournamentPhase", () => {
+  it("sorts every state into before, during, or after", () => {
+    expect(tournamentPhase("DRAFT")).toBe("before");
+    expect(tournamentPhase("READY")).toBe("before");
+    expect(tournamentPhase("LIVE")).toBe("during");
+    expect(tournamentPhase("PAUSED")).toBe("during");
+    expect(tournamentPhase("RESULTS_PENDING")).toBe("after");
+    expect(tournamentPhase("FINAL")).toBe("after");
+  });
+});
+
+describe("formatDuration", () => {
+  it("stops at two units and rounds down", () => {
+    expect(formatDuration(30_000)).toBe("under a minute");
+    expect(formatDuration(42 * 60_000)).toBe("42m");
+    expect(formatDuration(5 * 3_600_000 + 12 * 60_000)).toBe("5h 12m");
+    expect(formatDuration(3 * 3_600_000)).toBe("3h");
+    expect(formatDuration(2 * 86_400_000 + 3 * 3_600_000)).toBe("2 days 3h");
+    expect(formatDuration(86_400_000)).toBe("1 day");
+  });
+
+  it("drops the hours once the number of days is big enough that they do not matter", () => {
+    expect(formatDuration(9 * 86_400_000 + 5 * 3_600_000)).toBe("9 days");
+  });
+});
+
+describe("countdown", () => {
+  const now = Date.parse("2026-09-12T12:00:00.000Z");
+
+  it("counts down to the start before the event", () => {
+    expect(
+      countdown(now, {
+        status: "REGISTRATION_OPEN",
+        startsAt: "2026-09-18T12:00:00.000Z",
+        endsAt: null,
+      }),
+    ).toEqual({ label: "Starts in 6 days", urgent: false });
+  });
+
+  it("marks the last day before the start as urgent", () => {
+    const result = countdown(now, {
+      status: "READY",
+      startsAt: "2026-09-12T17:00:00.000Z",
+      endsAt: null,
+    });
+    expect(result).toEqual({ label: "Starts in 5h", urgent: true });
+  });
+
+  it("counts down to lines-out once the tournament is live", () => {
+    expect(
+      countdown(now, {
+        status: "LIVE",
+        startsAt: "2026-09-12T07:00:00.000Z",
+        endsAt: "2026-09-12T16:30:00.000Z",
+      }),
+    ).toEqual({ label: "4h 30m left", urgent: true });
+  });
+
+  it("never counts down inside a window the director has not started", () => {
+    // The scheduled window is open, but the state says entries are still being taken.
+    // A "4h left" pill here would contradict the status pill beside it.
+    expect(
+      countdown(now, {
+        status: "REGISTRATION_OPEN",
+        startsAt: "2026-09-12T07:00:00.000Z",
+        endsAt: "2026-09-12T16:30:00.000Z",
+      }),
+    ).toEqual({ label: "Start time has passed", urgent: false });
+  });
+
+  it("stops the clock for finished, paused, and cancelled tournaments", () => {
+    const schedule = { startsAt: "2026-09-12T07:00:00.000Z", endsAt: "2026-09-12T16:30:00.000Z" };
+    expect(countdown(now, { status: "PAUSED", ...schedule })?.label).toBe("Paused");
+    expect(countdown(now, { status: "FINAL", ...schedule })?.label).toBe("Official");
+    expect(countdown(now, { status: "CANCELLED", ...schedule })).toBeNull();
+  });
+});
+
+describe("formatSchedule", () => {
+  it("does not print the same date twice for a one-day event", () => {
+    const schedule = formatSchedule("2026-09-12T14:00:00.000Z", "2026-09-12T23:00:00.000Z");
+    expect(schedule).toContain("–");
+    expect(schedule.match(/Sep/g) ?? []).toHaveLength(1);
+  });
+
+  it("says so plainly when nothing is scheduled", () => {
+    expect(formatSchedule(null, null)).toBe("Date not set yet");
+  });
+});
+
+describe("entrySteps", () => {
+  it("keeps the four entry states separate, each with its own next step", () => {
+    const steps = entrySteps({
+      registration_status: "PENDING",
+      eligibility_status: "UNKNOWN",
+      check_in_status: "NOT_CHECKED_IN",
+      competition_status: "NOT_STARTED",
+    });
+
+    expect(steps).toHaveLength(4);
+    expect(steps.map((item) => item.value)).toEqual([
+      "Submitted",
+      "Not checked yet",
+      "Not checked in",
+      "Not started",
+    ]);
+    for (const item of steps) expect(item.hint.length).toBeGreaterThan(0);
+  });
+});
+
+describe("syncPresentation", () => {
+  it("never implies the server has a catch it has not confirmed", () => {
+    expect(syncPresentation("SAVED_OFFLINE").label).toBe("Saved on this phone");
+    expect(syncPresentation("PENDING_SYNC").label).toBe("Waiting to send");
+    expect(syncPresentation("SYNCED").label).toBe("Received by the scorer");
+    expect(syncPresentation("CONFLICT").tone).toBe("stopped");
+  });
+});

--- a/src/features/tournaments/format.ts
+++ b/src/features/tournaments/format.ts
@@ -1,0 +1,450 @@
+import { TOURNAMENT_STATUSES, type TournamentStatus } from "@/core/tournaments/lifecycle";
+
+/**
+ * Everything the tournament screens need to turn a backend enum into a sentence a person
+ * on a boat can read, with no React in sight so it can be tested directly.
+ *
+ * The rule this file exists to enforce: **no screen prints a raw enum.** `REGISTRATION_OPEN`
+ * lowercased with the underscores swapped for spaces is not English, it is a database
+ * column wearing a hat, and the old tournament UI did that in eleven places. A status is a
+ * word plus a tone plus, where it helps, a line of explanation.
+ *
+ * The second rule, from `docs/design/01-foundations.md` §1.3: a tone is never the only
+ * signal. Every consumer of `statusTone` pairs the colour with the label, and the pill
+ * component draws a dot as well, so the state survives both colour-vision deficiency and
+ * the glare that destroys hue first.
+ */
+
+/**
+ * Six tones, mapped onto the semantic palette. Not ten — a reader cannot hold ten colour
+ * meanings, and the lifecycle's ten states collapse cleanly into "not started yet",
+ * "taking entries", "running", "needs attention", "finished", "stopped".
+ */
+export type StatusTone = "neutral" | "open" | "live" | "attention" | "done" | "stopped";
+
+export interface ToneClasses {
+  /** Text colour for the label. */
+  readonly text: string;
+  /** Fill for the dot, and for a progress bar tinted to match. */
+  readonly dot: string;
+  /** Pill background + border, tinted from the same hue at low alpha. */
+  readonly pill: string;
+}
+
+/**
+ * Written out per tone rather than interpolated: Tailwind only ships classes it can see in
+ * the source, so `text-${token}` compiles to nothing and every pill renders grey.
+ */
+export const TONE_CLASSES: Readonly<Record<StatusTone, ToneClasses>> = {
+  neutral: {
+    text: "text-text-muted",
+    dot: "bg-text-muted",
+    pill: "border-hairline bg-surface-raised",
+  },
+  open: {
+    text: "text-success-green",
+    dot: "bg-success-green",
+    pill: "border-success-green/40 bg-success-green/10",
+  },
+  live: {
+    text: "text-signal-orange",
+    dot: "bg-signal-orange",
+    pill: "border-signal-orange/50 bg-signal-orange/10",
+  },
+  attention: {
+    text: "text-amber-flag",
+    dot: "bg-amber-flag",
+    pill: "border-amber-flag/40 bg-amber-flag/10",
+  },
+  done: {
+    text: "text-tide-cyan",
+    dot: "bg-tide-cyan",
+    pill: "border-tide-cyan/40 bg-tide-cyan/10",
+  },
+  stopped: {
+    text: "text-error-red",
+    dot: "bg-error-red",
+    pill: "border-error-red/40 bg-error-red/10",
+  },
+};
+
+interface StatusPresentation {
+  readonly label: string;
+  readonly tone: StatusTone;
+  /** One sentence: what this state means for the person reading it. */
+  readonly blurb: string;
+}
+
+const STATUS: Readonly<Record<TournamentStatus, StatusPresentation>> = {
+  DRAFT: {
+    label: "Draft",
+    tone: "neutral",
+    blurb: "Only you can see this. Nobody can enter until you open registration.",
+  },
+  REGISTRATION_OPEN: {
+    label: "Taking entries",
+    tone: "open",
+    blurb: "Anglers can enter now.",
+  },
+  REGISTRATION_CLOSED: {
+    label: "Entries closed",
+    tone: "neutral",
+    blurb: "The field is set. Nobody else can enter.",
+  },
+  READY: {
+    label: "Ready to start",
+    tone: "open",
+    blurb: "Rules, scoring, checks and boundaries are locked. Start when you are.",
+  },
+  LIVE: {
+    label: "Fishing now",
+    tone: "live",
+    blurb: "Catches count. Log them as you land them.",
+  },
+  PAUSED: {
+    label: "Paused",
+    tone: "attention",
+    blurb: "Fishing is stopped for now. Catches logged while paused need a judge's look.",
+  },
+  COMPLETED: {
+    label: "Lines out",
+    tone: "neutral",
+    blurb: "Fishing is over. Scores are still being settled.",
+  },
+  RESULTS_PENDING: {
+    label: "Results pending",
+    tone: "attention",
+    blurb: "Standings are provisional until the last review is closed.",
+  },
+  FINAL: {
+    label: "Final",
+    tone: "done",
+    blurb: "Results are official.",
+  },
+  CANCELLED: {
+    label: "Cancelled",
+    tone: "stopped",
+    blurb: "This tournament will not be fished.",
+  },
+};
+
+/** True for a string that is one of the ten lifecycle states. */
+export function isTournamentStatus(value: string): value is TournamentStatus {
+  return (TOURNAMENT_STATUSES as readonly string[]).includes(value);
+}
+
+/**
+ * An unknown status still has to render — a server that gains an eleventh state must not
+ * blank a screen — so it falls back to the enum, title-cased, and the neutral tone.
+ */
+export function statusPresentation(status: string): StatusPresentation {
+  if (isTournamentStatus(status)) return STATUS[status];
+  return { label: titleCase(status), tone: "neutral", blurb: "" };
+}
+
+export function statusLabel(status: string): string {
+  return statusPresentation(status).label;
+}
+
+export function statusTone(status: string): StatusTone {
+  return statusPresentation(status).tone;
+}
+
+/**
+ * Which of the organizer dashboard's three columns of work this state belongs to
+ * (UX-001 §12: before event / during event / after event). The dashboard opens on the
+ * phase the tournament is actually in, so a director running a live event does not land on
+ * a setup checklist.
+ */
+export type Phase = "before" | "during" | "after";
+
+export function tournamentPhase(status: string): Phase {
+  switch (status) {
+    case "LIVE":
+    case "PAUSED":
+      return "during";
+    case "COMPLETED":
+    case "RESULTS_PENDING":
+    case "FINAL":
+    case "CANCELLED":
+      return "after";
+    default:
+      return "before";
+  }
+}
+
+interface VisibilityPresentation {
+  readonly label: string;
+  readonly blurb: string;
+}
+
+const VISIBILITY: Readonly<Record<string, VisibilityPresentation>> = {
+  PRIVATE: { label: "Private", blurb: "Only people you add can see it." },
+  INVITE_ONLY: { label: "Invite only", blurb: "Anyone with an invite can enter." },
+  UNLISTED: { label: "Unlisted", blurb: "Anyone with the link can see it. It is not listed publicly." },
+  PUBLIC: { label: "Public", blurb: "Listed for anyone to find and follow." },
+};
+
+export function visibilityPresentation(visibility: string): VisibilityPresentation {
+  return VISIBILITY[visibility] ?? { label: titleCase(visibility), blurb: "" };
+}
+
+export function visibilityLabel(visibility: string): string {
+  return visibilityPresentation(visibility).label;
+}
+
+function titleCase(value: string): string {
+  return value
+    .toLowerCase()
+    .split("_")
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+/* -------------------------------------------------------------------------- */
+/* Dates                                                                       */
+/* -------------------------------------------------------------------------- */
+
+function parse(value: string | null): Date | null {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/** "Sat 12 Sep, 7:00 AM" — day name included, because "the 12th" is not a plan. */
+export function formatDateTime(value: string | null): string | null {
+  const date = parse(value);
+  if (!date) return null;
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+}
+
+export function formatDate(value: string | null): string | null {
+  const date = parse(value);
+  if (!date) return null;
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  }).format(date);
+}
+
+export function formatTime(value: string | null): string | null {
+  const date = parse(value);
+  if (!date) return null;
+  return new Intl.DateTimeFormat(undefined, { hour: "numeric", minute: "2-digit" }).format(date);
+}
+
+/**
+ * A one-day event reads "Sat 12 Sep · 7:00 AM – 4:00 PM"; a multi-day one reads
+ * "Sat 12 Sep – Sun 13 Sep". Repeating the date twice for a single day is the kind of
+ * detail that makes a screen feel machine-generated.
+ */
+export function formatSchedule(startsAt: string | null, endsAt: string | null): string {
+  const start = parse(startsAt);
+  const end = parse(endsAt);
+
+  if (!start && !end) return "Date not set yet";
+  if (!start) return `Ends ${formatDateTime(endsAt)}`;
+  if (!end) return `Starts ${formatDateTime(startsAt)}`;
+
+  const sameDay =
+    start.getFullYear() === end.getFullYear() &&
+    start.getMonth() === end.getMonth() &&
+    start.getDate() === end.getDate();
+
+  if (sameDay) return `${formatDate(startsAt)} · ${formatTime(startsAt)} – ${formatTime(endsAt)}`;
+  return `${formatDateTime(startsAt)} – ${formatDateTime(endsAt)}`;
+}
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/**
+ * Rounded down, two units at most: "6 days", "5h 12m", "42m", "under a minute". Precision
+ * past two units is noise on a screen being read at arm's length in the sun.
+ */
+export function formatDuration(ms: number): string {
+  if (ms < MINUTE) return "under a minute";
+  if (ms < HOUR) return `${Math.floor(ms / MINUTE)}m`;
+  if (ms < DAY) {
+    const hours = Math.floor(ms / HOUR);
+    const minutes = Math.floor((ms % HOUR) / MINUTE);
+    return minutes === 0 ? `${hours}h` : `${hours}h ${minutes}m`;
+  }
+  const days = Math.floor(ms / DAY);
+  const hours = Math.floor((ms % DAY) / HOUR);
+  if (days >= 7 || hours === 0) return days === 1 ? "1 day" : `${days} days`;
+  return days === 1 ? `1 day ${hours}h` : `${days} days ${hours}h`;
+}
+
+export interface CountdownState {
+  /** The short form for a pill: "Starts in 6 days", "4h 12m left", "Finished". */
+  readonly label: string;
+  /** Whether this is the clock the angler is racing — drives the live tone. */
+  readonly urgent: boolean;
+}
+
+/**
+ * The clock, derived from the schedule and the lifecycle state together.
+ *
+ * State wins over the calendar where they disagree: a tournament the director has not
+ * started yet does not say "3h left" merely because its scheduled window is open, and a
+ * FINAL tournament never counts down to anything. A clock that contradicts the status line
+ * six inches above it is worse than no clock.
+ */
+export function countdown(
+  now: number,
+  input: { readonly status: string; readonly startsAt: string | null; readonly endsAt: string | null },
+): CountdownState | null {
+  const phase = tournamentPhase(input.status);
+  if (input.status === "CANCELLED") return null;
+  if (phase === "after") return { label: input.status === "FINAL" ? "Official" : "Fishing finished", urgent: false };
+
+  const start = parse(input.startsAt);
+  const end = parse(input.endsAt);
+
+  if (phase === "during") {
+    if (input.status === "PAUSED") return { label: "Paused", urgent: false };
+    if (!end) return { label: "Fishing now", urgent: true };
+    const remaining = end.getTime() - now;
+    if (remaining <= 0) return { label: "Time is up", urgent: true };
+    return { label: `${formatDuration(remaining)} left`, urgent: true };
+  }
+
+  if (!start) return null;
+  const until = start.getTime() - now;
+  if (until <= 0) return { label: "Start time has passed", urgent: false };
+  return { label: `Starts in ${formatDuration(until)}`, urgent: until < DAY };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Entry, sync, and evidence states                                            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * UX-001 §5 is explicit that the four entry states must not be collapsed into
+ * "registered" — payment, eligibility, check-in and competition each move on their own,
+ * and flattening them is how an angler ends up at the dock believing they are entered when
+ * their eligibility is still unresolved. So each gets its own line, its own plain word,
+ * and its own "what do I do about it".
+ */
+export interface EntryStep {
+  readonly label: string;
+  readonly value: string;
+  readonly tone: StatusTone;
+  readonly hint: string;
+}
+
+const REGISTRATION: Readonly<Record<string, Omit<EntryStep, "label">>> = {
+  DRAFT: { value: "Not finished", tone: "attention", hint: "Your entry has not been submitted yet." },
+  PENDING: { value: "Submitted", tone: "neutral", hint: "Waiting on the organizer to confirm your place." },
+  SUBMITTED: { value: "Submitted", tone: "neutral", hint: "Waiting on the organizer to confirm your place." },
+  PAYMENT_REQUIRED: { value: "Payment needed", tone: "attention", hint: "Your place is held until the entry fee is paid." },
+  CONFIRMED: { value: "Confirmed", tone: "open", hint: "You are in." },
+  WAITLISTED: { value: "Waitlisted", tone: "attention", hint: "You are next in line if a place opens." },
+  CANCELLED: { value: "Cancelled", tone: "stopped", hint: "This entry has been withdrawn." },
+};
+
+const ELIGIBILITY: Readonly<Record<string, Omit<EntryStep, "label">>> = {
+  UNKNOWN: { value: "Not checked yet", tone: "neutral", hint: "The organizer has not run eligibility on this entry." },
+  PENDING: { value: "Being checked", tone: "neutral", hint: "The organizer is reviewing your details." },
+  ELIGIBLE: { value: "Eligible", tone: "open", hint: "You meet the rules for this event." },
+  ACTION_REQUIRED: { value: "Needs something from you", tone: "attention", hint: "The organizer has asked for more information." },
+  INELIGIBLE: { value: "Not eligible", tone: "stopped", hint: "Ask the organizer what would change this." },
+};
+
+const CHECK_IN: Readonly<Record<string, Omit<EntryStep, "label">>> = {
+  NOT_CHECKED_IN: { value: "Not checked in", tone: "neutral", hint: "Check in at the ramp before lines in." },
+  CHECKED_IN: { value: "Checked in", tone: "open", hint: "The organizer has you on the water." },
+  MISSED: { value: "Missed check-in", tone: "attention", hint: "Talk to the organizer before you fish." },
+};
+
+const COMPETITION: Readonly<Record<string, Omit<EntryStep, "label">>> = {
+  NOT_STARTED: { value: "Not started", tone: "neutral", hint: "Nothing counts until the tournament goes live." },
+  ACTIVE: { value: "Fishing", tone: "live", hint: "Your catches are counting." },
+  WITHDRAWN: { value: "Withdrawn", tone: "stopped", hint: "You are no longer being scored." },
+  DISQUALIFIED: { value: "Disqualified", tone: "stopped", hint: "A judge has recorded a reason for this." },
+};
+
+function step(
+  label: string,
+  table: Readonly<Record<string, Omit<EntryStep, "label">>>,
+  raw: string,
+): EntryStep {
+  const known = table[raw];
+  if (known) return { label, ...known };
+  return { label, value: titleCase(raw), tone: "neutral", hint: "" };
+}
+
+export function entrySteps(entry: {
+  readonly registration_status: string;
+  readonly eligibility_status: string;
+  readonly check_in_status: string;
+  readonly competition_status: string;
+}): readonly EntryStep[] {
+  return [
+    step("Your place", REGISTRATION, entry.registration_status),
+    step("Eligibility", ELIGIBILITY, entry.eligibility_status),
+    step("Check-in", CHECK_IN, entry.check_in_status),
+    step("Competing", COMPETITION, entry.competition_status),
+  ];
+}
+
+/**
+ * The five offline states UX-001 §9 requires, in the angler's words. "Saved on this
+ * device" is the important one: it is what the app can honestly promise while the boat is
+ * out of range, and it must never be dressed up as confirmation from a server that has not
+ * heard from us.
+ */
+export function syncPresentation(state: string): { readonly label: string; readonly tone: StatusTone; readonly hint: string } {
+  switch (state) {
+    case "SAVED_OFFLINE":
+      return {
+        label: "Saved on this phone",
+        tone: "neutral",
+        hint: "Nothing is lost. It goes up when you have service.",
+      };
+    case "PENDING_SYNC":
+      return { label: "Waiting to send", tone: "attention", hint: "Queued. Retrying does not create a second catch." };
+    case "SYNCED":
+      return { label: "Received by the scorer", tone: "open", hint: "The tournament has it. Scoring is a judge's job, not the phone's." };
+    case "CONFLICT":
+      return {
+        label: "Needs a person to look",
+        tone: "stopped",
+        hint: "Your original photo and details are kept exactly as recorded. Nothing was overwritten.",
+      };
+    default:
+      return { label: titleCase(state), tone: "neutral", hint: "" };
+  }
+}
+
+/**
+ * The QR outcomes an angler can see, phrased as observations rather than accusations.
+ * "Reused" is a fact about a token; it is not a finding about the person holding the phone,
+ * and a screen that implies otherwise will be wrong in front of the wrong person one day.
+ */
+export function qrPresentation(state: string): { readonly label: string; readonly tone: StatusTone } {
+  switch (state) {
+    case "VALID":
+      return { label: "Code checked out", tone: "open" };
+    case "NOT_SCANNED":
+      return { label: "No code scanned", tone: "neutral" };
+    case "EXPIRED":
+      return { label: "Code had expired", tone: "attention" };
+    case "REUSED":
+      return { label: "Code already used", tone: "attention" };
+    case "WRONG_CONTEXT":
+      return { label: "Code from another event", tone: "attention" };
+    default:
+      return { label: titleCase(state), tone: "neutral" };
+  }
+}

--- a/src/features/tournaments/ui-classes.ts
+++ b/src/features/tournaments/ui-classes.ts
@@ -1,11 +1,81 @@
-export const TOURNAMENT_CARD =
-  "rounded-card border border-hairline bg-surface p-space-4 shadow-card";
+/**
+ * The tournament section's control vocabulary.
+ *
+ * The previous version of this file was built on utilities that do not exist:
+ * `bg-action`, `text-on-action`, `rounded-card`, `shadow-card`, `bg-surface-muted`.
+ * Tailwind v4 generates utilities from the `@theme` block in `tokens.generated.css`, and
+ * none of those names are in it — so every primary button in the tournament section
+ * rendered as transparent text on the page background, and every card rendered as a
+ * square with no radius. That is most of why this section looked unfinished next to the
+ * rest of the app: it was not styled at all. Every class below is checked against
+ * `src/core/design/tokens.json`.
+ *
+ * Values are the ones already agreed in `docs/design/04-components.md` and used by
+ * `features/games/ui-classes.ts`. They are duplicated rather than imported for the reason
+ * that file states: ADR 005 §3 forbids reaching into another feature's internals, and a
+ * handful of class strings is a cheaper duplication than a cross-feature import.
+ */
 
-export const TOURNAMENT_PRIMARY_BUTTON =
-  "inline-flex min-h-touch-floor items-center justify-center rounded-control bg-action px-space-4 py-space-3 text-label text-on-action transition active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-50";
+export const FOCUS_RING =
+  "focus-visible:outline focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-focus-ring";
 
-export const TOURNAMENT_SECONDARY_BUTTON =
-  "inline-flex min-h-touch-floor items-center justify-center rounded-control border border-hairline bg-surface px-space-4 py-space-3 text-label text-text-primary transition active:scale-[0.99]";
+/**
+ * The page frame. Deliberately without horizontal padding of its own: the app shell
+ * (`shell-frame.tsx`) already pads `main` by 16px, and the old wrapper added another 16 on
+ * top of it, which cost 64px of a 390px phone before a card even started. Cards now run to
+ * the shell's gutter, which is what gives a leaderboard row room to breathe.
+ */
+export const PAGE = "mx-auto flex w-full max-w-reading flex-col gap-space-6";
 
-export const TOURNAMENT_INPUT =
-  "min-h-touch-floor w-full rounded-control border border-hairline bg-surface px-space-3 py-space-3 text-body text-text-primary outline-none focus:border-text-link";
+/** Resting card: `surface` fill, hairline border, radius-lg (design 04 → Card). */
+export const CARD = "rounded-lg border border-hairline bg-surface";
+export const CARD_PADDED = `${CARD} p-space-4`;
+
+/** The open/active state of a card, and the frame for anything that sits above one. */
+export const CARD_RAISED = "rounded-lg border border-border-interactive bg-surface-raised";
+export const CARD_RAISED_PADDED = `${CARD_RAISED} p-space-4`;
+
+/** An inset block *inside* a card — an evidence row, a rule line, a warning panel. */
+export const INSET = "rounded-md border border-hairline bg-background p-space-3";
+
+const BUTTON_BASE = `inline-flex min-h-touch-floor items-center justify-center gap-space-2 rounded-md px-space-4 text-label transition-colors ${FOCUS_RING} active:scale-95 motion-reduce:transition-none disabled:cursor-not-allowed disabled:opacity-disabled`;
+
+export const PRIMARY_BUTTON = `${BUTTON_BASE} bg-signal-orange text-ink-on-orange hover:bg-signal-orange-pressed`;
+
+export const SECONDARY_BUTTON = `${BUTTON_BASE} border border-border-interactive bg-surface-raised text-text-primary hover:border-text-link`;
+
+/** No fill, no border. For "Back", "Skip", and other low-emphasis moves. */
+export const TERTIARY_BUTTON = `${BUTTON_BASE} text-text-link hover:text-text-primary`;
+
+/**
+ * The screen-level primary action — 68px, full width (design 03 §1). The one control on a
+ * live-competition screen that has to be hit with wet hands without looking.
+ */
+export const BIG_ACTION = `flex min-h-touch-primary-standard w-full items-center justify-center gap-space-2 rounded-lg bg-signal-orange px-space-4 text-h3 text-ink-on-orange transition-colors hover:bg-signal-orange-pressed ${FOCUS_RING} active:scale-95 motion-reduce:transition-none disabled:cursor-not-allowed disabled:opacity-disabled`;
+
+export const INPUT = `min-h-touch-floor w-full rounded-md border border-border-interactive bg-background px-space-4 py-space-3 text-body text-text-primary placeholder:text-text-muted ${FOCUS_RING} focus:border-focus-ring`;
+
+export const SELECT = `min-h-touch-floor w-full rounded-md border border-border-interactive bg-background px-space-3 text-body text-text-primary ${FOCUS_RING}`;
+
+/**
+ * Chip picker (design 04 → Select/Chip picker). Selected is an orange fill, because a
+ * selected chip is a committed choice — the same weight as a tap on a button.
+ */
+export const CHIP = `inline-flex min-h-touch-floor items-center justify-center rounded-full border px-space-4 text-label transition-colors ${FOCUS_RING} active:scale-95 motion-reduce:transition-none`;
+export const CHIP_ON = "border-signal-orange bg-signal-orange text-ink-on-orange";
+export const CHIP_OFF = "border-border-interactive bg-surface text-text-link hover:border-text-link";
+
+/** The "← Tournaments" line at the top of a detail screen. 48px of tap area, not 20. */
+export const BACK_LINK = `inline-flex min-h-touch-floor items-center gap-space-2 self-start rounded-md text-caption text-text-link transition-colors hover:text-text-primary ${FOCUS_RING}`;
+
+/** Numbers that line up in a column: weights, ranks, counts, clocks. */
+export const TABULAR = "font-mono tabular-nums";
+
+/**
+ * Kept as named aliases because `app/(app)/tournaments/error.tsx` and any future screen
+ * outside this feature import by these names. Same values, real utilities underneath.
+ */
+export const TOURNAMENT_CARD = CARD_PADDED;
+export const TOURNAMENT_PRIMARY_BUTTON = PRIMARY_BUTTON;
+export const TOURNAMENT_SECONDARY_BUTTON = SECONDARY_BUTTON;
+export const TOURNAMENT_INPUT = INPUT;

--- a/src/features/tournaments/use-now.ts
+++ b/src/features/tournaments/use-now.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+/**
+ * A ticking clock and the online flag, as external stores rather than `useEffect` +
+ * `setState`.
+ *
+ * Copied value-for-value from `features/games/use-now.ts`, which explains the reasoning:
+ * setting state synchronously in an effect body is a cascading render, and with the React
+ * Compiler on it is exactly the shape that behaves differently from what the code appears
+ * to say. `useSyncExternalStore` is what these are for — an outside source of truth (the
+ * wall clock, the radio) that React subscribes to. Duplicated rather than imported because
+ * ADR 005 §3 forbids reaching into another feature's internals.
+ *
+ * The tournament section needs both for reasons the old code got wrong: it read
+ * `navigator.onLine` straight in a render body, which is a `ReferenceError` during the
+ * server render every one of these pages still gets, and that error was landing the whole
+ * live-catch screen in `error.tsx`.
+ *
+ * The cached `nowMs` matters: `getSnapshot` must return a value that is `Object.is`-equal
+ * between renders or React re-renders forever, so it returns the last tick rather than
+ * calling `Date.now()` itself.
+ */
+
+let nowMs = 0;
+const listeners = new Set<() => void>();
+let timer: number | null = null;
+
+function emit(): void {
+  const next = Date.now();
+  if (next === nowMs) return;
+  nowMs = next;
+  for (const listener of listeners) listener();
+}
+
+function subscribeNow(listener: () => void): () => void {
+  listeners.add(listener);
+  if (timer === null) {
+    nowMs = Date.now();
+    // Only while the tab is visible. A countdown burning battery in a pocket for six
+    // hours is a real cost on a boat with no charger.
+    timer = window.setInterval(() => {
+      if (document.visibilityState === "visible") emit();
+    }, 1000);
+    document.addEventListener("visibilitychange", emit);
+  }
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0 && timer !== null) {
+      window.clearInterval(timer);
+      document.removeEventListener("visibilitychange", emit);
+      timer = null;
+    }
+  };
+}
+
+const getNow = (): number => nowMs;
+/** Zero on the server, so the first client paint matches and the clock simply hides. */
+const getServerNow = (): number => 0;
+
+export function useNow(): number {
+  return useSyncExternalStore(subscribeNow, getNow, getServerNow);
+}
+
+function subscribeOnline(listener: () => void): () => void {
+  window.addEventListener("online", listener);
+  window.addEventListener("offline", listener);
+  return () => {
+    window.removeEventListener("online", listener);
+    window.removeEventListener("offline", listener);
+  };
+}
+
+/** A boolean, so it is stable between renders without any caching of its own. */
+const getOnline = (): boolean => navigator.onLine;
+const getServerOnline = (): boolean => true;
+
+export function useOnline(): boolean {
+  return useSyncExternalStore(subscribeOnline, getOnline, getServerOnline);
+}

--- a/src/features/tournaments/use-tournament.ts
+++ b/src/features/tournaments/use-tournament.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { createClient } from "@/lib/supabase/client";
+import { getDemoTournament, hasSupabaseBrowserConfig, type DemoTournament } from "./demo-store";
+
+/**
+ * One loader for every tournament detail screen.
+ *
+ * Each of the five screens used to fetch the tournament its own way, which is how they
+ * ended up with five different loading messages, three different error sentences, and two
+ * of them reading `localStorage` **during render** — a demo tournament that exists on the
+ * phone renders as "not found" in the server's HTML and then swaps to the real thing on
+ * hydration, which React reports as a mismatch and the founder experiences as a flash of
+ * "Tournament not found on this device."
+ *
+ * The fix is the boring one: fetch in an effect, hold three explicit states, and let every
+ * screen render the same skeleton and the same error card.
+ */
+
+export type TournamentLoad =
+  | { readonly state: "loading" }
+  | { readonly state: "error"; readonly message: string }
+  | { readonly state: "ready"; readonly tournament: DemoTournament };
+
+const SELECT_COLUMNS =
+  "id,name,status,visibility,starts_at,ends_at,organization_id,active_rule_set_version_id,active_scoring_version_id,active_verification_policy_version_id,active_boundary_version_id";
+
+export function useTournament(tournamentId: string): TournamentLoad {
+  const [load, setLoad] = useState<TournamentLoad>({ state: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      // Yield once before any `setState`. Without it the demo branch below would set state
+      // synchronously inside the effect body, which is a cascading render and is the exact
+      // shape `react-hooks/set-state-in-effect` exists to catch.
+      await Promise.resolve();
+      if (cancelled) return;
+      // Back to the skeleton whenever the id changes, so a second tournament never paints
+      // for a moment with the first one's name.
+      setLoad({ state: "loading" });
+
+      if (!hasSupabaseBrowserConfig()) {
+        const demo = getDemoTournament(tournamentId);
+        setLoad(
+          demo
+            ? { state: "ready", tournament: demo }
+            : {
+                state: "error",
+                message:
+                  "This tournament is not saved on this phone. Demo tournaments live on the device that created them.",
+              },
+        );
+        return;
+      }
+
+      try {
+        const supabase = createClient();
+        const { data, error } = await supabase
+          .from("tournament")
+          .select(SELECT_COLUMNS)
+          .eq("id", tournamentId)
+          .is("deleted_at", null)
+          .maybeSingle();
+
+        if (cancelled) return;
+        if (error) setLoad({ state: "error", message: error.message });
+        else if (!data) setLoad({ state: "error", message: "That tournament is not there, or it is not shared with you." });
+        else setLoad({ state: "ready", tournament: data as DemoTournament });
+      } catch (cause) {
+        if (cancelled) return;
+        setLoad({
+          state: "error",
+          message: cause instanceof Error ? cause.message : "The tournament could not be loaded.",
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [tournamentId]);
+
+  return load;
+}
+
+/** True when the app is running without a Supabase connection, i.e. on-device demo data. */
+export function useDemoMode(): boolean {
+  return !hasSupabaseBrowserConfig();
+}


### PR DESCRIPTION
## What changed

The tournament section was rebuilt against the real design system, and three functional faults were fixed along the way.

**It was never actually styled.** The section used utility classes that do not exist in `src/core/design/tokens.json` — `bg-action`, `text-on-action`, `rounded-card`, `shadow-card`, `bg-surface-muted`. Tailwind v4 generates utilities from the `@theme` block in `tokens.generated.css`, so nothing was emitted for any of them: every primary button rendered as bare text on the page background and every card as a square with no radius. `ui-classes.ts` is now built on the real vocabulary, at the values already agreed in `docs/design/04-components.md`.

**Two screens crashed or mismatched on hydration.** `tournament-live-catches.tsx` read `navigator.onLine` in the render body — a `ReferenceError` in the server render every one of these pages still gets — so the route fell through to `error.tsx` before drawing a field. That screen and `tournament-operations.tsx` also read `localStorage` during render, so a demo tournament rendered as "not found" server-side and swapped on hydration. Both now load through one shared effect-backed loader (`use-tournament.ts`, `use-now.ts`) with one skeleton and one error card.

**The Rules tab was a 404.** The tab strip has linked to `/tournaments/[id]/rules` since the section shipped and the route did not exist. It does now.

Beyond the fixes:

- **Standings are their own screen.** They were a tab inside "Tournament operations", so an angler had to open the organizer's screen — beside the payout controls — to see whether they were winning. Organizer tools are now one card on the overview and off the angler's tab strip (UX-001 §7).
- **No screen prints a database enum.** `REGISTRATION_OPEN` is "Taking entries"; `not_checked_in` is "Not checked in — check in at the ramp before lines in". Every tournament carries a real clock ("Starts in 6 days", "4h 30m left"), and the clock defers to lifecycle state so it can never contradict the status pill beside it. Wording, tone mapping and clock live in `format.ts`.
- **Organizer lifecycle controls are computed from `core/tournaments/lifecycle.ts`**, so the screen offers exactly the moves the transition table allows and names which frozen input is blocking "Start fishing". They stay disabled — that half is unwired.
- **Create-a-tournament is three steps**, one question per screen, and now rejects a finish time earlier than the start.

Two panels were removed rather than restyled, because they were untrue: the finance lane displayed **$1,250** of entry money nobody had taken, and the judge queue showed an invented catch. Finance now states the guarantee it enforces and shows no numbers; the queue is built from real flagged catches.

## Why

The founder's report was "amateur" and "barely functions". Both halves were literal: the styling never resolved, and one of the six screens error-boundaried on load.

## How it was checked

- `npm run verify` (tokens, tripwires, migrations, lint, `tsc --noEmit`, tests) and `npm run build` pass. 875 tests, 14 of them new, covering status wording, phase mapping, duration formatting and the countdown's deference to lifecycle state.
- Looked at every screen in a headless Chromium at 390px — hub, create, overview (live and pre-event), register, catches, standings, rules, operations. No console or page errors on any of them.

## Not fixed here

Nothing on these screens can change tournament state, judge a catch, or move money — the server side of all three is unbuilt, so those controls are visible, disabled, and say so. Real rule text, divisions, teams, boats and invites still have no UI; they need their backend contracts first. The confirmation copy for the three high-risk transitions (start, finalize, cancel) in UX-001 §6 is the natural next piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K73Uhpp8p52X4hxr9HJKuv

---
_Generated by [Claude Code](https://claude.ai/code/session_01K73Uhpp8p52X4hxr9HJKuv)_