### PR TITLE
Let a host choose what the tournament is

### DIFF
--- a/docs/team/channel/2026-09-05-02-ux-ui-to-head-dev.md
+++ b/docs/team/channel/2026-09-05-02-ux-ui-to-head-dev.md
@@ -1,0 +1,36 @@
+### 2026-09-05 | ux-ui -> head-dev
+
+`supabase/migrations/20260905194000_tournament_scoring.sql` references two tables that no
+migration creates:
+
+- line 25 — `standing.division_id uuid references public.tournament_division(id)`
+- line 72 — `final_result_award.tournament_award_category_id uuid not null references
+  public.tournament_award_category(id)`
+
+`grep -rn "tournament_division\|tournament_award_category" supabase/` returns only those two
+references. There is no `create table` for either, in that migration or any other, so a
+fresh `db reset` should fail at this file with "relation public.tournament_division does not
+exist". I have not run it against a live database — no Supabase is configured in this
+environment — so please confirm before assuming it is only a lint-level problem.
+
+Why it matters beyond the failing migration: divisions and award categories are the two
+things every competitor in this market leads with (CatchStat, WeighBook, Web Pro all sell
+"complex categories" as the headline capability for large events). A tournament with a
+Junior division, a Ladies division and a Heaviest-Single-Fish award is the ordinary case in
+the B2B pitch, not an advanced one. Until those tables exist the UI can only show one flat
+board, which is what it does today.
+
+I have not touched the migrations — not my lane.
+
+Two smaller asks from the same lane, in priority order:
+
+1. **A join code on `tournament`.** Directors read a code out at a captains' meeting and
+   anglers type it in; it is how a field of eighty actually gets registered. The invite
+   panel I shipped can only share a link, because a code has nowhere to live and no lookup.
+   A short unique column plus a `find_tournament_by_join_code` RPC (respecting visibility)
+   is all the UI needs.
+2. **Entry check-in.** The roster screen can toggle `check_in_status` in demo mode only.
+   Real check-in needs an RPC an organizer may call for entries in their own tournament —
+   `tournament_entry` is admin-write today and self-registration is the only RPC.
+
+— ux-ui (tournament UI lane, branch `claude/tournament-ui-redesign-lt45ay`)

--- a/docs/team/worklog/2026-09-05-93-ux-ui.md
+++ b/docs/team/worklog/2026-09-05-93-ux-ui.md
@@ -1,0 +1,39 @@
+### 2026-09-05 | ux-ui | ~2h
+
+- Built the field: a "Who's in" screen. You could create a tournament and enter one, but
+  there was no way to see who was in it — the biggest hole in the section. A director's
+  first question is "where are my eighty boats?" and three friends' first question is "is
+  Dad in yet?", and it is the same screen for both.
+- The roster shows the number on the hull, the boat, the team, who is aboard, and whether
+  they have checked in. Checking a boat in works (on this device), and the counts above the
+  list update with it. Search and filters appear when a field is big enough to need them —
+  a four-person family event does not see them.
+- Everything now reads the same list. The roster, the standings board, the overview summary
+  and the organizer's counts all come from one place, so they cannot disagree. Before this,
+  the leaderboard had three made-up names in it and nothing else had any.
+- Two boats on the same weight now share a place (1, 2, 2, 4) instead of one being quietly
+  put above the other by whatever order the rows arrived in.
+- Standings got a "Show on a big screen" view for the television in the marina bar — the
+  thing every competitor in this market sells first.
+- Entering a tournament now puts you on the roster, which it did not before.
+- Fixed copy that was wrong rather than merely ugly: the entry states I wrote last session
+  were half invented. Six real states the database can store (Withdrawn, Not accepted,
+  Checked out, Being checked, Paused, Finished) had no words at all and would have reached
+  an angler as grey text with no explanation. A test now reads the constraint out of the
+  migration and fails if the two ever drift again.
+- Sharing: a tournament can be shared with the phone's own share sheet. Deliberately no
+  join code — see the note to head-dev, there is nowhere to put one.
+- Checked every screen in a browser at phone width, no console or page errors.
+  `npm run verify` and `npm run build` pass; 899 tests, 24 of them new.
+- Files: `src/features/tournaments/**`, `src/app/(app)/tournaments/[id]/participants/`
+- **Found a broken migration, not mine to fix.** `20260905194000_tournament_scoring.sql`
+  has foreign keys to `tournament_division` and `tournament_award_category`, and no
+  migration ever creates either table — a fresh database should fail at that file. It also
+  blocks divisions and award categories, which is what every competitor leads with for
+  large events. Written up in `docs/team/channel/2026-09-05-02-ux-ui-to-head-dev.md`.
+- Still not working, and still needs the backend: nothing here can change tournament state,
+  judge a catch, take money, or check a boat in for real. Teams and boats are read-only —
+  there is no screen to create one. No divisions, no award categories, no weigh-in station.
+- Next: the weigh-in screen is the obvious one after this. A staff member with a scale and
+  an iPad entering official weights against an entry number is how these events are
+  actually scored, and the roster now has the entry numbers to do it against.

--- a/docs/team/worklog/2026-09-06-01-ux-ui.md
+++ b/docs/team/worklog/2026-09-06-01-ux-ui.md
@@ -1,0 +1,44 @@
+### 2026-09-06 | ux-ui | ~3h
+
+- A host can now say what their tournament actually is, instead of every event being
+  "heaviest fish and hope". Four presets on the create screen, laid out like the Boat Games
+  mode cards: heaviest fish wins; first/second/third; points per species; several categories.
+- Points per species is the Captain's Cup mechanic — you set what each fish is worth and the
+  table is the rules. It starts with a table for our water that the host edits, because a
+  calico bass is worth something different in Newport than off Seattle.
+- Several categories is the Bisbee's shape: biggest marlin, biggest tuna, biggest dorado, each
+  its own competition with its own winner, its own entry fee and its own pot. One boat can be
+  in all of them. The standings screen gets a row of chips and each one is a genuinely
+  different board.
+- All four are one thing underneath: a tournament is a list of categories, and a category has
+  a scoring rule and a payout. That is why adding a fifth shape later is data, not code.
+- The prize split maths is exact and tested. If a place goes unfilled its share is shared out
+  among the places that were, so the pot always leaves entirely; the odd cent goes to the
+  winner, which is what every tournament does.
+- **Money is declared, never collected.** A host can say a category costs $250 and the board
+  shows what the pot would be and how it splits. Nothing charges anybody — payments are their
+  own domain and are not switched on. Every screen that shows a figure says so.
+- **Fixed a migration that could never have run.** `20260905194000_tournament_scoring.sql`
+  had foreign keys to `tournament_division` and `tournament_award_category`; neither table
+  was ever created, so a fresh database failed at that file. Both now exist, created one
+  version earlier so the keys resolve. This was the thing blocking a real deployment.
+- Production write path: `save_tournament_format` appends a scoring version holding the
+  format, mirrors its categories into award-category rows, and points the tournament at the
+  new version. Owner/admin only, and refused once the tournament has started — the rules
+  cannot move under the people fishing it. Nothing is edited in place, so what an event was
+  scored under is always recoverable.
+- Demo mode still works and now reads the same format documents, so the same code runs both
+  ways.
+- Checked in a browser at phone width: walked the whole wizard, both editors, the review, all
+  three category boards. No console or page errors. `npm run verify` and `npm run build`
+  pass; 939 tests, 40 of them new.
+- Files: `src/core/tournaments/formats.ts`, `src/features/tournaments/**`,
+  `supabase/migrations/20260905193800_*.sql`, `supabase/migrations/20260906090000_*.sql`
+- **Not verified against a real database.** No Supabase is configured in this environment, so
+  the migrations and the RPC are written but have never been run. Somebody has to apply them
+  and walk a real tournament through before this can be called done.
+- Still missing: divisions (Junior, Ladies) have a table now but no UI; nothing scores from
+  the server yet, so boards are computed on the device from approved catches; no weigh-in
+  screen; teams and boats are still read-only.
+- Next: the weigh-in screen. Categories now exist, so a staff member entering an official
+  weight against an entry number has somewhere for that weight to land.

--- a/src/app/(app)/tournaments/[id]/participants/page.tsx
+++ b/src/app/(app)/tournaments/[id]/participants/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+import { TournamentParticipants } from "@/features/tournaments/components/tournament-participants";
+
+export const metadata: Metadata = { title: "Who's In | Fish Log Book" };
+
+/**
+ * The field. UX-001 §2 has had "participants" in the information architecture since the
+ * contract was written; this is it.
+ */
+export default async function TournamentParticipantsPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <TournamentParticipants tournamentId={id} />;
+}

--- a/src/app/(app)/tournaments/new/page.tsx
+++ b/src/app/(app)/tournaments/new/page.tsx
@@ -14,7 +14,7 @@ export default function NewTournamentPage() {
         </Link>
         <h1 className="text-h1 text-text-primary">Create a tournament</h1>
         <p className="text-body text-text-muted">
-          Three questions. The rest waits until you need it.
+          Four questions. The rest waits until you need it.
         </p>
       </header>
       <CreateTournamentForm />

--- a/src/core/tournaments/formats.test.ts
+++ b/src/core/tournaments/formats.test.ts
@@ -1,0 +1,336 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  catchesIn,
+  countsIn,
+  describeCategory,
+  emptyCategory,
+  familyColumnFor,
+  FORMAT_PRESETS,
+  formatMoney,
+  parseFormat,
+  payoutBreakdown,
+  poolFor,
+  scoreRuleFor,
+  validateFormat,
+  type FormatCategory,
+  type TournamentFormat,
+} from "./formats";
+import { computeOfficialStandings, type EligibleCatch } from "./official-scoring";
+
+function fish(id: string, entryId: string, speciesId: string | null, weightG: number): EligibleCatch {
+  return { id, entryId, speciesId, weightG, lengthMm: null, approved: true, disqualified: false };
+}
+
+describe("presets", () => {
+  it("every preset produces a format that validates", () => {
+    for (const preset of FORMAT_PRESETS) {
+      expect(validateFormat(preset.build()), preset.id).toEqual([]);
+    }
+  });
+
+  it("covers the four shapes a host asked for", () => {
+    const ids = FORMAT_PRESETS.map((preset) => preset.id);
+    expect(ids).toEqual(["biggest_fish", "places", "species_points", "categories"]);
+  });
+
+  it("the multi-category preset is three separate competitions", () => {
+    const format = FORMAT_PRESETS.find((preset) => preset.id === "categories")!.build();
+    expect(format.categories).toHaveLength(3);
+    for (const item of format.categories) {
+      expect(item.species.length).toBeGreaterThan(0);
+      expect(item.payout.model).toBe("WINNER_TAKE_ALL");
+    }
+  });
+
+  it("the points preset ships a table the host can edit rather than an empty one", () => {
+    const format = FORMAT_PRESETS.find((preset) => preset.id === "species_points")!.build();
+    expect(Object.keys(format.categories[0].speciesPoints).length).toBeGreaterThan(4);
+  });
+});
+
+describe("validateFormat", () => {
+  const base = FORMAT_PRESETS[0].build();
+
+  it("accepts a sound format", () => {
+    expect(validateFormat(base)).toEqual([]);
+  });
+
+  it("rejects a tournament with nothing to score", () => {
+    expect(validateFormat({ ...base, categories: [] })).toContain(
+      "A tournament needs at least one category to score.",
+    );
+  });
+
+  it("rejects a place split that does not add up to 100", () => {
+    const format: TournamentFormat = {
+      currency: "USD",
+      categories: [
+        { ...emptyCategory("a", "Overall"), payout: { model: "PLACES", split: [50, 30] } },
+      ],
+    };
+    expect(validateFormat(format)).toContain('The split for “Overall” adds up to 80%, not 100%.');
+  });
+
+  it("allows a split a host typed as thirds", () => {
+    const format: TournamentFormat = {
+      currency: "USD",
+      categories: [
+        { ...emptyCategory("a", "Overall"), payout: { model: "PLACES", split: [33.3, 33.3, 33.4] } },
+      ],
+    };
+    expect(validateFormat(format)).toEqual([]);
+  });
+
+  it("rejects two categories with the same name", () => {
+    const format: TournamentFormat = {
+      currency: "USD",
+      categories: [emptyCategory("a", "Tuna"), emptyCategory("b", "tuna")],
+    };
+    expect(validateFormat(format).join(" ")).toContain("Two categories are both called");
+  });
+
+  it("rejects a points category with no species worth anything", () => {
+    const format: TournamentFormat = {
+      currency: "USD",
+      categories: [{ ...emptyCategory("a", "Points"), family: "SPECIES_POINTS" }],
+    };
+    expect(validateFormat(format).join(" ")).toContain("at least one species needs a value");
+  });
+
+  it("rejects a best-few category that never says how many", () => {
+    const format: TournamentFormat = {
+      currency: "USD",
+      categories: [{ ...emptyCategory("a", "Best few"), family: "BEST_N_WEIGHT" }],
+    };
+    expect(validateFormat(format).join(" ")).toContain("needs to say how many");
+  });
+
+  it("rejects a nonsense currency", () => {
+    expect(validateFormat({ ...base, currency: "dollars" }).join(" ")).toContain("three-letter code");
+  });
+});
+
+describe("category eligibility", () => {
+  const marlin: FormatCategory = {
+    ...emptyCategory("marlin", "Biggest marlin"),
+    species: ["blue_marlin", "striped_marlin"],
+  };
+
+  it("counts only the species named", () => {
+    expect(countsIn(marlin, "blue_marlin")).toBe(true);
+    expect(countsIn(marlin, "bluefin_tuna")).toBe(false);
+  });
+
+  it("counts everything when no species are named", () => {
+    expect(countsIn(emptyCategory("all", "Overall"), "anything_at_all")).toBe(true);
+  });
+
+  it("does not count a fish nobody identified into a species-restricted category", () => {
+    expect(countsIn(marlin, null)).toBe(false);
+    expect(countsIn(emptyCategory("all", "Overall"), null)).toBe(true);
+  });
+
+  it("splits one boat's catches across the categories they belong to", () => {
+    const landed = [
+      fish("c1", "e1", "blue_marlin", 180_000),
+      fish("c2", "e1", "bluefin_tuna", 40_000),
+      fish("c3", "e1", "bluefin_tuna", 52_000),
+    ];
+    const tuna: FormatCategory = {
+      ...emptyCategory("tuna", "Biggest tuna"),
+      species: ["bluefin_tuna", "yellowfin_tuna"],
+    };
+
+    expect(catchesIn(marlin, landed).map((c) => c.id)).toEqual(["c1"]);
+    expect(catchesIn(tuna, landed).map((c) => c.id)).toEqual(["c2", "c3"]);
+  });
+});
+
+describe("scoring through the official scorer", () => {
+  it("scores a species-points category on the host's own table", () => {
+    const item: FormatCategory = {
+      ...emptyCategory("points", "Points"),
+      family: "SPECIES_POINTS",
+      speciesPoints: { yellowtail: 8, bonito: 1 },
+    };
+    const landed = [
+      fish("c1", "e1", "yellowtail", 9_000),
+      fish("c2", "e1", "bonito", 2_000),
+      fish("c3", "e2", "yellowtail", 4_000),
+    ];
+
+    const standings = computeOfficialStandings(
+      ["e1", "e2"],
+      catchesIn(item, landed),
+      [],
+      scoreRuleFor(item),
+    );
+
+    expect(standings.find((row) => row.entryId === "e1")?.score).toBe(9);
+    expect(standings.find((row) => row.entryId === "e2")?.score).toBe(8);
+  });
+
+  it("scores a heaviest-fish category on the single best weight", () => {
+    const item = emptyCategory("overall", "Heaviest");
+    const standings = computeOfficialStandings(
+      ["e1"],
+      [fish("c1", "e1", "dorado", 12_000), fish("c2", "e1", "dorado", 20_000)],
+      [],
+      scoreRuleFor(item),
+    );
+    expect(standings[0].score).toBe(20_000);
+  });
+});
+
+describe("payoutBreakdown", () => {
+  it("gives the whole pot to the winner when that is the model", () => {
+    expect(
+      payoutBreakdown({
+        poolMinor: 250_000,
+        payout: { model: "WINNER_TAKE_ALL", split: [] },
+        placesFilled: 9,
+      }),
+    ).toEqual([{ rank: 1, amountMinor: 250_000 }]);
+  });
+
+  it("splits down the places", () => {
+    expect(
+      payoutBreakdown({
+        poolMinor: 100_000,
+        payout: { model: "PLACES", split: [50, 30, 20] },
+        placesFilled: 3,
+      }),
+    ).toEqual([
+      { rank: 1, amountMinor: 50_000 },
+      { rank: 2, amountMinor: 30_000 },
+      { rank: 3, amountMinor: 20_000 },
+    ]);
+  });
+
+  it("shares an unfilled place out rather than leaving money unaccounted for", () => {
+    const slices = payoutBreakdown({
+      poolMinor: 100_000,
+      payout: { model: "PLACES", split: [50, 30, 20] },
+      placesFilled: 2,
+    });
+    expect(slices).toEqual([
+      { rank: 1, amountMinor: 62_500 },
+      { rank: 2, amountMinor: 37_500 },
+    ]);
+    expect(slices.reduce((sum, slice) => sum + slice.amountMinor, 0)).toBe(100_000);
+  });
+
+  it("never invents or loses a cent, and the remainder goes to the winner", () => {
+    const slices = payoutBreakdown({
+      poolMinor: 10_000,
+      payout: { model: "PLACES", split: [33.3, 33.3, 33.4] },
+      placesFilled: 3,
+    });
+    expect(slices.reduce((sum, slice) => sum + slice.amountMinor, 0)).toBe(10_000);
+    expect(slices[0].amountMinor).toBeGreaterThanOrEqual(slices[1].amountMinor);
+  });
+
+  it("pays nothing out of an empty pot, or to an empty field", () => {
+    const payout = { model: "PLACES", split: [50, 30, 20] } as const;
+    expect(payoutBreakdown({ poolMinor: 0, payout, placesFilled: 3 })).toEqual([]);
+    expect(payoutBreakdown({ poolMinor: 100, payout, placesFilled: 0 })).toEqual([]);
+  });
+
+  it("pays nothing when the category has no prize structure", () => {
+    expect(
+      payoutBreakdown({ poolMinor: 100_000, payout: { model: "NONE", split: [] }, placesFilled: 4 }),
+    ).toEqual([]);
+  });
+});
+
+describe("poolFor", () => {
+  it("multiplies the fee by the entries", () => {
+    const item = { ...emptyCategory("a", "A"), entryFeeMinor: 25_000 };
+    expect(poolFor(item, 12)).toBe(300_000);
+  });
+
+  it("is nothing when the category is free", () => {
+    expect(poolFor(emptyCategory("a", "A"), 12)).toBe(0);
+  });
+});
+
+describe("parseFormat", () => {
+  it("round-trips a preset through JSON", () => {
+    const format = FORMAT_PRESETS[3].build();
+    expect(parseFormat(JSON.parse(JSON.stringify(format)))).toEqual(format);
+  });
+
+  it("refuses anything that is not a format rather than half-reading it", () => {
+    expect(parseFormat(null)).toBeNull();
+    expect(parseFormat({})).toBeNull();
+    expect(parseFormat({ categories: [] })).toBeNull();
+    expect(parseFormat({ categories: [{ name: "no id" }] })).toBeNull();
+  });
+
+  it("fills in the parts an older stored format did not have", () => {
+    const parsed = parseFormat({
+      categories: [{ id: "a", name: "Overall", family: "BIGGEST_FISH" }],
+    });
+    expect(parsed).toEqual({
+      currency: "USD",
+      categories: [
+        {
+          id: "a",
+          name: "Overall",
+          family: "BIGGEST_FISH",
+          species: [],
+          speciesPoints: {},
+          bestN: null,
+          payout: { model: "NONE", split: [] },
+          entryFeeMinor: null,
+        },
+      ],
+    });
+  });
+});
+
+describe("familyColumnFor", () => {
+  it("is the one family when every category agrees", () => {
+    expect(familyColumnFor(FORMAT_PRESETS[3].build())).toBe("BIGGEST_FISH");
+  });
+
+  it("is CUSTOM when they do not, rather than picking the first", () => {
+    const format: TournamentFormat = {
+      currency: "USD",
+      categories: [
+        emptyCategory("a", "A"),
+        { ...emptyCategory("b", "B"), family: "TOTAL_WEIGHT" },
+      ],
+    };
+    expect(familyColumnFor(format)).toBe("CUSTOM");
+  });
+});
+
+describe("describeCategory", () => {
+  it("says how it is won, what it costs, and what it pays", () => {
+    const line = describeCategory(
+      {
+        ...emptyCategory("marlin", "Biggest marlin"),
+        species: ["blue_marlin", "striped_marlin"],
+        entryFeeMinor: 50_000,
+        payout: { model: "PLACES", split: [60, 30, 10] },
+      },
+      "USD",
+    );
+    expect(line).toContain("heaviest single fish");
+    expect(line).toContain("2 species");
+    expect(line).toContain("$500.00");
+    expect(line).toContain("60/30/10");
+  });
+
+  it("says a free category is free rather than saying nothing", () => {
+    expect(describeCategory(emptyCategory("a", "Overall"), "USD")).toContain("no entry fee");
+  });
+});
+
+describe("formatMoney", () => {
+  it("reads minor units in the currency's own decimal places", () => {
+    expect(formatMoney(250_000, "USD")).toContain("2,500");
+  });
+});

--- a/src/core/tournaments/formats.ts
+++ b/src/core/tournaments/formats.ts
@@ -1,0 +1,584 @@
+import type { EligibleCatch, ScoreRule, ScoringFamily } from "./official-scoring";
+
+/**
+ * What a tournament is, expressed as data the host chooses rather than code somebody has
+ * to write.
+ *
+ * The demand this file answers: a Captain's-Cup points event, a winner-take-all biggest
+ * fish, a 1st/2nd/3rd payout, and a Bisbee's-style event where one boat enters several
+ * categories — biggest marlin, biggest tuna, biggest dorado — each with its own pot. Those
+ * look like four products. They are one shape:
+ *
+ *     a tournament is a list of CATEGORIES
+ *     a category has a SCORING RULE and a PAYOUT
+ *
+ * Biggest-fish-winner-takes-all is one category. Bisbee's is three. Captain's Cup is one
+ * category whose rule happens to be a species points table. Nothing else has to change,
+ * and a host who wants the simple thing never meets the complicated thing — which is the
+ * same bet Boat Games makes in `core/rules/games/modes.ts`, where three very different
+ * games are one engine and a handful of preset rules.
+ *
+ * The scoring itself is not reimplemented here. `official-scoring.ts` already folds
+ * catches into a score for nine families and is the server-authoritative one; a category
+ * maps onto its `ScoreRule` and that is what runs.
+ *
+ * Money: a category can carry an entry fee, and the payout math below is exact. Nothing in
+ * this file, or anywhere it is used, *collects* anything. A fee here is a fact about the
+ * event, the same way it is a fact on the printed flyer — it is what the host tells
+ * entrants it costs, and the payment domain is a separate, deliberate act.
+ */
+
+export type PayoutModel =
+  /** No prize structure. A friendly event, or one settled outside the app. */
+  | "NONE"
+  /** One winner takes the category's pot. */
+  | "WINNER_TAKE_ALL"
+  /** Split down the places by percentage — 60/30/10 and the like. */
+  | "PLACES";
+
+export interface CategoryPayout {
+  readonly model: PayoutModel;
+  /** Percentages, first place first. Ignored unless the model is PLACES. */
+  readonly split: readonly number[];
+}
+
+export interface FormatCategory {
+  /** Stable within a tournament. Used by standings rows and award records. */
+  readonly id: string;
+  /** What the host calls it: "Biggest Marlin", "Overall", "Junior angler". */
+  readonly name: string;
+  readonly family: ScoringFamily;
+  /** Species that score here. Empty means every species counts. */
+  readonly species: readonly string[];
+  /** Species id → points. Only meaningful for SPECIES_POINTS / SPECIES_MULTIPLIER. */
+  readonly speciesPoints: Readonly<Record<string, number>>;
+  /** How many fish count, for BEST_N_WEIGHT. */
+  readonly bestN: number | null;
+  readonly payout: CategoryPayout;
+  /**
+   * What it costs to enter this category, in minor units (cents). `null` means free, or
+   * not decided. Declared only — see the note at the top of this file.
+   */
+  readonly entryFeeMinor: number | null;
+}
+
+export interface TournamentFormat {
+  /** ISO 4217, uppercase. Applies to every fee and pot in the format. */
+  readonly currency: string;
+  readonly categories: readonly FormatCategory[];
+}
+
+/* -------------------------------------------------------------------------- */
+/* The families a host can actually choose                                     */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * `official-scoring.ts` supports nine families. Five are offered here, because the other
+ * four (SPECIES_MULTIPLIER, EVERY_FISH_COUNTS, POINTS, TOTAL_LENGTH) are either the same
+ * idea in different clothes or need a rule text nobody has written yet. A family that
+ * cannot be explained in one line on a phone does not belong in a picker.
+ */
+export const OFFERED_FAMILIES = [
+  "BIGGEST_FISH",
+  "TOTAL_WEIGHT",
+  "BEST_N_WEIGHT",
+  "SPECIES_POINTS",
+  "BIGGEST_LENGTH",
+] as const satisfies readonly ScoringFamily[];
+
+export type OfferedFamily = (typeof OFFERED_FAMILIES)[number];
+
+export const FAMILY_COPY: Readonly<Record<OfferedFamily, { readonly name: string; readonly blurb: string }>> = {
+  BIGGEST_FISH: {
+    name: "Heaviest single fish",
+    blurb: "One fish decides it. Your best weight is your score.",
+  },
+  TOTAL_WEIGHT: {
+    name: "Total weight",
+    blurb: "Every eligible fish adds up.",
+  },
+  BEST_N_WEIGHT: {
+    name: "Best few, added up",
+    blurb: "Your heaviest handful counts, and nothing beyond it.",
+  },
+  SPECIES_POINTS: {
+    name: "Points per species",
+    blurb: "You set what each fish is worth. Most points wins.",
+  },
+  BIGGEST_LENGTH: {
+    name: "Longest fish",
+    blurb: "Measured, not weighed — for catch-and-release events.",
+  },
+};
+
+export function isOfferedFamily(value: string): value is OfferedFamily {
+  return (OFFERED_FAMILIES as readonly string[]).includes(value);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Presets                                                                     */
+/* -------------------------------------------------------------------------- */
+
+export interface FormatPreset {
+  readonly id: string;
+  readonly name: string;
+  /** One line, the way a host would describe the event to somebody at the dock. */
+  readonly tagline: string;
+  /** Three or four lines of "how it works", as on the Boat Games mode cards. */
+  readonly how: readonly string[];
+  readonly build: () => TournamentFormat;
+}
+
+const DEFAULT_CURRENCY = "USD";
+
+function category(input: Partial<FormatCategory> & Pick<FormatCategory, "id" | "name">): FormatCategory {
+  return {
+    family: "BIGGEST_FISH",
+    species: [],
+    speciesPoints: {},
+    bestN: null,
+    payout: { model: "NONE", split: [] },
+    entryFeeMinor: null,
+    ...input,
+  };
+}
+
+/**
+ * A starting points table, not a truth about fish.
+ *
+ * Same reasoning as Boat Games' SoCal template: a calico bass is an ordinary afternoon in
+ * Newport and a notable day off Seattle. The host edits this, and the tournament stores
+ * the edited copy — so a table that came out wrong for their water costs them thirty
+ * seconds rather than being an argument with the app.
+ */
+export const STARTING_SPECIES_POINTS: Readonly<Record<string, number>> = {
+  yellowtail: 8,
+  bluefin_tuna: 10,
+  yellowfin_tuna: 8,
+  dorado: 6,
+  white_seabass: 8,
+  kelp_bass: 2,
+  barred_sand_bass: 2,
+  pacific_bonito: 1,
+  pacific_barracuda: 1,
+};
+
+export const FORMAT_PRESETS: readonly FormatPreset[] = [
+  {
+    id: "biggest_fish",
+    name: "Heaviest fish wins",
+    tagline: "One category, one winner, simplest thing that works.",
+    how: [
+      "Everybody fishes for the same thing.",
+      "Your heaviest fish of the day is your score.",
+      "Winner takes the pot, if there is one.",
+    ],
+    build: () => ({
+      currency: DEFAULT_CURRENCY,
+      categories: [
+        category({
+          id: "overall",
+          name: "Heaviest fish",
+          family: "BIGGEST_FISH",
+          payout: { model: "WINNER_TAKE_ALL", split: [] },
+        }),
+      ],
+    }),
+  },
+  {
+    id: "places",
+    name: "First, second, third",
+    tagline: "Heaviest fish, and the pot splits down the places.",
+    how: [
+      "Scored the same as heaviest fish.",
+      "The pot is split by percentage — 50/30/20 to start, and you can change it.",
+      "If a place goes unfilled, its share is shared out among the places that were.",
+    ],
+    build: () => ({
+      currency: DEFAULT_CURRENCY,
+      categories: [
+        category({
+          id: "overall",
+          name: "Heaviest fish",
+          family: "BIGGEST_FISH",
+          payout: { model: "PLACES", split: [50, 30, 20] },
+        }),
+      ],
+    }),
+  },
+  {
+    id: "species_points",
+    name: "Points per species",
+    tagline: "You decide what each fish is worth. Most points wins.",
+    how: [
+      "You set a points value per species, and edit the starting table to suit your water.",
+      "Every eligible fish adds its points to the boat's total.",
+      "A species with no value set scores nothing, so the table is the rules.",
+    ],
+    build: () => ({
+      currency: DEFAULT_CURRENCY,
+      categories: [
+        category({
+          id: "overall",
+          name: "Points",
+          family: "SPECIES_POINTS",
+          speciesPoints: { ...STARTING_SPECIES_POINTS },
+          payout: { model: "WINNER_TAKE_ALL", split: [] },
+        }),
+      ],
+    }),
+  },
+  {
+    id: "categories",
+    name: "Several categories",
+    tagline: "One entry, several fish, a pot for each — the Bisbee's shape.",
+    how: [
+      "Each category is its own competition with its own winner and its own pot.",
+      "A boat can be in one category or all of them.",
+      "Each carries its own entry fee, so the pots are separate money.",
+    ],
+    build: () => ({
+      currency: DEFAULT_CURRENCY,
+      categories: [
+        category({
+          id: "marlin",
+          name: "Biggest marlin",
+          family: "BIGGEST_FISH",
+          species: ["blue_marlin", "black_marlin", "striped_marlin", "white_marlin"],
+          payout: { model: "WINNER_TAKE_ALL", split: [] },
+        }),
+        category({
+          id: "tuna",
+          name: "Biggest tuna",
+          family: "BIGGEST_FISH",
+          species: ["bluefin_tuna", "yellowfin_tuna", "bigeye_tuna"],
+          payout: { model: "WINNER_TAKE_ALL", split: [] },
+        }),
+        category({
+          id: "dorado",
+          name: "Biggest dorado",
+          family: "BIGGEST_FISH",
+          species: ["dorado"],
+          payout: { model: "WINNER_TAKE_ALL", split: [] },
+        }),
+      ],
+    }),
+  },
+];
+
+/** The format a tournament has before its host has chosen anything. */
+export function defaultFormat(): TournamentFormat {
+  return FORMAT_PRESETS[0].build();
+}
+
+export function emptyCategory(id: string, name: string): FormatCategory {
+  return category({ id, name });
+}
+
+/* -------------------------------------------------------------------------- */
+/* Reading one back out of the database                                        */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A format arrives from `tournament_scoring_version.configuration`, which is `jsonb` and
+ * therefore anything at all. This is the only door: it returns a format or `null`, never a
+ * half-parsed one, so no screen downstream has to defend itself against a missing field.
+ */
+export function parseFormat(value: unknown): TournamentFormat | null {
+  if (typeof value !== "object" || value === null) return null;
+  const raw = value as Record<string, unknown>;
+  if (!Array.isArray(raw.categories)) return null;
+
+  const categories: FormatCategory[] = [];
+  for (const item of raw.categories) {
+    if (typeof item !== "object" || item === null) return null;
+    const entry = item as Record<string, unknown>;
+    if (typeof entry.id !== "string" || typeof entry.name !== "string") return null;
+    if (typeof entry.family !== "string") return null;
+
+    categories.push({
+      id: entry.id,
+      name: entry.name,
+      family: entry.family as ScoringFamily,
+      species: Array.isArray(entry.species) ? entry.species.filter((s): s is string => typeof s === "string") : [],
+      speciesPoints: numberRecord(entry.speciesPoints),
+      bestN: typeof entry.bestN === "number" ? entry.bestN : null,
+      payout: parsePayout(entry.payout),
+      entryFeeMinor: typeof entry.entryFeeMinor === "number" ? entry.entryFeeMinor : null,
+    });
+  }
+
+  if (categories.length === 0) return null;
+  return {
+    currency: typeof raw.currency === "string" ? raw.currency : DEFAULT_CURRENCY,
+    categories,
+  };
+}
+
+function numberRecord(value: unknown): Record<string, number> {
+  if (typeof value !== "object" || value === null) return {};
+  const out: Record<string, number> = {};
+  for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof item === "number" && Number.isFinite(item)) out[key] = item;
+  }
+  return out;
+}
+
+function parsePayout(value: unknown): CategoryPayout {
+  if (typeof value !== "object" || value === null) return { model: "NONE", split: [] };
+  const raw = value as Record<string, unknown>;
+  const model: PayoutModel =
+    raw.model === "WINNER_TAKE_ALL" || raw.model === "PLACES" ? raw.model : "NONE";
+  const split = Array.isArray(raw.split)
+    ? raw.split.filter((n): n is number => typeof n === "number" && Number.isFinite(n))
+    : [];
+  return { model, split };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Validation                                                                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Everything a host could set that would produce a tournament nobody can score, in the
+ * words they would need to fix it. Empty means the format is sound.
+ *
+ * These run before the format is saved, because the alternative is finding out on the
+ * water — and a scoring version, once locked, is deliberately immutable.
+ */
+export function validateFormat(format: TournamentFormat): readonly string[] {
+  const problems: string[] = [];
+
+  if (format.categories.length === 0) {
+    problems.push("A tournament needs at least one category to score.");
+  }
+
+  const seenIds = new Set<string>();
+  const seenNames = new Set<string>();
+
+  for (const item of format.categories) {
+    const name = item.name.trim();
+    if (name.length === 0) {
+      problems.push("Every category needs a name.");
+    } else if (seenNames.has(name.toLowerCase())) {
+      problems.push(`Two categories are both called “${name}”. Give them different names.`);
+    } else {
+      seenNames.add(name.toLowerCase());
+    }
+
+    if (seenIds.has(item.id)) problems.push(`Two categories share the id “${item.id}”.`);
+    seenIds.add(item.id);
+
+    if (item.family === "SPECIES_POINTS") {
+      const values = Object.values(item.speciesPoints);
+      if (values.length === 0) {
+        problems.push(`“${name || item.id}” scores on points, so at least one species needs a value.`);
+      }
+      if (values.some((points) => points < 0)) {
+        problems.push(`“${name || item.id}” has a species worth less than nothing.`);
+      }
+    }
+
+    if (item.family === "BEST_N_WEIGHT" && (item.bestN === null || item.bestN < 1)) {
+      problems.push(`“${name || item.id}” counts your best few fish, so it needs to say how many.`);
+    }
+
+    if (item.payout.model === "PLACES") {
+      if (item.payout.split.length === 0) {
+        problems.push(`“${name || item.id}” pays down the places, so it needs a split.`);
+      } else {
+        if (item.payout.split.some((share) => share <= 0)) {
+          problems.push(`“${name || item.id}” has a place worth nothing. Remove it instead.`);
+        }
+        const total = item.payout.split.reduce((sum, share) => sum + share, 0);
+        // Rounded, because a host typing 33.3/33.3/33.4 means 100 and should not be
+        // argued with over a floating-point tenth.
+        if (Math.round(total * 10) / 10 !== 100) {
+          problems.push(`The split for “${name || item.id}” adds up to ${trim(total)}%, not 100%.`);
+        }
+      }
+    }
+
+    if (item.entryFeeMinor !== null && item.entryFeeMinor < 0) {
+      problems.push(`“${name || item.id}” has a negative entry fee.`);
+    }
+  }
+
+  if (!/^[A-Z]{3}$/.test(format.currency)) {
+    problems.push("The currency needs to be a three-letter code, like USD.");
+  }
+
+  return problems;
+}
+
+function trim(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Scoring                                                                     */
+/* -------------------------------------------------------------------------- */
+
+/** The rule `official-scoring.ts` runs for this category. */
+export function scoreRuleFor(item: FormatCategory): ScoreRule {
+  return {
+    family: item.family,
+    bestN: item.bestN ?? undefined,
+    speciesPoints: item.family === "SPECIES_POINTS" ? item.speciesPoints : undefined,
+    speciesMultiplier: item.family === "SPECIES_MULTIPLIER" ? item.speciesPoints : undefined,
+  };
+}
+
+/** Does this fish count in this category at all? */
+export function countsIn(item: FormatCategory, speciesId: string | null): boolean {
+  if (item.species.length === 0) return true;
+  if (speciesId === null) return false;
+  return item.species.includes(speciesId);
+}
+
+/**
+ * The catches that score in a category, out of everything an entry landed.
+ *
+ * A boat in a Bisbee's-style event lands a marlin and two tuna; the marlin category sees
+ * one fish and the tuna category sees two. Filtering here rather than inside the scorer
+ * keeps `official-scoring.ts` as the one place a score is computed.
+ */
+export function catchesIn(
+  item: FormatCategory,
+  catches: readonly EligibleCatch[],
+): readonly EligibleCatch[] {
+  return catches.filter((entry) => countsIn(item, entry.speciesId));
+}
+
+/* -------------------------------------------------------------------------- */
+/* Money                                                                       */
+/* -------------------------------------------------------------------------- */
+
+export interface PayoutSlice {
+  readonly rank: number;
+  readonly amountMinor: number;
+}
+
+/**
+ * How a category's pot is divided, in whole minor units, given how many places actually
+ * got filled.
+ *
+ * Three rules, each of which exists because the naive version is wrong somewhere real:
+ *
+ * 1. **Unfilled places do not vanish.** A 50/30/20 category fished by two boats pays those
+ *    two boats the whole pot in the ratio 50:30, not 80% of it with the rest unaccounted
+ *    for. Money that arrives has to leave.
+ * 2. **Whole units only.** Everything is integer minor units, so no rounding invents or
+ *    loses a cent.
+ * 3. **The remainder goes to first place.** Splitting 100.00 three ways leaves a cent;
+ *    somebody has to have it, and the convention every tournament uses is the winner.
+ */
+export function payoutBreakdown(input: {
+  readonly poolMinor: number;
+  readonly payout: CategoryPayout;
+  /** How many places were actually filled — usually the number of scored entries. */
+  readonly placesFilled: number;
+}): readonly PayoutSlice[] {
+  const pool = Math.max(0, Math.floor(input.poolMinor));
+  if (pool === 0 || input.placesFilled <= 0 || input.payout.model === "NONE") return [];
+
+  if (input.payout.model === "WINNER_TAKE_ALL") {
+    return [{ rank: 1, amountMinor: pool }];
+  }
+
+  const shares = input.payout.split.slice(0, input.placesFilled);
+  const total = shares.reduce((sum, share) => sum + share, 0);
+  if (shares.length === 0 || total <= 0) return [];
+
+  const slices = shares.map((share, index) => ({
+    rank: index + 1,
+    amountMinor: Math.floor((pool * share) / total),
+  }));
+
+  const distributed = slices.reduce((sum, slice) => sum + slice.amountMinor, 0);
+  const remainder = pool - distributed;
+  if (remainder > 0) {
+    slices[0] = { rank: 1, amountMinor: slices[0].amountMinor + remainder };
+  }
+
+  return slices;
+}
+
+/** The pot a category holds if every paid entry pays its fee. */
+export function poolFor(item: FormatCategory, entries: number): number {
+  if (item.entryFeeMinor === null || entries <= 0) return 0;
+  return item.entryFeeMinor * entries;
+}
+
+/**
+ * Minor units to something a person reads. `Intl` handles the currency's own decimal
+ * places, so this is correct for JPY (none) as well as USD (two).
+ */
+export function formatMoney(amountMinor: number, currency: string): string {
+  const fractionDigits = currencyDigits(currency);
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency,
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  }).format(amountMinor / 10 ** fractionDigits);
+}
+
+function currencyDigits(currency: string): number {
+  try {
+    const parts = new Intl.NumberFormat(undefined, { style: "currency", currency }).resolvedOptions();
+    return parts.maximumFractionDigits ?? 2;
+  } catch {
+    return 2;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Saying it in English                                                        */
+/* -------------------------------------------------------------------------- */
+
+/** One line describing how a category is won. */
+export function describeCategory(item: FormatCategory, currency: string): string {
+  const scoring = isOfferedFamily(item.family)
+    ? FAMILY_COPY[item.family].name.toLowerCase()
+    : item.family.toLowerCase().replaceAll("_", " ");
+
+  const scope =
+    item.species.length === 0
+      ? "any fish"
+      : item.species.length === 1
+        ? "one species"
+        : `${item.species.length} species`;
+
+  const money =
+    item.entryFeeMinor === null || item.entryFeeMinor === 0
+      ? "no entry fee"
+      : `${formatMoney(item.entryFeeMinor, currency)} to enter`;
+
+  const prize =
+    item.payout.model === "WINNER_TAKE_ALL"
+      ? "winner takes the pot"
+      : item.payout.model === "PLACES"
+        ? `pot splits ${item.payout.split.join("/")}`
+        : "no pot";
+
+  return `${scoring}, ${scope} · ${money} · ${prize}`;
+}
+
+/** The whole format, as the lines a rules page prints. */
+export function describeFormat(format: TournamentFormat): readonly string[] {
+  return format.categories.map((item) => `${item.name}: ${describeCategory(item, format.currency)}`);
+}
+
+/**
+ * The single family that goes in `tournament_scoring_version.scoring_family`.
+ *
+ * That column predates categories and holds one value. When every category scores the same
+ * way it is that family; when they differ it is CUSTOM, and the `configuration` document
+ * is the truth. Writing the first category's family into a column that claims to describe
+ * the tournament would be a lie a future query would believe.
+ */
+export function familyColumnFor(format: TournamentFormat): ScoringFamily | "CUSTOM" {
+  const families = new Set(format.categories.map((item) => item.family));
+  return families.size === 1 ? [...families][0] : "CUSTOM";
+}

--- a/src/features/tournaments/components/create-tournament-form.tsx
+++ b/src/features/tournaments/components/create-tournament-form.tsx
@@ -3,9 +3,16 @@
 import { useRouter } from "next/navigation";
 import { useId, useState } from "react";
 
+import {
+  defaultFormat,
+  FORMAT_PRESETS,
+  validateFormat,
+  type TournamentFormat,
+} from "@/core/tournaments/formats";
 import { createClient } from "@/lib/supabase/client";
 import { createDemoTournament, hasSupabaseBrowserConfig } from "../demo-store";
 import { formatSchedule, visibilityPresentation } from "../format";
+import { saveFormat } from "../use-format";
 import {
   BIG_ACTION,
   CARD_PADDED,
@@ -14,6 +21,7 @@ import {
   SECONDARY_BUTTON,
   TERTIARY_BUTTON,
 } from "../ui-classes";
+import { FormatEditor, FormatSummary } from "./format-editor";
 import { CheckRow, DemoNote } from "./tournament-chrome";
 
 /**
@@ -38,7 +46,7 @@ const VISIBILITIES = ["PRIVATE", "INVITE_ONLY", "UNLISTED", "PUBLIC"] as const;
 
 type Visibility = (typeof VISIBILITIES)[number];
 
-const STEPS = ["The basics", "Who can see it", "Check it over"] as const;
+const STEPS = ["The basics", "Who can see it", "How it is won", "Check it over"] as const;
 
 function toIsoOrNull(value: string) {
   return value ? new Date(value).toISOString() : null;
@@ -53,6 +61,8 @@ export function CreateTournamentForm() {
   const [visibility, setVisibility] = useState<Visibility>("PRIVATE");
   const [startsAt, setStartsAt] = useState("");
   const [endsAt, setEndsAt] = useState("");
+  const [presetId, setPresetId] = useState<string | null>(null);
+  const [format, setFormat] = useState<TournamentFormat>(defaultFormat);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -68,7 +78,14 @@ export function CreateTournamentForm() {
       ? "The finish has to be after the start."
       : null;
 
-  const stepReady = step === 0 ? name.trim().length > 0 && !scheduleProblem : true;
+  const formatProblems = validateFormat(format);
+
+  const stepReady =
+    step === 0
+      ? name.trim().length > 0 && !scheduleProblem
+      : step === 2
+        ? presetId !== null && formatProblems.length === 0
+        : true;
 
   async function create() {
     setSubmitting(true);
@@ -81,6 +98,7 @@ export function CreateTournamentForm() {
         starts_at: toIsoOrNull(startsAt),
         ends_at: toIsoOrNull(endsAt),
       });
+      await saveFormat(tournament.id, format);
       router.push(`/tournaments/${tournament.id}/overview`);
       router.refresh();
       return;
@@ -118,6 +136,20 @@ export function CreateTournamentForm() {
 
       if (insertError) {
         setError(insertError.message);
+        return;
+      }
+
+      /*
+        The tournament and its format are two writes, not one. If the second fails the
+        first still stands — a draft with no format is a real, recoverable state that the
+        overview's readiness checklist already knows how to show — so the failure is
+        reported against the tournament that exists rather than rolled back into nothing.
+      */
+      const saved = await saveFormat(data.id, format);
+      if (!saved.ok) {
+        setError(
+          `The tournament was created, but its scoring could not be saved: ${saved.message} You can set it from the tournament's own screen.`,
+        );
         return;
       }
 
@@ -242,7 +274,57 @@ export function CreateTournamentForm() {
         </fieldset>
       ) : null}
 
+      {/*
+        The format step, shaped like the Boat Games mode picker: four cards that each build
+        a complete, valid tournament, and only then the parts worth changing. A host who
+        taps "Heaviest fish wins" and then Next has made every decision the scorer needs.
+      */}
       {step === 2 ? (
+        <div className="flex flex-col gap-space-4">
+          {presetId === null ? (
+            <ul className="flex flex-col gap-space-3">
+              {FORMAT_PRESETS.map((preset) => (
+                <li key={preset.id}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setPresetId(preset.id);
+                      setFormat(preset.build());
+                    }}
+                    className={`${CARD_PADDED} ${FOCUS_RING} flex w-full flex-col gap-space-2 text-left transition-colors hover:border-border-interactive active:scale-[0.995] motion-reduce:transition-none`}
+                  >
+                    <span className="text-h3 text-text-primary">{preset.name}</span>
+                    <span className="text-body text-text-muted">{preset.tagline}</span>
+                    <ul className="flex list-disc flex-col gap-space-1 pl-space-4 text-caption text-text-muted">
+                      {preset.how.map((line) => (
+                        <li key={line}>{line}</li>
+                      ))}
+                    </ul>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <>
+              <div className="flex flex-wrap items-baseline justify-between gap-space-2">
+                <h2 className="text-h3 text-text-primary">
+                  {FORMAT_PRESETS.find((preset) => preset.id === presetId)?.name}
+                </h2>
+                <button
+                  type="button"
+                  onClick={() => setPresetId(null)}
+                  className={`${FOCUS_RING} min-h-touch-floor text-caption text-text-link`}
+                >
+                  Pick a different one
+                </button>
+              </div>
+              <FormatEditor format={format} onChange={setFormat} />
+            </>
+          )}
+        </div>
+      ) : null}
+
+      {step === 3 ? (
         <section className={`${CARD_PADDED} flex flex-col gap-space-4`}>
           <div className="flex flex-col gap-space-2">
             <h2 className="text-h3 text-text-primary">{name.trim() || "Untitled tournament"}</h2>
@@ -250,6 +332,11 @@ export function CreateTournamentForm() {
             <p className="text-caption text-text-muted">
               {visibilityPresentation(visibility).label} · {visibilityPresentation(visibility).blurb}
             </p>
+          </div>
+
+          <div className="flex flex-col gap-space-3 border-t border-hairline pt-space-4">
+            <p className="text-label text-text-primary">How it is won</p>
+            <FormatSummary format={format} />
           </div>
 
           <div className="flex flex-col gap-space-3 border-t border-hairline pt-space-4">
@@ -261,9 +348,14 @@ export function CreateTournamentForm() {
                 detail="Nobody can enter until you open registration, so nothing is public by accident."
               />
               <CheckRow
+                state="done"
+                label="Scoring is set"
+                detail="You can change it while the tournament is still a draft. Once it starts, it is fixed — that is what makes the result defensible."
+              />
+              <CheckRow
                 state="pending"
-                label="Four things get locked before it can go live"
-                detail="Rules, how it is scored, what counts as proof of a catch, and where you can fish. The overview walks you through them."
+                label="Three things still get locked before it can go live"
+                detail="The rules, what counts as proof of a catch, and where you can fish. The overview walks you through them."
               />
               <CheckRow
                 state="pending"
@@ -300,9 +392,15 @@ export function CreateTournamentForm() {
           </button>
         )}
 
-        {step === 0 && !stepReady ? (
+        {!stepReady ? (
           <p id={`${fieldId}-next-hint`} className="text-caption text-text-muted">
-            {scheduleProblem ? "Fix the times to carry on." : "Give it a name to carry on."}
+            {step === 2
+              ? presetId === null
+                ? "Pick how it is won to carry on."
+                : "Fix the notes above to carry on."
+              : scheduleProblem
+                ? "Fix the times to carry on."
+                : "Give it a name to carry on."}
           </p>
         ) : null}
 

--- a/src/features/tournaments/components/format-editor.tsx
+++ b/src/features/tournaments/components/format-editor.tsx
@@ -1,0 +1,615 @@
+"use client";
+
+import { useId, useMemo, useState } from "react";
+
+import { searchSpecies, speciesById, SPECIES } from "@/core/ontology/species";
+import {
+  describeCategory,
+  emptyCategory,
+  FAMILY_COPY,
+  formatMoney,
+  OFFERED_FAMILIES,
+  validateFormat,
+  type FormatCategory,
+  type TournamentFormat,
+} from "@/core/tournaments/formats";
+import {
+  CARD,
+  CARD_PADDED,
+  CHIP,
+  CHIP_OFF,
+  CHIP_ON,
+  FOCUS_RING,
+  INPUT,
+  INSET,
+  SECONDARY_BUTTON,
+  TABULAR,
+  TERTIARY_BUTTON,
+} from "../ui-classes";
+import { AlertIcon, PlusIcon } from "./icons";
+
+/**
+ * The screen where a host says what their tournament actually is.
+ *
+ * Every control here edits one `TournamentFormat` and hands it back. It holds no state of
+ * its own beyond which category is open, so the wizard, and later an edit screen on a draft
+ * tournament, are the same component with a different Save button.
+ *
+ * The shape of the editing follows Boat Games: the preset already chose sensible answers,
+ * so what is on screen is a small number of things worth changing, not a form. A host who
+ * picks "Heaviest fish wins" and taps straight through gets a complete, valid tournament.
+ */
+
+export function FormatEditor({
+  format,
+  onChange,
+}: {
+  format: TournamentFormat;
+  onChange: (next: TournamentFormat) => void;
+}) {
+  const problems = validateFormat(format);
+  const multi = format.categories.length > 1;
+
+  function updateCategory(index: number, next: FormatCategory) {
+    onChange({
+      ...format,
+      categories: format.categories.map((item, position) => (position === index ? next : item)),
+    });
+  }
+
+  function addCategory() {
+    const index = format.categories.length + 1;
+    onChange({
+      ...format,
+      categories: [...format.categories, emptyCategory(`category-${index}`, `Category ${index}`)],
+    });
+  }
+
+  function removeCategory(index: number) {
+    onChange({
+      ...format,
+      categories: format.categories.filter((_, position) => position !== index),
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-space-4">
+      {format.categories.map((item, index) => (
+        <CategoryEditor
+          key={item.id}
+          category={item}
+          currency={format.currency}
+          index={index}
+          removable={multi}
+          onChange={(next) => updateCategory(index, next)}
+          onRemove={() => removeCategory(index)}
+        />
+      ))}
+
+      <button type="button" className={SECONDARY_BUTTON} onClick={addCategory}>
+        <PlusIcon />
+        Add another category
+      </button>
+
+      <p className="text-caption text-text-muted">
+        A category is one thing people are competing for. Most events have one. A Bisbee&apos;s-style
+        event has several, each with its own winner and its own pot.
+      </p>
+
+      {problems.length > 0 ? (
+        <div className={`${INSET} flex flex-col gap-space-2`} role="alert">
+          <p className="inline-flex items-center gap-space-2 text-body-strong text-amber-flag">
+            <AlertIcon />
+            Not quite ready
+          </p>
+          <ul className="flex list-disc flex-col gap-space-1 pl-space-4 text-caption text-text-muted">
+            {problems.map((problem) => (
+              <li key={problem}>{problem}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function CategoryEditor({
+  category,
+  currency,
+  index,
+  removable,
+  onChange,
+  onRemove,
+}: {
+  category: FormatCategory;
+  currency: string;
+  index: number;
+  removable: boolean;
+  onChange: (next: FormatCategory) => void;
+  onRemove: () => void;
+}) {
+  const fieldId = useId();
+  const [open, setOpen] = useState(index === 0);
+
+  return (
+    <section className={`${CARD} flex flex-col gap-space-3 p-space-4`}>
+      <div className="flex flex-col gap-space-2">
+        <label htmlFor={`${fieldId}-name`} className="text-label text-text-primary">
+          What is this category called?
+        </label>
+        <input
+          id={`${fieldId}-name`}
+          value={category.name}
+          maxLength={60}
+          onChange={(event) => onChange({ ...category, name: event.target.value })}
+          className={INPUT}
+          placeholder="Biggest marlin"
+        />
+        <p className="text-caption text-text-muted">{describeCategory(category, currency)}</p>
+      </div>
+
+      {/*
+        Everything past the name is folded away by default. A host who wants the preset's
+        answers should not have to scroll past six controls to reach the next step, and a
+        host who wants to change them is looking for exactly this button.
+      */}
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        className={TERTIARY_BUTTON}
+      >
+        {open ? "Hide the details" : "Change how it is scored and paid"}
+      </button>
+
+      {open ? (
+        <div className="flex flex-col gap-space-5 border-t border-hairline pt-space-4">
+          <FamilyPicker category={category} onChange={onChange} />
+          {category.family === "SPECIES_POINTS" ? (
+            <SpeciesPointsEditor category={category} onChange={onChange} />
+          ) : (
+            <SpeciesPicker category={category} onChange={onChange} />
+          )}
+          {category.family === "BEST_N_WEIGHT" ? (
+            <BestNEditor category={category} onChange={onChange} />
+          ) : null}
+          <PayoutEditor category={category} currency={currency} onChange={onChange} />
+
+          {removable ? (
+            <button
+              type="button"
+              onClick={onRemove}
+              className={`${TERTIARY_BUTTON} text-error-red hover:text-error-red`}
+            >
+              Remove this category
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function FamilyPicker({
+  category,
+  onChange,
+}: {
+  category: FormatCategory;
+  onChange: (next: FormatCategory) => void;
+}) {
+  return (
+    <fieldset className="flex flex-col gap-space-2">
+      <legend className="text-label text-text-primary">How is it won?</legend>
+      <div className="flex flex-col gap-space-2">
+        {OFFERED_FAMILIES.map((family) => {
+          const selected = category.family === family;
+          return (
+            <button
+              key={family}
+              type="button"
+              aria-pressed={selected}
+              onClick={() => onChange({ ...category, family })}
+              className={`${FOCUS_RING} flex min-h-touch-floor flex-col items-start gap-space-1 rounded-md border p-space-3 text-left transition-colors ${
+                selected
+                  ? "border-signal-orange bg-signal-orange/10"
+                  : "border-border-interactive bg-surface hover:border-text-link"
+              }`}
+            >
+              <span className={`text-label ${selected ? "text-signal-orange" : "text-text-primary"}`}>
+                {FAMILY_COPY[family].name}
+              </span>
+              <span className="text-caption text-text-muted">{FAMILY_COPY[family].blurb}</span>
+            </button>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}
+
+/**
+ * Which fish count. Empty means all of them, which is the right default for a simple event
+ * and the wrong one for "Biggest marlin", so the empty state says so out loud.
+ */
+function SpeciesPicker({
+  category,
+  onChange,
+}: {
+  category: FormatCategory;
+  onChange: (next: FormatCategory) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const fieldId = useId();
+  const results = useMemo(
+    () => (query.trim().length > 0 ? searchSpecies(query).slice(0, 8) : []),
+    [query],
+  );
+
+  function toggle(speciesId: string) {
+    const next = category.species.includes(speciesId)
+      ? category.species.filter((id) => id !== speciesId)
+      : [...category.species, speciesId];
+    onChange({ ...category, species: next });
+    setQuery("");
+  }
+
+  return (
+    <div className="flex flex-col gap-space-2">
+      <label htmlFor={`${fieldId}-species`} className="text-label text-text-primary">
+        Which fish count?
+      </label>
+
+      {category.species.length === 0 ? (
+        <p className="text-caption text-text-muted">Every species counts. Add one to narrow it down.</p>
+      ) : (
+        <ul className="flex flex-wrap gap-space-2">
+          {category.species.map((speciesId) => (
+            <li key={speciesId}>
+              <button type="button" onClick={() => toggle(speciesId)} className={`${CHIP} ${CHIP_ON}`}>
+                {speciesById(speciesId)?.commonName ?? speciesId} ✕
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <input
+        id={`${fieldId}-species`}
+        type="search"
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        className={INPUT}
+        placeholder="Search a species to add"
+        autoComplete="off"
+      />
+
+      {results.length > 0 ? (
+        <ul className="flex flex-wrap gap-space-2">
+          {results.map((species) => (
+            <li key={species.id}>
+              <button type="button" onClick={() => toggle(species.id)} className={`${CHIP} ${CHIP_OFF}`}>
+                {species.commonName}
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The Captain's Cup table: a species and what it is worth.
+ *
+ * Points are typed, not stepped, because a host filling in fifteen species with a stepper
+ * would rightly give up. The starting table comes from the preset and is entirely theirs to
+ * edit — the app has no opinion about what a calico bass is worth in their water.
+ */
+function SpeciesPointsEditor({
+  category,
+  onChange,
+}: {
+  category: FormatCategory;
+  onChange: (next: FormatCategory) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const fieldId = useId();
+  const rows = Object.entries(category.speciesPoints);
+  const results = useMemo(
+    () =>
+      query.trim().length > 0
+        ? searchSpecies(query)
+            .filter((species) => !(species.id in category.speciesPoints))
+            .slice(0, 8)
+        : [],
+    [category.speciesPoints, query],
+  );
+
+  function setPoints(speciesId: string, points: number) {
+    onChange({ ...category, speciesPoints: { ...category.speciesPoints, [speciesId]: points } });
+  }
+
+  function remove(speciesId: string) {
+    const next = { ...category.speciesPoints };
+    delete next[speciesId];
+    onChange({ ...category, speciesPoints: next });
+  }
+
+  return (
+    <div className="flex flex-col gap-space-3">
+      <div className="flex flex-col gap-space-1">
+        <span className="text-label text-text-primary">What is each fish worth?</span>
+        <span className="text-caption text-text-muted">
+          A species that is not on this list scores nothing, so the list is the rules.
+        </span>
+      </div>
+
+      <ul className="flex flex-col gap-space-2">
+        {rows.map(([speciesId, points]) => (
+          <li key={speciesId} className={`${INSET} flex items-center gap-space-3`}>
+            <span className="flex-1 text-body text-text-primary">
+              {speciesById(speciesId)?.commonName ?? speciesId}
+            </span>
+            <label className="flex items-center gap-space-2">
+              <span className="sr-only">
+                Points for {speciesById(speciesId)?.commonName ?? speciesId}
+              </span>
+              <input
+                type="number"
+                inputMode="numeric"
+                min="0"
+                max="999"
+                value={points}
+                onChange={(event) => setPoints(speciesId, Number(event.target.value) || 0)}
+                className={`${INPUT} ${TABULAR} w-space-16 px-space-2 text-center`}
+              />
+            </label>
+            <button
+              type="button"
+              onClick={() => remove(speciesId)}
+              aria-label={`Remove ${speciesById(speciesId)?.commonName ?? speciesId}`}
+              className={`${FOCUS_RING} min-h-touch-floor rounded-md px-space-2 text-caption text-text-link`}
+            >
+              Remove
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      <input
+        id={`${fieldId}-add-species`}
+        type="search"
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        className={INPUT}
+        placeholder="Add a species"
+        autoComplete="off"
+      />
+
+      {results.length > 0 ? (
+        <ul className="flex flex-wrap gap-space-2">
+          {results.map((species) => (
+            <li key={species.id}>
+              <button
+                type="button"
+                onClick={() => {
+                  setPoints(species.id, 1);
+                  setQuery("");
+                }}
+                className={`${CHIP} ${CHIP_OFF}`}
+              >
+                {species.commonName}
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      <p className="text-caption text-text-muted">
+        {rows.length} of {SPECIES.length} species are worth something.
+      </p>
+    </div>
+  );
+}
+
+function BestNEditor({
+  category,
+  onChange,
+}: {
+  category: FormatCategory;
+  onChange: (next: FormatCategory) => void;
+}) {
+  const fieldId = useId();
+  return (
+    <label className="flex flex-col gap-space-2">
+      <span className="text-label text-text-primary">How many fish count?</span>
+      <input
+        id={`${fieldId}-bestn`}
+        type="number"
+        inputMode="numeric"
+        min="1"
+        max="20"
+        value={category.bestN ?? 3}
+        onChange={(event) => onChange({ ...category, bestN: Math.max(1, Number(event.target.value) || 1) })}
+        className={`${INPUT} ${TABULAR}`}
+      />
+      <span className="text-caption text-text-muted">Your heaviest few add up. Anything beyond does not.</span>
+    </label>
+  );
+}
+
+const PAYOUT_CHOICES = [
+  { model: "NONE", label: "No pot", blurb: "Bragging rights, or money settled off the app." },
+  { model: "WINNER_TAKE_ALL", label: "Winner takes it", blurb: "One winner, the whole pot." },
+  { model: "PLACES", label: "Down the places", blurb: "Split by percentage — 50/30/20 and the like." },
+] as const;
+
+function PayoutEditor({
+  category,
+  currency,
+  onChange,
+}: {
+  category: FormatCategory;
+  currency: string;
+  onChange: (next: FormatCategory) => void;
+}) {
+  const fieldId = useId();
+  const feeMajor = category.entryFeeMinor === null ? "" : String(category.entryFeeMinor / 100);
+
+  function setSplit(index: number, value: number) {
+    const split = [...category.payout.split];
+    split[index] = value;
+    onChange({ ...category, payout: { ...category.payout, split } });
+  }
+
+  return (
+    <div className="flex flex-col gap-space-3">
+      <fieldset className="flex flex-col gap-space-2">
+        <legend className="text-label text-text-primary">What does it pay?</legend>
+        <div className="flex flex-wrap gap-space-2">
+          {PAYOUT_CHOICES.map((choice) => (
+            <button
+              key={choice.model}
+              type="button"
+              aria-pressed={category.payout.model === choice.model}
+              onClick={() =>
+                onChange({
+                  ...category,
+                  payout: {
+                    model: choice.model,
+                    // A host switching to places should land on a sensible split rather
+                    // than an empty one they have to invent from nothing.
+                    split:
+                      choice.model === "PLACES" && category.payout.split.length === 0
+                        ? [50, 30, 20]
+                        : category.payout.split,
+                  },
+                })
+              }
+              className={`${CHIP} ${category.payout.model === choice.model ? CHIP_ON : CHIP_OFF}`}
+            >
+              {choice.label}
+            </button>
+          ))}
+        </div>
+        <p className="text-caption text-text-muted">
+          {PAYOUT_CHOICES.find((choice) => choice.model === category.payout.model)?.blurb}
+        </p>
+      </fieldset>
+
+      {category.payout.model === "PLACES" ? (
+        <div className="flex flex-col gap-space-2">
+          <span className="text-label text-text-primary">The split</span>
+          <ul className="flex flex-col gap-space-2">
+            {category.payout.split.map((share, index) => (
+              <li key={index} className={`${INSET} flex items-center gap-space-3`}>
+                <span className="flex-1 text-body text-text-primary">
+                  {["First", "Second", "Third", "Fourth", "Fifth"][index] ?? `Place ${index + 1}`}
+                </span>
+                <label className="flex items-center gap-space-2">
+                  <span className="sr-only">Percentage for place {index + 1}</span>
+                  <input
+                    type="number"
+                    inputMode="decimal"
+                    min="0"
+                    max="100"
+                    step="0.1"
+                    value={share}
+                    onChange={(event) => setSplit(index, Number(event.target.value) || 0)}
+                    className={`${INPUT} ${TABULAR} w-space-16 px-space-2 text-center`}
+                  />
+                </label>
+                <span className="text-caption text-text-muted">%</span>
+              </li>
+            ))}
+          </ul>
+          <div className="flex flex-wrap gap-space-2">
+            <button
+              type="button"
+              className={SECONDARY_BUTTON}
+              onClick={() =>
+                onChange({
+                  ...category,
+                  payout: { ...category.payout, split: [...category.payout.split, 10] },
+                })
+              }
+            >
+              Add a place
+            </button>
+            {category.payout.split.length > 1 ? (
+              <button
+                type="button"
+                className={SECONDARY_BUTTON}
+                onClick={() =>
+                  onChange({
+                    ...category,
+                    payout: { ...category.payout, split: category.payout.split.slice(0, -1) },
+                  })
+                }
+              >
+                One fewer
+              </button>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+
+      <label className="flex flex-col gap-space-2">
+        <span className="text-label text-text-primary">Entry fee for this category</span>
+        <input
+          id={`${fieldId}-fee`}
+          type="number"
+          inputMode="decimal"
+          min="0"
+          step="1"
+          value={feeMajor}
+          onChange={(event) => {
+            const value = event.target.value.trim();
+            onChange({
+              ...category,
+              entryFeeMinor: value === "" ? null : Math.max(0, Math.round(Number(value) * 100)),
+            });
+          }}
+          className={`${INPUT} ${TABULAR}`}
+          placeholder="0"
+        />
+        <span className="text-caption text-text-muted">
+          {category.entryFeeMinor === null || category.entryFeeMinor === 0
+            ? "Free to enter."
+            : `${formatMoney(category.entryFeeMinor, currency)} per entry.`}{" "}
+          This is what you tell entrants it costs. The app is not taking payments yet, so nothing is
+          collected here.
+        </span>
+      </label>
+    </div>
+  );
+}
+
+/** A read-only summary, for the review step and the rules page. */
+export function FormatSummary({ format }: { format: TournamentFormat }) {
+  return (
+    <ul className="flex flex-col gap-space-3">
+      {format.categories.map((item) => (
+        <li key={item.id} className={`${CARD_PADDED} flex flex-col gap-space-1`}>
+          <span className="text-body-strong text-text-primary">{item.name}</span>
+          <span className="text-caption text-text-muted">{describeCategory(item, format.currency)}</span>
+          {item.family === "SPECIES_POINTS" ? (
+            <span className="text-caption text-text-muted">
+              {Object.entries(item.speciesPoints)
+                .sort(([, a], [, b]) => b - a)
+                .slice(0, 6)
+                .map(([id, points]) => `${speciesById(id)?.commonName ?? id} ${points}`)
+                .join(" · ")}
+              {Object.keys(item.speciesPoints).length > 6 ? " …" : ""}
+            </span>
+          ) : null}
+          {item.species.length > 0 && item.family !== "SPECIES_POINTS" ? (
+            <span className="text-caption text-text-muted">
+              {item.species.map((id) => speciesById(id)?.commonName ?? id).join(", ")}
+            </span>
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/features/tournaments/components/tournament-chrome.tsx
+++ b/src/features/tournaments/components/tournament-chrome.tsx
@@ -202,6 +202,7 @@ export function TournamentHero({
 const TABS = [
   ["Overview", "overview"],
   ["Enter", "register"],
+  ["Who's in", "participants"],
   ["Catches", "catches"],
   ["Standings", "leaderboard"],
   ["Rules", "rules"],

--- a/src/features/tournaments/components/tournament-invite.tsx
+++ b/src/features/tournaments/components/tournament-invite.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+
+import { visibilityPresentation } from "../format";
+import { CARD_PADDED, INSET, SECONDARY_BUTTON } from "../ui-classes";
+import { CheckIcon } from "./icons";
+
+/**
+ * Getting other people into a tournament.
+ *
+ * What this shares is the tournament's own link, because that is the only invitation this
+ * product can currently honour. A six-character join code is what a director actually
+ * wants — it is what gets read out at a captains' meeting — but a code has to be minted and
+ * looked up by the server, there is no column for one, and a code printed here that another
+ * phone cannot resolve is a promise made to somebody standing on a dock. It is in the
+ * backend ask instead.
+ *
+ * The visibility line under the button is the part people get wrong: sending a link to a
+ * PRIVATE tournament does not let anybody in, and finding that out after the invitations
+ * have gone is a bad afternoon.
+ */
+export function TournamentInvite({
+  tournamentId,
+  visibility,
+}: {
+  tournamentId: string;
+  visibility: string;
+}) {
+  const [copied, setCopied] = useState(false);
+  const presentation = visibilityPresentation(visibility);
+
+  async function share() {
+    const url = `${window.location.origin}/tournaments/${tournamentId}/overview`;
+
+    // The native sheet where there is one — on a phone that is AirDrop, Messages and
+    // WhatsApp, which is how a tournament actually gets shared. Clipboard otherwise.
+    if (typeof navigator.share === "function") {
+      try {
+        await navigator.share({ url, title: "Fishing tournament" });
+        return;
+      } catch {
+        // A cancelled share sheet throws. That is not a failure worth reporting, and it
+        // must not fall through to silently copying something they chose not to send.
+        return;
+      }
+    }
+
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 4000);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  return (
+    <section className={`${CARD_PADDED} flex flex-col gap-space-3`} aria-labelledby="invite-heading">
+      <h2 id="invite-heading" className="text-h3 text-text-primary">
+        Get people in
+      </h2>
+
+      <button type="button" className={SECONDARY_BUTTON} onClick={share}>
+        {copied ? (
+          <>
+            <CheckIcon />
+            Link copied
+          </>
+        ) : (
+          "Share the tournament"
+        )}
+      </button>
+
+      <p className={`${INSET} text-caption text-text-muted`}>
+        <span className="text-text-primary">{presentation.label}.</span> {presentation.blurb}{" "}
+        {visibility === "PRIVATE"
+          ? "A link on its own will not let anybody in — you have to add them."
+          : "Anyone you send this to can open it and enter while entries are open."}
+      </p>
+    </section>
+  );
+}

--- a/src/features/tournaments/components/tournament-leaderboard.tsx
+++ b/src/features/tournaments/components/tournament-leaderboard.tsx
@@ -2,11 +2,12 @@
 
 import { useEffect, useState } from "react";
 
-import { getDemoStandings, type DemoStanding } from "../demo-store";
+import { boardName, boardSubtitle, rankField, type RankedEntry } from "../field";
 import { tournamentPhase } from "../format";
 import { getDemoTournamentCatches, type DemoTournamentCatch } from "../live-catch-demo";
+import { useField } from "../use-field";
 import { useDemoMode, useTournament } from "../use-tournament";
-import { CARD, CARD_PADDED, INSET, PAGE, TABULAR } from "../ui-classes";
+import { CARD, CARD_PADDED, INSET, PAGE, SECONDARY_BUTTON, TABULAR } from "../ui-classes";
 import { TrophyIcon } from "./icons";
 import {
   BackLink,
@@ -22,47 +23,53 @@ import {
 /**
  * /tournaments/[id]/leaderboard — the board.
  *
- * This used to be the "Leaderboard" tab of the operations screen, which meant an angler
- * who wanted to know whether they were winning had to open a screen headed "Tournament
- * operations" and sit next to the payout controls. Standings are the most-looked-at screen
- * in any tournament and they belong to everybody, so they are their own place now.
+ * It reads the same field as the roster (`use-field.ts`), so the board and "who's in" can
+ * never disagree. It used to carry three hardcoded names of its own, which is fine until
+ * somebody opens both screens in front of you.
  *
- * Two rules hold this screen honest:
+ * Three rules hold this screen honest:
  *
- * 1. **Provisional is said out loud.** A rank that could still move is not presented as a
- *    result. Only FINAL gets called official.
+ * 1. **Provisional is said out loud.** A rank that could still move is not a result. Only
+ *    FINAL gets called official.
  * 2. **Public-safe fields only** (`core/tournaments/public-projection.ts`): a name, a
- *    species, a measurement, a rank. No positions, no evidence, no review notes — not
- *    because they are secret, but because a leaderboard is the one tournament screen that
- *    gets screenshotted and sent to a group chat.
+ *    species, a measurement, a rank. No positions, no evidence, no review notes — a
+ *    leaderboard is the one tournament screen that gets screenshotted into a group chat.
+ * 3. **A tie is a tie.** Two boats on the same weight share the place (`rankField`), rather
+ *    than one being quietly put above the other by row order.
  */
 export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }) {
   const load = useTournament(tournamentId);
+  const fieldLoad = useField(tournamentId);
   const demoMode = useDemoMode();
-  const [standings, setStandings] = useState<readonly DemoStanding[]>([]);
   const [mine, setMine] = useState<readonly DemoTournamentCatch[]>([]);
+  const [bigScreen, setBigScreen] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     void (async () => {
       await Promise.resolve();
-      if (cancelled) return;
-      setStandings(demoMode ? getDemoStandings(tournamentId) : []);
-      setMine(getDemoTournamentCatches(tournamentId));
+      if (!cancelled) setMine(getDemoTournamentCatches(tournamentId));
     })();
     return () => {
       cancelled = true;
     };
-  }, [demoMode, tournamentId]);
+  }, [tournamentId]);
 
   if (load.state === "loading") return <LoadingScreen label="Loading standings" />;
   if (load.state === "error") return <ErrorScreen message={load.message} />;
+  if (fieldLoad.state === "error") return <ErrorScreen message={fieldLoad.message} onRetry={fieldLoad.reload} />;
 
   const tournament = load.tournament;
   const official = tournament.status === "FINAL";
   const finished = tournamentPhase(tournament.status) === "after";
-  const leader = standings.find((row) => row.rank === 1) ?? null;
-  const rest = standings.filter((row) => row !== leader);
+  const ranked = fieldLoad.state === "ready" ? rankField(fieldLoad.field) : [];
+
+  if (bigScreen) {
+    return <BigScreenBoard ranked={ranked} name={tournament.name} official={official} onExit={() => setBigScreen(false)} />;
+  }
+
+  const leader = ranked[0] ?? null;
+  const rest = ranked.slice(1);
 
   return (
     <div className={PAGE}>
@@ -83,54 +90,80 @@ export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }
 
       <TournamentTabs tournamentId={tournament.id} />
 
-      {standings.length === 0 ? (
+      {ranked.length === 0 ? (
         <EmptyState
           title="Nothing has been scored yet"
-          body="Catches appear here once a judge has approved them. A catch on a phone is not a score — that is the point."
+          body="Boats appear here once a judge has approved a catch. A catch on a phone is not a score — that is the point."
         />
       ) : (
-        <section className="flex flex-col gap-space-3" aria-label="Standings">
-          {leader ? (
-            <article
-              className={`${CARD} flex items-center gap-space-4 border-signal-orange/50 bg-linear-to-b from-surface-raised to-surface p-space-5`}
-            >
-              <span className="text-signal-orange">
-                <TrophyIcon size="h-space-8 w-space-8" />
-              </span>
-              <span className="flex flex-1 flex-col gap-space-1">
-                <span className="text-caption text-text-muted">
-                  {official ? "Winner" : "Leading"} · {leader.species}
-                </span>
-                <span className="text-h2 text-text-primary">{leader.display_name}</span>
-              </span>
-              <span className="flex flex-col items-end">
-                <span className={`text-h1 ${TABULAR} text-signal-orange`}>{leader.weight_lb.toFixed(1)}</span>
-                <span className="text-caption text-text-muted">lb</span>
-              </span>
-            </article>
-          ) : null}
-
-          <ol className="flex flex-col gap-space-2">
-            {rest.map((row) => (
-              <li
-                key={`${row.rank}-${row.display_name}`}
-                className={`${CARD} grid grid-cols-[auto_1fr_auto] items-center gap-space-3 p-space-4`}
+        <>
+          <section className="flex flex-col gap-space-3" aria-label="Standings">
+            {leader ? (
+              <article
+                className={`${CARD} flex items-center gap-space-4 border-signal-orange/50 bg-linear-to-b from-surface-raised to-surface p-space-5`}
               >
-                <span className={`w-space-6 text-h3 ${TABULAR} text-text-muted`}>{row.rank}</span>
-                <span className="flex flex-col">
-                  <span className="text-body-strong text-text-primary">{row.display_name}</span>
+                <span className="text-signal-orange">
+                  <TrophyIcon size="h-space-8 w-space-8" />
+                </span>
+                <span className="flex min-w-0 flex-1 flex-col gap-space-1">
                   <span className="text-caption text-text-muted">
-                    {row.species}
-                    {row.official ? "" : " · waiting on a review"}
+                    {official ? "Winner" : "Leading"}
+                    {leader.tied ? " · tied" : ""}
+                    {leader.species ? ` · ${leader.species}` : ""}
                   </span>
+                  <span className="text-h2 text-text-primary">{boardName(leader)}</span>
+                  {boardSubtitle(leader) ? (
+                    <span className="text-caption text-text-muted">{boardSubtitle(leader)}</span>
+                  ) : null}
                 </span>
-                <span className={`text-body-strong ${TABULAR} text-text-primary`}>
-                  {row.weight_lb.toFixed(1)} lb
+                <span className="flex flex-col items-end">
+                  <span className={`text-h1 ${TABULAR} text-signal-orange`}>
+                    {(leader.bestWeightLb ?? 0).toFixed(1)}
+                  </span>
+                  <span className="text-caption text-text-muted">lb</span>
                 </span>
-              </li>
-            ))}
-          </ol>
-        </section>
+              </article>
+            ) : null}
+
+            <ol className="flex flex-col gap-space-2">
+              {rest.map((row) => (
+                <li
+                  key={row.entryId}
+                  className={`${CARD} grid grid-cols-[auto_1fr_auto] items-center gap-space-3 p-space-4 ${
+                    row.isYou ? "border-signal-orange/50" : ""
+                  }`}
+                >
+                  <span className={`w-space-8 text-h3 ${TABULAR} text-text-muted`}>
+                    {row.tied ? `T${row.rank}` : row.rank}
+                  </span>
+                  <span className="flex min-w-0 flex-col">
+                    <span className="text-body-strong text-text-primary">
+                      {boardName(row)}
+                      {row.isYou ? " · you" : ""}
+                    </span>
+                    <span className="text-caption text-text-muted">
+                      {[row.species, row.awaitingReview ? "waiting on a review" : null]
+                        .filter(Boolean)
+                        .join(" · ")}
+                    </span>
+                  </span>
+                  <span className={`text-body-strong ${TABULAR} text-text-primary`}>
+                    {(row.bestWeightLb ?? 0).toFixed(1)} lb
+                  </span>
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          {/*
+            The dock television. A tournament's board spends the afternoon on a screen in a
+            marina bar with sponsors watching it, which is the single thing every competitor
+            in this market leads with, and it costs one button.
+          */}
+          <button type="button" className={SECONDARY_BUTTON} onClick={() => setBigScreen(true)}>
+            Show on a big screen
+          </button>
+        </>
       )}
 
       {mine.length > 0 ? (
@@ -161,6 +194,77 @@ export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }
       </p>
 
       {demoMode ? <DemoNote /> : null}
+    </div>
+  );
+}
+
+/**
+ * The same standings, sized for a room rather than a hand.
+ *
+ * Ten places, no chrome, type that reads from the back of a bar. It is deliberately the
+ * same data and the same ranking as the phone board — a second implementation of "who is
+ * winning" is a second answer to it.
+ */
+function BigScreenBoard({
+  ranked,
+  name,
+  official,
+  onExit,
+}: {
+  ranked: readonly RankedEntry[];
+  name: string;
+  official: boolean;
+  onExit: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-space-5">
+      <div className="flex flex-wrap items-center justify-between gap-space-3">
+        <div className="flex min-w-0 flex-col">
+          <span className="text-caption tracking-station text-text-muted uppercase">
+            {official ? "Final result" : "Live standings"}
+          </span>
+          <h1 className="text-h1 text-text-primary sm:text-display">{name}</h1>
+        </div>
+        <button type="button" className={SECONDARY_BUTTON} onClick={onExit}>
+          Done
+        </button>
+      </div>
+
+      {/*
+        Sized up at the breakpoint rather than always. A dock television is landscape and
+        wide, but this same view opens on the phone that casts to it, and `text-display` on
+        all three columns at 390px runs the boat name straight through the weight.
+      */}
+      <ol className="flex flex-col gap-space-2">
+        {ranked.slice(0, 10).map((row) => (
+          <li
+            key={row.entryId}
+            className={`grid grid-cols-[auto_1fr_auto] items-baseline gap-space-3 rounded-lg border p-space-4 sm:gap-space-4 ${
+              row.rank === 1 ? "border-signal-orange/60 bg-signal-orange/10" : "border-hairline bg-surface"
+            }`}
+          >
+            <span
+              className={`text-h1 sm:text-display ${TABULAR} ${row.rank === 1 ? "text-signal-orange" : "text-text-muted"}`}
+            >
+              {row.rank}
+            </span>
+            <span className="flex min-w-0 flex-col">
+              <span className="truncate text-h3 text-text-primary sm:text-h1">{boardName(row)}</span>
+              {row.species ? (
+                <span className="truncate text-caption text-text-muted sm:text-h3">{row.species}</span>
+              ) : null}
+            </span>
+            <span className={`shrink-0 whitespace-nowrap text-h2 sm:text-display ${TABULAR} text-text-primary`}>
+              {(row.bestWeightLb ?? 0).toFixed(1)}
+              <span className="text-caption text-text-muted sm:text-h3"> lb</span>
+            </span>
+          </li>
+        ))}
+      </ol>
+
+      <p className="text-caption text-text-muted">
+        {official ? "Official." : "Provisional — places move as catches are approved."}
+      </p>
     </div>
   );
 }

--- a/src/features/tournaments/components/tournament-leaderboard.tsx
+++ b/src/features/tournaments/components/tournament-leaderboard.tsx
@@ -2,12 +2,22 @@
 
 import { useEffect, useState } from "react";
 
-import { boardName, boardSubtitle, rankField, type RankedEntry } from "../field";
+import { formatMoney, payoutBreakdown, poolFor, type FormatCategory } from "@/core/tournaments/formats";
+import {
+  boardName,
+  boardSubtitle,
+  fieldSummary,
+  scoreboardFor,
+  scoreLabel,
+  speciesName,
+  type CategoryStanding,
+} from "../field";
 import { tournamentPhase } from "../format";
 import { getDemoTournamentCatches, type DemoTournamentCatch } from "../live-catch-demo";
 import { useField } from "../use-field";
+import { useFormat } from "../use-format";
 import { useDemoMode, useTournament } from "../use-tournament";
-import { CARD, CARD_PADDED, INSET, PAGE, SECONDARY_BUTTON, TABULAR } from "../ui-classes";
+import { CARD, CARD_PADDED, CHIP, CHIP_OFF, CHIP_ON, INSET, PAGE, SECONDARY_BUTTON, TABULAR } from "../ui-classes";
 import { TrophyIcon } from "./icons";
 import {
   BackLink,
@@ -19,6 +29,26 @@ import {
   TonePill,
   TournamentTabs,
 } from "./tournament-chrome";
+
+/**
+ * The board a tournament has before its host has chosen a format: heaviest fish, anything
+ * counts, no pot. Every event has at least this one, so the screen has one code path.
+ */
+const IMPLIED_CATEGORY: FormatCategory = {
+  id: "overall",
+  name: "Heaviest fish",
+  family: "BIGGEST_FISH",
+  species: [],
+  speciesPoints: {},
+  bestN: null,
+  payout: { model: "NONE", split: [] },
+  entryFeeMinor: null,
+};
+
+function ordinal(rank: number): string {
+  const suffix = rank === 1 ? "st" : rank === 2 ? "nd" : rank === 3 ? "rd" : "th";
+  return `${rank}${suffix}`;
+}
 
 /**
  * /tournaments/[id]/leaderboard — the board.
@@ -40,9 +70,13 @@ import {
 export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }) {
   const load = useTournament(tournamentId);
   const fieldLoad = useField(tournamentId);
+  const formatLoad = useFormat(
+    load.state === "ready" ? load.tournament : { id: tournamentId, active_scoring_version_id: null },
+  );
   const demoMode = useDemoMode();
   const [mine, setMine] = useState<readonly DemoTournamentCatch[]>([]);
   const [bigScreen, setBigScreen] = useState(false);
+  const [categoryId, setCategoryId] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -62,10 +96,34 @@ export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }
   const tournament = load.tournament;
   const official = tournament.status === "FINAL";
   const finished = tournamentPhase(tournament.status) === "after";
-  const ranked = fieldLoad.state === "ready" ? rankField(fieldLoad.field) : [];
+  const field = fieldLoad.state === "ready" ? fieldLoad.field : [];
+
+  /*
+    Every board on this screen is one category's board. A tournament with no format saved
+    yet still has one — the implied "heaviest fish, anything counts" — so the screen never
+    has to carry a second, formatless code path.
+  */
+  const format = formatLoad.state === "ready" ? formatLoad.format : null;
+  const categories: readonly FormatCategory[] = format?.categories ?? [IMPLIED_CATEGORY];
+  const category = categories.find((item) => item.id === categoryId) ?? categories[0];
+  const currency = format?.currency ?? "USD";
+
+  const ranked = scoreboardFor(field, category);
+  // Entries still in the tournament, not every row ever created: a withdrawn boat does not
+  // pay into the pot, and a pot that counts one is money the organizer does not have.
+  const pool = poolFor(category, fieldSummary(field).entered);
+  const payouts = payoutBreakdown({ poolMinor: pool, payout: category.payout, placesFilled: ranked.length });
 
   if (bigScreen) {
-    return <BigScreenBoard ranked={ranked} name={tournament.name} official={official} onExit={() => setBigScreen(false)} />;
+    return (
+      <BigScreenBoard
+        ranked={ranked}
+        category={category}
+        name={tournament.name}
+        official={official}
+        onExit={() => setBigScreen(false)}
+      />
+    );
   }
 
   const leader = ranked[0] ?? null;
@@ -90,6 +148,42 @@ export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }
 
       <TournamentTabs tournamentId={tournament.id} />
 
+      {/*
+        One row of chips per category. A Bisbee's-shaped event has three or four boards and
+        they are genuinely different competitions — the marlin board and the tuna board
+        share nothing but the entry list.
+      */}
+      {categories.length > 1 ? (
+        <nav aria-label="Categories">
+          <ul className="flex flex-wrap gap-space-2">
+            {categories.map((item) => (
+              <li key={item.id}>
+                <button
+                  type="button"
+                  aria-pressed={item.id === category.id}
+                  onClick={() => setCategoryId(item.id)}
+                  className={`${CHIP} ${item.id === category.id ? CHIP_ON : CHIP_OFF}`}
+                >
+                  {item.name}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      ) : null}
+
+      {payouts.length > 0 ? (
+        <p className={`${INSET} text-caption text-text-muted`}>
+          <span className="text-text-primary">
+            {formatMoney(pool, currency)} in {category.name.toLowerCase()}
+          </span>{" "}
+          if every entry pays — {payouts
+            .map((slice) => `${ordinal(slice.rank)} ${formatMoney(slice.amountMinor, currency)}`)
+            .join(", ")}
+          . Nothing has been collected: the app is not taking payments yet.
+        </p>
+      ) : null}
+
       {ranked.length === 0 ? (
         <EmptyState
           title="Nothing has been scored yet"
@@ -109,7 +203,7 @@ export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }
                   <span className="text-caption text-text-muted">
                     {official ? "Winner" : "Leading"}
                     {leader.tied ? " · tied" : ""}
-                    {leader.species ? ` · ${leader.species}` : ""}
+                    {categories.length > 1 ? ` · ${category.name}` : ""}
                   </span>
                   <span className="text-h2 text-text-primary">{boardName(leader)}</span>
                   {boardSubtitle(leader) ? (
@@ -118,9 +212,11 @@ export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }
                 </span>
                 <span className="flex flex-col items-end">
                   <span className={`text-h1 ${TABULAR} text-signal-orange`}>
-                    {(leader.bestWeightLb ?? 0).toFixed(1)}
+                    {scoreLabel(category, leader.score).split(" ")[0]}
                   </span>
-                  <span className="text-caption text-text-muted">lb</span>
+                  <span className="text-caption text-text-muted">
+                    {scoreLabel(category, leader.score).split(" ")[1]}
+                  </span>
                 </span>
               </article>
             ) : null}
@@ -142,13 +238,13 @@ export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }
                       {row.isYou ? " · you" : ""}
                     </span>
                     <span className="text-caption text-text-muted">
-                      {[row.species, row.awaitingReview ? "waiting on a review" : null]
+                      {[speciesName(row.species), row.awaitingReview ? "waiting on a review" : null]
                         .filter(Boolean)
                         .join(" · ")}
                     </span>
                   </span>
                   <span className={`text-body-strong ${TABULAR} text-text-primary`}>
-                    {(row.bestWeightLb ?? 0).toFixed(1)} lb
+                    {scoreLabel(category, row.score)}
                   </span>
                 </li>
               ))}
@@ -207,11 +303,13 @@ export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }
  */
 function BigScreenBoard({
   ranked,
+  category,
   name,
   official,
   onExit,
 }: {
-  ranked: readonly RankedEntry[];
+  ranked: readonly CategoryStanding[];
+  category: FormatCategory;
   name: string;
   official: boolean;
   onExit: () => void;
@@ -221,7 +319,7 @@ function BigScreenBoard({
       <div className="flex flex-wrap items-center justify-between gap-space-3">
         <div className="flex min-w-0 flex-col">
           <span className="text-caption tracking-station text-text-muted uppercase">
-            {official ? "Final result" : "Live standings"}
+            {official ? "Final result" : "Live standings"} · {category.name}
           </span>
           <h1 className="text-h1 text-text-primary sm:text-display">{name}</h1>
         </div>
@@ -255,8 +353,11 @@ function BigScreenBoard({
               ) : null}
             </span>
             <span className={`shrink-0 whitespace-nowrap text-h2 sm:text-display ${TABULAR} text-text-primary`}>
-              {(row.bestWeightLb ?? 0).toFixed(1)}
-              <span className="text-caption text-text-muted sm:text-h3"> lb</span>
+              {scoreLabel(category, row.score).split(" ")[0]}
+              <span className="text-caption text-text-muted sm:text-h3">
+                {" "}
+                {scoreLabel(category, row.score).split(" ")[1]}
+              </span>
             </span>
           </li>
         ))}

--- a/src/features/tournaments/components/tournament-operations.tsx
+++ b/src/features/tournaments/components/tournament-operations.tsx
@@ -9,9 +9,10 @@ import {
   validateTournamentTransition,
   type TournamentStatus,
 } from "@/core/tournaments/lifecycle";
-import { getDemoStandings, type DemoStanding } from "../demo-store";
+import { fieldSummary, rankField, type FieldSummary } from "../field";
 import { isTournamentStatus, tournamentPhase, type Phase } from "../format";
 import { getDemoTournamentCatches, type DemoTournamentCatch } from "../live-catch-demo";
+import { useField } from "../use-field";
 import { useDemoMode, useTournament } from "../use-tournament";
 import {
   CARD,
@@ -78,23 +79,25 @@ export function TournamentOperations({
   initialPanel?: Lane;
 }) {
   const load = useTournament(tournamentId);
+  const fieldLoad = useField(tournamentId);
   const demoMode = useDemoMode();
   const [lane, setLane] = useState<Lane>(initialPanel);
   const [catches, setCatches] = useState<readonly DemoTournamentCatch[]>([]);
-  const [standings, setStandings] = useState<readonly DemoStanding[]>([]);
 
   useEffect(() => {
     let cancelled = false;
     void (async () => {
       await Promise.resolve();
-      if (cancelled) return;
-      setCatches(getDemoTournamentCatches(tournamentId));
-      setStandings(demoMode ? getDemoStandings(tournamentId) : []);
+      if (!cancelled) setCatches(getDemoTournamentCatches(tournamentId));
     })();
     return () => {
       cancelled = true;
     };
-  }, [demoMode, tournamentId]);
+  }, [tournamentId]);
+
+  const field = fieldLoad.state === "ready" ? fieldLoad.field : [];
+  const summary = fieldSummary(field);
+  const onTheBoard = rankField(field).length;
 
   const flagged = useMemo(() => catches.filter((item) => item.fair_play_messages.length > 0), [catches]);
 
@@ -136,7 +139,13 @@ export function TournamentOperations({
       </nav>
 
       {lane === "organizer" ? (
-        <OrganizerLane tournament={tournament} phase={phase} catches={catches.length} flagged={flagged.length} standings={standings.length} />
+        <OrganizerLane
+          tournament={tournament}
+          phase={phase}
+          flagged={flagged.length}
+          summary={summary}
+          onTheBoard={onTheBoard}
+        />
       ) : null}
       {lane === "judge" ? <JudgeLane flagged={flagged} /> : null}
       {lane === "finance" ? <FinanceLane /> : null}
@@ -181,9 +190,9 @@ const HIGH_RISK: ReadonlySet<TournamentStatus> = new Set(["LIVE", "FINAL", "CANC
 function OrganizerLane({
   tournament,
   phase,
-  catches,
   flagged,
-  standings,
+  summary,
+  onTheBoard,
 }: {
   tournament: {
     readonly status: string;
@@ -194,9 +203,9 @@ function OrganizerLane({
     readonly active_boundary_version_id: string | null;
   };
   phase: Phase;
-  catches: number;
   flagged: number;
-  standings: number;
+  summary: FieldSummary;
+  onTheBoard: number;
 }) {
   const versions = {
     ruleSetVersionId: tournament.active_rule_set_version_id,
@@ -220,14 +229,23 @@ function OrganizerLane({
   return (
     <div className="flex flex-col gap-space-5">
       {/*
-        Two across on a phone rather than one. Three full-width cards each holding a single
-        digit is a lot of scrolling to learn three numbers.
+        Two across on a phone rather than one. Four full-width cards each holding a single
+        digit is a lot of scrolling to learn four numbers. They are counts of the same field
+        the roster lists, computed in `field.ts`, so this panel cannot say a number the
+        roster contradicts.
       */}
-      <section className="grid grid-cols-2 gap-space-3 sm:grid-cols-3" aria-label="Event at a glance">
-        <StatTile label="Catches logged" value={String(catches)} />
+      <section className="grid grid-cols-2 gap-space-3 sm:grid-cols-4" aria-label="Event at a glance">
+        <StatTile label="Entered" value={String(summary.entered)} />
+        <StatTile label="Checked in" value={`${summary.checkedIn}/${summary.entered}`} />
         <StatTile label="For a judge" value={String(flagged)} tone={flagged > 0 ? "attention" : "neutral"} />
-        <StatTile label="On the board" value={String(standings)} />
+        <StatTile label="On the board" value={String(onTheBoard)} />
       </section>
+
+      {summary.needsAttention > 0 ? (
+        <Link href={`/tournaments/${tournament.id}/participants`} className={SECONDARY_BUTTON}>
+          {summary.needsAttention} {summary.needsAttention === 1 ? "entry needs" : "entries need"} a look
+        </Link>
+      ) : null}
 
       {phase === "before" ? (
         <section className={`${CARD_PADDED} flex flex-col gap-space-3`}>

--- a/src/features/tournaments/components/tournament-overview.tsx
+++ b/src/features/tournaments/components/tournament-overview.tsx
@@ -3,9 +3,11 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
-import { getDemoEntry, getDemoStandings, type DemoEntry, type DemoStanding } from "../demo-store";
+import { getDemoEntry, type DemoEntry } from "../demo-store";
+import { boardName, fieldSummary, rankField } from "../field";
 import { entrySteps, formatDateTime, tournamentPhase, visibilityPresentation } from "../format";
 import { getDemoTournamentCatches } from "../live-catch-demo";
+import { useField } from "../use-field";
 import { useDemoMode, useTournament } from "../use-tournament";
 import { BIG_ACTION, CARD, CARD_PADDED, FOCUS_RING, PAGE, SECONDARY_BUTTON, TABULAR } from "../ui-classes";
 import { ChevronIcon, LockIcon, TrophyIcon } from "./icons";
@@ -19,6 +21,7 @@ import {
   TournamentHero,
   TournamentTabs,
 } from "./tournament-chrome";
+import { TournamentInvite } from "./tournament-invite";
 
 /**
  * /tournaments/[id]/overview — the tournament's home.
@@ -62,9 +65,9 @@ const READINESS = [
 
 export function TournamentOverview({ tournamentId }: { tournamentId: string }) {
   const load = useTournament(tournamentId);
+  const fieldLoad = useField(tournamentId);
   const demoMode = useDemoMode();
   const [entry, setEntry] = useState<DemoEntry | null>(null);
-  const [standings, setStandings] = useState<readonly DemoStanding[]>([]);
   const [deviceCatches, setDeviceCatches] = useState(0);
 
   useEffect(() => {
@@ -75,7 +78,6 @@ export function TournamentOverview({ tournamentId }: { tournamentId: string }) {
       await Promise.resolve();
       if (cancelled) return;
       setEntry(demoMode ? getDemoEntry(tournamentId) : null);
-      setStandings(demoMode ? getDemoStandings(tournamentId) : []);
       setDeviceCatches(getDemoTournamentCatches(tournamentId).length);
     })();
     return () => {
@@ -88,6 +90,11 @@ export function TournamentOverview({ tournamentId }: { tournamentId: string }) {
 
   const tournament = load.tournament;
   const phase = tournamentPhase(tournament.status);
+  // The board and the field come from one place, so the overview's summary can never
+  // disagree with the roster it links to.
+  const field = fieldLoad.state === "ready" ? fieldLoad.field : [];
+  const summary = fieldSummary(field);
+  const standings = rankField(field);
   const locked = READINESS.filter((item) => tournament[item.key] !== null);
   const ready = locked.length === READINESS.length;
   const visibility = visibilityPresentation(tournament.visibility);
@@ -168,13 +175,16 @@ export function TournamentOverview({ tournamentId }: { tournamentId: string }) {
           </SectionHeading>
           <ol className="flex flex-col gap-space-2">
             {standings.slice(0, 3).map((row) => (
-              <li key={row.rank} className="flex items-center gap-space-3">
+              <li key={row.entryId} className="flex items-center gap-space-3">
                 <span className={`text-h3 ${TABULAR} ${row.rank === 1 ? "text-signal-orange" : "text-text-muted"}`}>
-                  {row.rank}
+                  {row.tied ? `T${row.rank}` : row.rank}
                 </span>
-                <span className="flex-1 text-body text-text-primary">{row.display_name}</span>
+                <span className="flex-1 text-body text-text-primary">
+                  {boardName(row)}
+                  {row.isYou ? " · you" : ""}
+                </span>
                 <span className={`text-body-strong ${TABULAR} text-text-primary`}>
-                  {row.weight_lb.toFixed(1)} lb
+                  {(row.bestWeightLb ?? 0).toFixed(1)} lb
                 </span>
               </li>
             ))}
@@ -189,6 +199,32 @@ export function TournamentOverview({ tournamentId }: { tournamentId: string }) {
         </section>
       ) : null}
 
+      {/*
+        The field, as a link rather than a number in a box. "14 entered, 11 checked in" is
+        the sentence a director says out loud, and it is one tap from the list it counts.
+      */}
+      {summary.entered > 0 ? (
+        <Link
+          href={`/tournaments/${tournament.id}/participants`}
+          className={`${CARD} ${FOCUS_RING} flex items-center gap-space-3 p-space-4 transition-colors hover:border-border-interactive`}
+        >
+          <span className="flex flex-1 flex-col gap-space-1">
+            <span className="text-body-strong text-text-primary">
+              {summary.entered} {summary.entered === 1 ? "entry" : "entries"}
+              {phase === "before" || phase === "during"
+                ? ` · ${summary.checkedIn} checked in`
+                : ""}
+            </span>
+            <span className="text-caption text-text-muted">
+              {summary.needsAttention > 0
+                ? `${summary.needsAttention} need a look before lines in.`
+                : "Who is fishing, their boats, and who has checked in."}
+            </span>
+          </span>
+          <ChevronIcon className="text-text-muted" />
+        </Link>
+      ) : null}
+
       <section className="grid gap-space-3 sm:grid-cols-2" aria-label="Tournament details">
         <DetailCard label="Lines in" value={formatDateTime(tournament.starts_at) ?? "Not set yet"} />
         <DetailCard label="Lines out" value={formatDateTime(tournament.ends_at) ?? "Not set yet"} />
@@ -199,6 +235,14 @@ export function TournamentOverview({ tournamentId }: { tournamentId: string }) {
           hint="Recorded here, whether or not they have reached the scorer yet."
         />
       </section>
+
+      {/*
+        Sharing sits before the event and disappears once it is being fished — nobody
+        invites a boat at 2pm on tournament day.
+      */}
+      {phase === "before" ? (
+        <TournamentInvite tournamentId={tournament.id} visibility={tournament.visibility} />
+      ) : null}
 
       {/*
         Organizer tools, as one card rather than a sixth tab. An angler fishing this

--- a/src/features/tournaments/components/tournament-participants.tsx
+++ b/src/features/tournaments/components/tournament-participants.tsx
@@ -1,0 +1,361 @@
+"use client";
+
+import { useEffect, useId, useMemo, useState } from "react";
+
+import { setDemoCheckIn } from "../demo-field";
+import { boardName, boardSubtitle, fieldSummary, isInTheField, searchField, type FieldEntry } from "../field";
+import { entrySteps } from "../format";
+import { useField } from "../use-field";
+import { useDemoMode, useTournament } from "../use-tournament";
+import {
+  CARD,
+  CARD_PADDED,
+  CHIP,
+  CHIP_OFF,
+  CHIP_ON,
+  FOCUS_RING,
+  INPUT,
+  PAGE,
+  SECONDARY_BUTTON,
+  TABULAR,
+} from "../ui-classes";
+import { CheckIcon, PendingIcon } from "./icons";
+import {
+  BackLink,
+  DemoNote,
+  EmptyState,
+  ErrorScreen,
+  LoadingScreen,
+  SectionHeading,
+  StatTile,
+  TonePill,
+  TournamentTabs,
+} from "./tournament-chrome";
+import { TournamentInvite } from "./tournament-invite";
+
+/**
+ * /tournaments/[id]/participants — the field.
+ *
+ * This screen did not exist, and its absence was the largest hole in the section: you
+ * could create a tournament and enter one, but there was no way to see who was in it. For
+ * a director that is the first question ("where are my eighty boats?"), and for three
+ * friends it is most of the product ("is Dad in yet?").
+ *
+ * It is one screen for both, which is the whole B2C/B2B bet (UX-001 §13): a four-person
+ * family event and an eighty-boat offshore tournament are the same list, and the parts a
+ * small event does not need — the search box, the filters, the check-in counts — appear
+ * because the field is big, not because somebody bought a different product.
+ */
+
+type Filter = "all" | "not-checked-in" | "attention";
+
+const FILTERS: Array<{ value: Filter; label: string }> = [
+  { value: "all", label: "Everyone" },
+  { value: "not-checked-in", label: "Not checked in" },
+  { value: "attention", label: "Needs a look" },
+];
+
+/** The size at which a list stops being readable by eye and needs a search box. */
+const SEARCHABLE_FROM = 8;
+
+/** One shared empty array, so "still loading" does not look like a new field every render. */
+const NO_FIELD: readonly FieldEntry[] = [];
+
+export function TournamentParticipants({ tournamentId }: { tournamentId: string }) {
+  const load = useTournament(tournamentId);
+  const fieldLoad = useField(tournamentId);
+  const demoMode = useDemoMode();
+  const fieldId = useId();
+
+  const [query, setQuery] = useState("");
+  const [filter, setFilter] = useState<Filter>("all");
+  const [checkInTick, setCheckInTick] = useState(0);
+  const { reload } = fieldLoad;
+
+  // A check-in writes to the device and then the field is read again, rather than the row
+  // being patched in place. One source of truth for who is checked in, even when the change
+  // came from this screen.
+  useEffect(() => {
+    if (checkInTick > 0) reload();
+  }, [checkInTick, reload]);
+
+  const field = fieldLoad.state === "ready" ? fieldLoad.field : NO_FIELD;
+  const summary = useMemo(() => fieldSummary(field), [field]);
+
+  const shown = useMemo(() => {
+    const searched = searchField(field, query);
+    if (filter === "not-checked-in") {
+      return searched.filter((entry) => isInTheField(entry) && entry.checkInStatus === "NOT_CHECKED_IN");
+    }
+    if (filter === "attention") {
+      return searched.filter(
+        (entry) =>
+          isInTheField(entry) &&
+          (entry.registrationStatus === "PENDING" ||
+            entry.registrationStatus === "WAITLISTED" ||
+            entry.eligibilityStatus === "PENDING_REVIEW" ||
+            entry.eligibilityStatus === "INELIGIBLE"),
+      );
+    }
+    return searched;
+  }, [field, filter, query]);
+
+  if (load.state === "loading") return <LoadingScreen label="Loading the field" />;
+  if (load.state === "error") return <ErrorScreen message={load.message} />;
+  if (fieldLoad.state === "error") return <ErrorScreen message={fieldLoad.message} onRetry={reload} />;
+
+  const tournament = load.tournament;
+  const out = field.filter((entry) => !isInTheField(entry));
+
+  return (
+    <div className={PAGE}>
+      <header className="flex flex-col gap-space-3">
+        <BackLink href={`/tournaments/${tournament.id}/overview`}>{tournament.name}</BackLink>
+        <div className="flex flex-wrap items-end justify-between gap-space-3">
+          <h1 className="text-h1 text-text-primary">Who&apos;s in</h1>
+          <span className={`text-body ${TABULAR} text-text-muted`}>
+            {summary.entered} {summary.entered === 1 ? "entry" : "entries"}
+          </span>
+        </div>
+      </header>
+
+      <TournamentTabs tournamentId={tournament.id} />
+
+      {field.length === 0 ? (
+        <>
+          <EmptyState
+            title="Nobody has entered yet"
+            body="Everyone who enters shows up here with their boat, their number, and whether they have checked in."
+          />
+          <TournamentInvite tournamentId={tournament.id} visibility={tournament.visibility} />
+        </>
+      ) : (
+        <>
+          {/*
+            Four numbers a director reads out loud at a captains' meeting. They are counts
+            of the same list below, computed in one place (`field.ts`), so the roster can
+            never say twelve while the summary says fourteen.
+          */}
+          <section className="grid grid-cols-2 gap-space-3 sm:grid-cols-4" aria-label="The field at a glance">
+            <StatTile label="Entered" value={String(summary.entered)} />
+            <StatTile label="Checked in" value={`${summary.checkedIn}/${summary.entered}`} />
+            <StatTile label="On the board" value={String(summary.onTheBoard)} />
+            <StatTile
+              label="Needs a look"
+              value={String(summary.needsAttention)}
+              tone={summary.needsAttention > 0 ? "attention" : "neutral"}
+            />
+          </section>
+
+          {field.length >= SEARCHABLE_FROM ? (
+            <div className="flex flex-col gap-space-3">
+              <label className="flex flex-col gap-space-2">
+                <span className="text-label text-text-primary">Find a boat</span>
+                <input
+                  id={`${fieldId}-search`}
+                  type="search"
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  className={INPUT}
+                  placeholder="Name, boat, team, or number"
+                  autoComplete="off"
+                />
+              </label>
+
+              <div className="flex flex-wrap gap-space-2" role="group" aria-label="Filter the field">
+                {FILTERS.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    aria-pressed={filter === option.value}
+                    onClick={() => setFilter(option.value)}
+                    className={`${CHIP} ${filter === option.value ? CHIP_ON : CHIP_OFF}`}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {shown.filter(isInTheField).length === 0 ? (
+            <EmptyState
+              title="Nothing matches"
+              body={
+                query.trim().length > 0
+                  ? `No entry matches “${query.trim()}”. Try the boat name or the number on the hull.`
+                  : "Nobody is in this state right now."
+              }
+              action={
+                <button type="button" className={SECONDARY_BUTTON} onClick={() => { setQuery(""); setFilter("all"); }}>
+                  Show everyone
+                </button>
+              }
+            />
+          ) : (
+            <ul className="flex flex-col gap-space-3">
+              {shown.filter(isInTheField).map((entry) => (
+                <ParticipantRow
+                  key={entry.entryId}
+                  entry={entry}
+                  canCheckIn={demoMode}
+                  onCheckIn={(status) => {
+                    setDemoCheckIn(tournamentId, entry.entryId, status);
+                    setCheckInTick((value) => value + 1);
+                  }}
+                />
+              ))}
+            </ul>
+          )}
+
+          {/*
+            Entries that are out of the tournament are kept, below the line, rather than
+            deleted from the view. A withdrawn boat is a thing that happened, and a director
+            asked "what happened to 16?" needs an answer.
+          */}
+          {out.length > 0 && filter === "all" && query.trim().length === 0 ? (
+            <section className="flex flex-col gap-space-3" aria-labelledby="out-heading">
+              <SectionHeading aside={`${out.length}`}>
+                <span id="out-heading">Not fishing</span>
+              </SectionHeading>
+              <ul className="flex flex-col gap-space-2">
+                {out.map((entry) => (
+                  <li key={entry.entryId} className={`${CARD} flex items-center justify-between gap-space-3 p-space-3`}>
+                    <span className="flex flex-col">
+                      <span className="text-body text-text-muted">{boardName(entry)}</span>
+                      {boardSubtitle(entry) ? (
+                        <span className="text-caption text-text-muted">{boardSubtitle(entry)}</span>
+                      ) : null}
+                    </span>
+                    <TonePill tone="stopped">{registrationWord(entry)}</TonePill>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+
+          <TournamentInvite tournamentId={tournament.id} visibility={tournament.visibility} />
+        </>
+      )}
+
+      {demoMode ? <DemoNote /> : null}
+    </div>
+  );
+}
+
+/** The four entry states, in the shape `entrySteps` reads them. */
+function stepsFor(entry: FieldEntry) {
+  return entrySteps({
+    registration_status: entry.registrationStatus,
+    eligibility_status: entry.eligibilityStatus,
+    check_in_status: entry.checkInStatus,
+    competition_status: entry.competitionStatus,
+  });
+}
+
+/** "Withdrawn", "Not accepted", "Cancelled" — why this entry is below the line. */
+function registrationWord(entry: FieldEntry): string {
+  return stepsFor(entry)[0].value;
+}
+
+/**
+ * One entry. The number on the hull is the anchor, because that is what gets shouted across
+ * a dock; the name is second.
+ */
+function ParticipantRow({
+  entry,
+  canCheckIn,
+  onCheckIn,
+}: {
+  entry: FieldEntry;
+  canCheckIn: boolean;
+  onCheckIn: (status: string) => void;
+}) {
+  const checkedIn = entry.checkInStatus === "CHECKED_IN";
+  const steps = stepsFor(entry);
+
+  // Only the states worth a pill. A confirmed, eligible entry needs no decoration — the
+  // row being there is the information, and four green pills on every row is noise that
+  // hides the one row that is not fine.
+  const flags = [
+    entry.registrationStatus === "CONFIRMED" ? null : steps[0],
+    entry.eligibilityStatus === "ELIGIBLE" || entry.eligibilityStatus === "UNKNOWN" ? null : steps[1],
+  ].filter((step): step is NonNullable<typeof step> => step !== null);
+
+  return (
+    <li className={`${CARD_PADDED} flex flex-col gap-space-3`}>
+      <div className="flex items-start gap-space-3">
+        <span
+          className={`flex h-space-10 w-space-10 shrink-0 items-center justify-center rounded-md border text-body-strong ${TABULAR} ${
+            entry.isYou
+              ? "border-signal-orange bg-signal-orange/10 text-signal-orange"
+              : "border-hairline bg-background text-text-muted"
+          }`}
+          aria-hidden={entry.entryNumber === null}
+        >
+          {entry.entryNumber ?? "–"}
+        </span>
+
+        <span className="flex min-w-0 flex-1 flex-col gap-space-1">
+          <span className="flex flex-wrap items-center gap-space-2">
+            <span className="text-body-strong text-text-primary">{boardName(entry)}</span>
+            {entry.isYou ? <TonePill tone="live">You</TonePill> : null}
+          </span>
+          {boardSubtitle(entry) ? (
+            <span className="text-caption text-text-muted">{boardSubtitle(entry)}</span>
+          ) : null}
+          {entry.bestWeightLb !== null ? (
+            <span className={`text-caption ${TABULAR} text-text-muted`}>
+              Best so far: {entry.bestWeightLb.toFixed(1)} lb {entry.species ? `· ${entry.species}` : ""}
+              {entry.awaitingReview ? " · waiting on a review" : ""}
+            </span>
+          ) : null}
+        </span>
+
+        {/*
+          Check-in rides on the row rather than sitting under it as a full-width button.
+          Thirteen boats × a 48px button each was most of the length of this screen, and a
+          director working down a list at the ramp wants the next boat on screen, not the
+          last one's control.
+        */}
+        {canCheckIn ? (
+          <button
+            type="button"
+            aria-label={
+              checkedIn ? `Undo check-in for ${boardName(entry)}` : `Check in ${boardName(entry)}`
+            }
+            onClick={() => onCheckIn(checkedIn ? "NOT_CHECKED_IN" : "CHECKED_IN")}
+            className={`${FOCUS_RING} inline-flex min-h-touch-floor shrink-0 items-center gap-space-2 rounded-md border px-space-3 text-caption transition-colors active:scale-95 motion-reduce:transition-none ${
+              checkedIn
+                ? "border-success-green/40 bg-success-green/10 text-success-green"
+                : "border-border-interactive bg-surface-raised text-text-primary"
+            }`}
+          >
+            {checkedIn ? <CheckIcon size="h-space-4 w-space-4" /> : <PendingIcon size="h-space-4 w-space-4" />}
+            {checkedIn ? "In" : "Check in"}
+          </button>
+        ) : (
+          <span
+            className={`inline-flex shrink-0 items-center gap-space-2 text-caption ${
+              checkedIn ? "text-success-green" : "text-text-muted"
+            }`}
+          >
+            {checkedIn ? <CheckIcon size="h-space-4 w-space-4" /> : <PendingIcon size="h-space-4 w-space-4" />}
+            {checkedIn ? "In" : "Not in"}
+          </span>
+        )}
+      </div>
+
+      {flags.length > 0 ? (
+        <ul className="flex flex-wrap gap-space-2">
+          {flags.map((step) => (
+            <li key={step.label}>
+              <TonePill tone={step.tone}>{step.value}</TonePill>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+    </li>
+  );
+}

--- a/src/features/tournaments/components/tournament-participants.tsx
+++ b/src/features/tournaments/components/tournament-participants.tsx
@@ -3,7 +3,15 @@
 import { useEffect, useId, useMemo, useState } from "react";
 
 import { setDemoCheckIn } from "../demo-field";
-import { boardName, boardSubtitle, fieldSummary, isInTheField, searchField, type FieldEntry } from "../field";
+import {
+  boardName,
+  boardSubtitle,
+  fieldSummary,
+  isInTheField,
+  searchField,
+  speciesName,
+  type FieldEntry,
+} from "../field";
 import { entrySteps } from "../format";
 import { useField } from "../use-field";
 import { useDemoMode, useTournament } from "../use-tournament";
@@ -306,7 +314,7 @@ function ParticipantRow({
           ) : null}
           {entry.bestWeightLb !== null ? (
             <span className={`text-caption ${TABULAR} text-text-muted`}>
-              Best so far: {entry.bestWeightLb.toFixed(1)} lb {entry.species ? `· ${entry.species}` : ""}
+              Best so far: {entry.bestWeightLb.toFixed(1)} lb {entry.species ? `· ${speciesName(entry.species)}` : ""}
               {entry.awaitingReview ? " · waiting on a review" : ""}
             </span>
           ) : null}

--- a/src/features/tournaments/components/tournament-rules.tsx
+++ b/src/features/tournaments/components/tournament-rules.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import { describeFormat } from "@/core/tournaments/formats";
+import { useFormat } from "../use-format";
 import { useDemoMode, useTournament } from "../use-tournament";
+import { FormatSummary } from "./format-editor";
 import { CARD_PADDED, INSET, PAGE } from "../ui-classes";
 import { CheckRow, DemoNote, ErrorScreen, LoadingScreen, SectionHeading, TournamentHero, TournamentTabs, BackLink } from "./tournament-chrome";
 
@@ -48,11 +51,17 @@ const INPUTS = [
 export function TournamentRules({ tournamentId }: { tournamentId: string }) {
   const load = useTournament(tournamentId);
   const demoMode = useDemoMode();
+  const formatLoad = useFormat(
+    load.state === "ready"
+      ? load.tournament
+      : { id: tournamentId, active_scoring_version_id: null },
+  );
 
   if (load.state === "loading") return <LoadingScreen label="Loading rules" />;
   if (load.state === "error") return <ErrorScreen message={load.message} />;
 
   const tournament = load.tournament;
+  const format = formatLoad.state === "ready" ? formatLoad.format : null;
 
   return (
     <div className={PAGE}>
@@ -64,6 +73,24 @@ export function TournamentRules({ tournamentId }: { tournamentId: string }) {
       />
 
       <TournamentTabs tournamentId={tournament.id} />
+
+      {/*
+        The one part of "the rules" this app can state exactly: what the host chose, read
+        back from the scoring version the tournament is actually pointed at. Everything
+        below it is still the shape of the agreement rather than its text.
+      */}
+      {format ? (
+        <section className={`${CARD_PADDED} flex flex-col gap-space-3`} aria-labelledby="format-heading">
+          <SectionHeading aside={format.categories.length > 1 ? `${format.categories.length} categories` : undefined}>
+            <span id="format-heading">How it is won</span>
+          </SectionHeading>
+          <FormatSummary format={format} />
+          <p className="text-caption text-text-muted">
+            {describeFormat(format).length} way{describeFormat(format).length === 1 ? "" : "s"} to win.
+            A boat can be in more than one.
+          </p>
+        </section>
+      ) : null}
 
       <section className={`${CARD_PADDED} flex flex-col gap-space-4`} aria-labelledby="agreement-heading">
         <SectionHeading>

--- a/src/features/tournaments/demo-field.ts
+++ b/src/features/tournaments/demo-field.ts
@@ -22,17 +22,40 @@ const CHECK_IN_KEY = "fish-log-book:demo-tournament-check-in";
  * the roster's search box earns its place, which is the honest test of the screen.
  */
 const HARBOR_SHOOTOUT: readonly FieldEntry[] = [
-  row("hs-1", "12", "M. Rivera", "Reel Deal", "Miss Ellie", { weight: 28.6, species: "Yellowtail", checkedIn: true }),
-  row("hs-2", "7", "J. Park", null, "Second Wind", { weight: 24.2, species: "Yellowtail", checkedIn: true }),
-  row("hs-3", "22", "A. Lewis", "Bluewater", "Bluewater", { weight: 21.9, species: "White seabass", checkedIn: true, awaitingReview: true }),
-  row("hs-4", "3", "D. Okafor", null, "Salt Habit", { weight: 19.4, species: "Yellowtail", checkedIn: true }),
+  row("hs-1", "12", "M. Rivera", "Reel Deal", "Miss Ellie", {
+    weight: 28.6,
+    species: "yellowtail",
+    checkedIn: true,
+    also: [
+      { species: "bluefin_tuna", weight: 22.4 },
+      { species: "dorado", weight: 11.2 },
+    ],
+  }),
+  row("hs-2", "7", "J. Park", null, "Second Wind", {
+    weight: 24.2,
+    species: "yellowtail",
+    checkedIn: true,
+    also: [{ species: "dorado", weight: 14.8 }],
+  }),
+  row("hs-3", "22", "A. Lewis", "Bluewater", "Bluewater", {
+    weight: 21.9,
+    species: "white_seabass",
+    checkedIn: true,
+    awaitingReview: true,
+  }),
+  row("hs-4", "3", "D. Okafor", null, "Salt Habit", {
+    weight: 19.4,
+    species: "yellowtail",
+    checkedIn: true,
+    also: [{ species: "bluefin_tuna", weight: 31.7 }],
+  }),
   row("hs-5", "18", "You", null, "Nauti Buoy", { weight: null, species: null, checkedIn: true, isYou: true }),
-  row("hs-6", "9", "T. Nguyen", null, "Calico Kid", { weight: 8.1, species: "Calico bass", checkedIn: true }),
-  row("hs-7", "14", "R. Delgado", "Tuna Tango", "Tuna Tango", { weight: 17.8, species: "Yellowtail", checkedIn: true }),
+  row("hs-6", "9", "T. Nguyen", null, "Calico Kid", { weight: 8.1, species: "kelp_bass", checkedIn: true }),
+  row("hs-7", "14", "R. Delgado", "Tuna Tango", "Tuna Tango", { weight: 17.8, species: "yellowtail", checkedIn: true }),
   row("hs-8", "5", "K. Mbeki", null, "Grey Ghost", { weight: null, species: null, checkedIn: true }),
-  row("hs-9", "27", "S. Whitfield", "Knot Working", "Knot Working", { weight: 11.3, species: "Bonito", checkedIn: true }),
+  row("hs-9", "27", "S. Whitfield", "Knot Working", "Knot Working", { weight: 11.3, species: "pacific_bonito", checkedIn: true }),
   row("hs-10", "31", "P. Andersen", null, "Fintastic", { weight: null, species: null, checkedIn: true }),
-  row("hs-11", "8", "L. Moreau", null, "Wave Dancer", { weight: 6.9, species: "Barracuda", checkedIn: true }),
+  row("hs-11", "8", "L. Moreau", null, "Wave Dancer", { weight: 6.9, species: "pacific_barracuda", checkedIn: true }),
   row("hs-12", "40", "C. Ferreira", "Hook, Line", "Sinker", { weight: null, species: null, checkedIn: false, registration: "PENDING", eligibility: "PENDING_REVIEW" }),
   row("hs-13", "—", "B. Osei", null, "Late Entry", { weight: null, species: null, checkedIn: false, registration: "WAITLISTED" }),
   row("hs-14", "16", "H. Tanaka", null, "Kuroshio", { weight: null, species: null, checkedIn: false, registration: "WITHDRAWN" }),
@@ -49,10 +72,10 @@ const YELLOWTAIL_OPEN: readonly FieldEntry[] = [
 
 /** A finished family event. Everything settled, everybody scored. */
 const CREW_CUP: readonly FieldEntry[] = [
-  row("cc-1", "1", "Sam", null, null, { weight: 17.2, species: "Lingcod", checkedIn: true, competition: "FINISHED" }),
-  row("cc-2", "2", "Dad", null, null, { weight: 15.8, species: "Lingcod", checkedIn: true, competition: "FINISHED" }),
-  row("cc-3", "3", "Ellie", null, null, { weight: 6.4, species: "Rockfish", checkedIn: true, competition: "FINISHED" }),
-  row("cc-4", "4", "You", null, null, { weight: 12.1, species: "Cabezon", checkedIn: true, competition: "FINISHED", isYou: true }),
+  row("cc-1", "1", "Sam", null, null, { weight: 17.2, species: "lingcod", checkedIn: true, competition: "FINISHED" }),
+  row("cc-2", "2", "Dad", null, null, { weight: 15.8, species: "lingcod", checkedIn: true, competition: "FINISHED" }),
+  row("cc-3", "3", "Ellie", null, null, { weight: 6.4, species: "rockfish", checkedIn: true, competition: "FINISHED" }),
+  row("cc-4", "4", "You", null, null, { weight: 12.1, species: "cabezon", checkedIn: true, competition: "FINISHED", isYou: true }),
 ];
 
 const FIELDS: Readonly<Record<string, readonly FieldEntry[]>> = {
@@ -76,6 +99,8 @@ function row(
     registration?: string;
     eligibility?: string;
     competition?: string;
+    /** Everything else this boat landed, beyond its best fish. */
+    also?: ReadonlyArray<{ species: string; weight: number }>;
   },
 ): FieldEntry {
   return {
@@ -92,6 +117,19 @@ function row(
     bestWeightLb: options.weight,
     species: options.species,
     awaitingReview: options.awaitingReview ?? false,
+    // The best fish is a catch like any other; `bestWeightLb` is a summary of this list,
+    // not a separate fact, so a category board and a roster row cannot disagree.
+    catches: [
+      ...(options.weight !== null
+        ? [{ id: `${entryId}-best`, speciesId: options.species, weightLb: options.weight, lengthIn: null }]
+        : []),
+      ...(options.also ?? []).map((item, index) => ({
+        id: `${entryId}-${index}`,
+        speciesId: item.species,
+        weightLb: item.weight,
+        lengthIn: null,
+      })),
+    ],
   };
 }
 
@@ -157,6 +195,7 @@ function withYourEntry(tournamentId: string, base: readonly FieldEntry[]): reado
       bestWeightLb: null,
       species: null,
       awaitingReview: false,
+      catches: [],
     },
   ];
 }

--- a/src/features/tournaments/demo-field.ts
+++ b/src/features/tournaments/demo-field.ts
@@ -1,0 +1,170 @@
+import { getDemoEntry } from "./demo-store";
+import type { FieldEntry } from "./field";
+
+/**
+ * The demo field: a tournament with real boats in it.
+ *
+ * The point of this file is that the roster, the board, the organizer's counts and the
+ * catch screen are all reading the *same* people. Before it existed the leaderboard had
+ * three invented names in it and no other screen had any, so nothing added up — which is
+ * the first thing anybody notices when they are being shown a product.
+ *
+ * Everything here is fictional and local to the device. Real fields come from
+ * `tournament_entry` joined to `tournament_team` / `tournament_boat`; this file has the
+ * same shape so the screens do not care which one they were handed.
+ */
+
+const CHECK_IN_KEY = "fish-log-book:demo-tournament-check-in";
+
+/**
+ * A mid-size offshore event: fourteen boats, one of them yours, a couple still waiting on
+ * the organizer, one waitlisted, and half of them already on the board. Big enough that
+ * the roster's search box earns its place, which is the honest test of the screen.
+ */
+const HARBOR_SHOOTOUT: readonly FieldEntry[] = [
+  row("hs-1", "12", "M. Rivera", "Reel Deal", "Miss Ellie", { weight: 28.6, species: "Yellowtail", checkedIn: true }),
+  row("hs-2", "7", "J. Park", null, "Second Wind", { weight: 24.2, species: "Yellowtail", checkedIn: true }),
+  row("hs-3", "22", "A. Lewis", "Bluewater", "Bluewater", { weight: 21.9, species: "White seabass", checkedIn: true, awaitingReview: true }),
+  row("hs-4", "3", "D. Okafor", null, "Salt Habit", { weight: 19.4, species: "Yellowtail", checkedIn: true }),
+  row("hs-5", "18", "You", null, "Nauti Buoy", { weight: null, species: null, checkedIn: true, isYou: true }),
+  row("hs-6", "9", "T. Nguyen", null, "Calico Kid", { weight: 8.1, species: "Calico bass", checkedIn: true }),
+  row("hs-7", "14", "R. Delgado", "Tuna Tango", "Tuna Tango", { weight: 17.8, species: "Yellowtail", checkedIn: true }),
+  row("hs-8", "5", "K. Mbeki", null, "Grey Ghost", { weight: null, species: null, checkedIn: true }),
+  row("hs-9", "27", "S. Whitfield", "Knot Working", "Knot Working", { weight: 11.3, species: "Bonito", checkedIn: true }),
+  row("hs-10", "31", "P. Andersen", null, "Fintastic", { weight: null, species: null, checkedIn: true }),
+  row("hs-11", "8", "L. Moreau", null, "Wave Dancer", { weight: 6.9, species: "Barracuda", checkedIn: true }),
+  row("hs-12", "40", "C. Ferreira", "Hook, Line", "Sinker", { weight: null, species: null, checkedIn: false, registration: "PENDING", eligibility: "PENDING_REVIEW" }),
+  row("hs-13", "—", "B. Osei", null, "Late Entry", { weight: null, species: null, checkedIn: false, registration: "WAITLISTED" }),
+  row("hs-14", "16", "H. Tanaka", null, "Kuroshio", { weight: null, species: null, checkedIn: false, registration: "WITHDRAWN" }),
+];
+
+/** A friend event that has not started: nobody scored, nobody checked in yet. */
+const YELLOWTAIL_OPEN: readonly FieldEntry[] = [
+  row("yt-1", "1", "M. Rivera", null, "Miss Ellie", { weight: null, species: null, checkedIn: false }),
+  row("yt-2", "2", "T. Nguyen", null, "Calico Kid", { weight: null, species: null, checkedIn: false }),
+  row("yt-3", "3", "S. Whitfield", null, null, { weight: null, species: null, checkedIn: false, registration: "PENDING" }),
+  row("yt-4", "4", "D. Okafor", null, "Salt Habit", { weight: null, species: null, checkedIn: false }),
+  row("yt-5", "5", "L. Moreau", null, null, { weight: null, species: null, checkedIn: false, eligibility: "PENDING_REVIEW" }),
+];
+
+/** A finished family event. Everything settled, everybody scored. */
+const CREW_CUP: readonly FieldEntry[] = [
+  row("cc-1", "1", "Sam", null, null, { weight: 17.2, species: "Lingcod", checkedIn: true, competition: "FINISHED" }),
+  row("cc-2", "2", "Dad", null, null, { weight: 15.8, species: "Lingcod", checkedIn: true, competition: "FINISHED" }),
+  row("cc-3", "3", "Ellie", null, null, { weight: 6.4, species: "Rockfish", checkedIn: true, competition: "FINISHED" }),
+  row("cc-4", "4", "You", null, null, { weight: 12.1, species: "Cabezon", checkedIn: true, competition: "FINISHED", isYou: true }),
+];
+
+const FIELDS: Readonly<Record<string, readonly FieldEntry[]>> = {
+  "demo-harbor-shootout": HARBOR_SHOOTOUT,
+  "demo-yellowtail-open": YELLOWTAIL_OPEN,
+  "demo-crew-cup": CREW_CUP,
+};
+
+function row(
+  entryId: string,
+  entryNumber: string,
+  displayName: string,
+  teamName: string | null,
+  boatName: string | null,
+  options: {
+    weight: number | null;
+    species: string | null;
+    checkedIn: boolean;
+    isYou?: boolean;
+    awaitingReview?: boolean;
+    registration?: string;
+    eligibility?: string;
+    competition?: string;
+  },
+): FieldEntry {
+  return {
+    entryId,
+    entryNumber: entryNumber === "—" ? null : entryNumber,
+    displayName,
+    teamName,
+    boatName,
+    registrationStatus: options.registration ?? "CONFIRMED",
+    eligibilityStatus: options.eligibility ?? "ELIGIBLE",
+    checkInStatus: options.checkedIn ? "CHECKED_IN" : "NOT_CHECKED_IN",
+    competitionStatus: options.competition ?? (options.checkedIn ? "ACTIVE" : "NOT_STARTED"),
+    isYou: options.isYou ?? false,
+    bestWeightLb: options.weight,
+    species: options.species,
+    awaitingReview: options.awaitingReview ?? false,
+  };
+}
+
+function readOverrides(): Record<string, string> {
+  if (typeof window === "undefined") return {};
+  try {
+    return JSON.parse(window.localStorage.getItem(CHECK_IN_KEY) ?? "{}") as Record<string, string>;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Check-in is the one thing on the roster a director actually changes during a demo, so it
+ * persists. Everything else about a demo entry is fixed — inventing a way to fake an
+ * eligibility decision would teach the wrong thing about who gets to make one.
+ */
+export function getDemoField(tournamentId: string): readonly FieldEntry[] {
+  const overrides = readOverrides();
+  const base = withYourEntry(tournamentId, FIELDS[tournamentId] ?? []);
+  return base.map((entry) => {
+    const override = overrides[`${tournamentId}:${entry.entryId}`];
+    if (!override) return entry;
+    return {
+      ...entry,
+      checkInStatus: override,
+      // Being on the water is what makes an entry active; the two move together at the
+      // ramp, and a roster that shows "checked in / not started" is just confusing.
+      competitionStatus:
+        override === "CHECKED_IN" && entry.competitionStatus === "NOT_STARTED"
+          ? "ACTIVE"
+          : entry.competitionStatus,
+    };
+  });
+}
+
+/**
+ * If you have entered this tournament on this device, you are in the field.
+ *
+ * Without this, entering a tournament and then opening "Who's in" shows everybody except
+ * you, which is the single most obvious way for a demo to look broken. Seeded events that
+ * already carry a "You" row are left alone.
+ */
+function withYourEntry(tournamentId: string, base: readonly FieldEntry[]): readonly FieldEntry[] {
+  if (base.some((entry) => entry.isYou)) return base;
+
+  const yours = getDemoEntry(tournamentId);
+  if (!yours) return base;
+
+  return [
+    ...base,
+    {
+      entryId: yours.id,
+      entryNumber: base.length > 0 ? String(base.length + 1) : "1",
+      displayName: yours.display_name,
+      teamName: null,
+      boatName: null,
+      registrationStatus: yours.registration_status,
+      eligibilityStatus: yours.eligibility_status,
+      checkInStatus: yours.check_in_status,
+      competitionStatus: yours.competition_status,
+      isYou: true,
+      bestWeightLb: null,
+      species: null,
+      awaitingReview: false,
+    },
+  ];
+}
+
+export function setDemoCheckIn(tournamentId: string, entryId: string, status: string): void {
+  if (typeof window === "undefined") return;
+  const overrides = readOverrides();
+  overrides[`${tournamentId}:${entryId}`] = status;
+  window.localStorage.setItem(CHECK_IN_KEY, JSON.stringify(overrides));
+}
+

--- a/src/features/tournaments/demo-store.ts
+++ b/src/features/tournaments/demo-store.ts
@@ -22,16 +22,6 @@ export type DemoEntry = {
   display_name: string;
 };
 
-/** A public-safe standings row: exactly the fields `core/tournaments/public-projection` allows. */
-export type DemoStanding = {
-  rank: number;
-  display_name: string;
-  species: string;
-  weight_lb: number;
-  /** Official once every review behind it is closed; provisional until then. */
-  official: boolean;
-};
-
 const TOURNAMENTS_KEY = "fish-log-book:demo-tournaments";
 const ENTRIES_KEY = "fish-log-book:demo-tournament-entries";
 
@@ -105,21 +95,6 @@ function seedTournaments(): DemoTournament[] {
     },
   ];
 }
-
-const SEED_STANDINGS: Readonly<Record<string, readonly DemoStanding[]>> = {
-  "demo-harbor-shootout": [
-    { rank: 1, display_name: "M. Rivera", species: "Yellowtail", weight_lb: 28.6, official: true },
-    { rank: 2, display_name: "J. Park", species: "Yellowtail", weight_lb: 24.2, official: true },
-    { rank: 3, display_name: "A. Lewis", species: "White seabass", weight_lb: 21.9, official: false },
-    { rank: 4, display_name: "D. Okafor", species: "Yellowtail", weight_lb: 19.4, official: true },
-    { rank: 5, display_name: "T. Nguyen", species: "Calico bass", weight_lb: 8.1, official: true },
-  ],
-  "demo-crew-cup": [
-    { rank: 1, display_name: "Sam", species: "Lingcod", weight_lb: 17.2, official: true },
-    { rank: 2, display_name: "Dad", species: "Lingcod", weight_lb: 15.8, official: true },
-    { rank: 3, display_name: "Ellie", species: "Rockfish", weight_lb: 6.4, official: true },
-  ],
-};
 
 export function hasSupabaseBrowserConfig(): boolean {
   return Boolean(
@@ -198,11 +173,3 @@ export function registerDemoEntry(tournamentId: string, displayName: string): De
   return entry;
 }
 
-/**
- * Standings for the seeded demo events only. A tournament the founder creates has no
- * standings, and inventing some would teach the wrong thing about where scores come from —
- * the empty leaderboard with "nothing has been scored yet" is the honest screen.
- */
-export function getDemoStandings(tournamentId: string): readonly DemoStanding[] {
-  return SEED_STANDINGS[tournamentId] ?? [];
-}

--- a/src/features/tournaments/entry-states.test.ts
+++ b/src/features/tournaments/entry-states.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ENTRY_STATE_TABLES } from "./format";
+
+/**
+ * The copy tables in `format.ts` are a second copy of the `check` constraints on
+ * `public.tournament_entry`, and two copies of anything drift. This reads the constraint
+ * out of the migration itself and fails when a state exists in the database that no screen
+ * knows how to say out loud.
+ *
+ * It is deliberately a test rather than a tripwire: a new entry state is a normal thing for
+ * the backend lane to add, and the right consequence is a failing test that says "give this
+ * one a sentence", not a blocked commit.
+ */
+
+const MIGRATION = path.join(
+  process.cwd(),
+  "supabase/migrations/20260905190000_tournament_registration.sql",
+);
+
+/**
+ * Scoped to the `tournament_entry` block first. `tournament_boat` lives in the same
+ * migration and has its own `registration_status` with a different set of values
+ * (`APPROVED` rather than `CONFIRMED`), so a file-wide search silently reads the boat's
+ * constraint and reports the wrong answer — which is what it did on the first run.
+ */
+function entryTableSql(sql: string): string {
+  const start = sql.indexOf("create table if not exists public.tournament_entry (");
+  if (start === -1) throw new Error("tournament_entry table not found. Has the migration moved?");
+  const end = sql.indexOf(");", start);
+  return sql.slice(start, end);
+}
+
+function constraintValues(sql: string, column: string): string[] {
+  const match = new RegExp(`${column} in \\(([^)]*)\\)`).exec(entryTableSql(sql));
+  if (!match) throw new Error(`No check constraint found for ${column}. Has the migration moved?`);
+  return [...match[1].matchAll(/'([^']+)'/g)].map((value) => value[1]);
+}
+
+describe("entry state copy", () => {
+  const sql = readFileSync(MIGRATION, "utf8");
+
+  for (const [column, table] of Object.entries(ENTRY_STATE_TABLES)) {
+    describe(column, () => {
+      const values = constraintValues(sql, column);
+
+      it("covers every state the database can store", () => {
+        const missing = values.filter((value) => !(value in table));
+        expect(missing, `no copy for ${column}: ${missing.join(", ")}`).toEqual([]);
+      });
+
+      it("invents no state the database cannot store", () => {
+        const extra = Object.keys(table).filter((key) => !values.includes(key));
+        expect(extra, `${column} has copy for states that do not exist: ${extra.join(", ")}`).toEqual(
+          [],
+        );
+      });
+
+      it("says something useful about each one", () => {
+        for (const [state, copy] of Object.entries(table)) {
+          expect(copy.value, state).not.toMatch(/_/);
+          expect(copy.hint.length, state).toBeGreaterThan(0);
+        }
+      });
+    });
+  }
+});

--- a/src/features/tournaments/field.test.ts
+++ b/src/features/tournaments/field.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+
+import { boardName, boardSubtitle, fieldSummary, rankField, searchField, type FieldEntry } from "./field";
+
+function entry(overrides: Partial<FieldEntry> & Pick<FieldEntry, "entryId" | "displayName">): FieldEntry {
+  return {
+    entryNumber: null,
+    teamName: null,
+    boatName: null,
+    registrationStatus: "CONFIRMED",
+    eligibilityStatus: "ELIGIBLE",
+    checkInStatus: "NOT_CHECKED_IN",
+    competitionStatus: "NOT_STARTED",
+    isYou: false,
+    bestWeightLb: null,
+    species: null,
+    awaitingReview: false,
+    ...overrides,
+  };
+}
+
+describe("fieldSummary", () => {
+  it("does not count withdrawn, rejected or cancelled entries as part of the field", () => {
+    const summary = fieldSummary([
+      entry({ entryId: "1", displayName: "A" }),
+      entry({ entryId: "2", displayName: "B", registrationStatus: "WITHDRAWN" }),
+      entry({ entryId: "3", displayName: "C", registrationStatus: "REJECTED" }),
+      entry({ entryId: "4", displayName: "D", registrationStatus: "CANCELLED" }),
+    ]);
+    expect(summary.entered).toBe(1);
+  });
+
+  it("counts places, check-ins and who is on the board separately", () => {
+    const summary = fieldSummary([
+      entry({ entryId: "1", displayName: "A", checkInStatus: "CHECKED_IN", bestWeightLb: 12 }),
+      entry({ entryId: "2", displayName: "B", checkInStatus: "CHECKED_IN" }),
+      entry({ entryId: "3", displayName: "C", registrationStatus: "WAITLISTED" }),
+      entry({ entryId: "4", displayName: "D", registrationStatus: "PENDING" }),
+    ]);
+    expect(summary).toMatchObject({
+      entered: 4,
+      confirmed: 2,
+      waitlisted: 1,
+      checkedIn: 2,
+      onTheBoard: 1,
+      needsAttention: 1,
+    });
+  });
+
+  it("flags an unanswered eligibility question as needing attention", () => {
+    const summary = fieldSummary([
+      entry({ entryId: "1", displayName: "A", eligibilityStatus: "PENDING_REVIEW" }),
+      entry({ entryId: "2", displayName: "B", eligibilityStatus: "INELIGIBLE" }),
+      entry({ entryId: "3", displayName: "C", eligibilityStatus: "UNKNOWN" }),
+    ]);
+    expect(summary.needsAttention).toBe(2);
+  });
+});
+
+describe("searchField", () => {
+  const field = [
+    entry({ entryId: "1", displayName: "M. Rivera", teamName: "Reel Deal", boatName: "Miss Ellie", entryNumber: "12" }),
+    entry({ entryId: "2", displayName: "J. Park", boatName: "Second Wind", entryNumber: "7" }),
+  ];
+
+  it("finds an entry by the boat, the team, the person, or the number on the hull", () => {
+    expect(searchField(field, "miss ellie")).toHaveLength(1);
+    expect(searchField(field, "reel")).toHaveLength(1);
+    expect(searchField(field, "park")).toHaveLength(1);
+    expect(searchField(field, "12")).toHaveLength(1);
+  });
+
+  it("returns the whole field for an empty query", () => {
+    expect(searchField(field, "   ")).toHaveLength(2);
+  });
+});
+
+describe("rankField", () => {
+  it("ranks by weight, heaviest first", () => {
+    const ranked = rankField([
+      entry({ entryId: "1", displayName: "A", bestWeightLb: 12 }),
+      entry({ entryId: "2", displayName: "B", bestWeightLb: 28.6 }),
+      entry({ entryId: "3", displayName: "C", bestWeightLb: 19 }),
+    ]);
+    expect(ranked.map((row) => [row.displayName, row.rank])).toEqual([
+      ["B", 1],
+      ["C", 2],
+      ["A", 3],
+    ]);
+  });
+
+  it("shares a place on a tie and skips the next one", () => {
+    const ranked = rankField([
+      entry({ entryId: "1", displayName: "A", bestWeightLb: 20 }),
+      entry({ entryId: "2", displayName: "B", bestWeightLb: 20 }),
+      entry({ entryId: "3", displayName: "C", bestWeightLb: 10 }),
+    ]);
+    expect(ranked.map((row) => row.rank)).toEqual([1, 1, 3]);
+    expect(ranked.map((row) => row.tied)).toEqual([true, true, false]);
+  });
+
+  it("leaves an entry with nothing scored off the board rather than ranking it last", () => {
+    const ranked = rankField([
+      entry({ entryId: "1", displayName: "A", bestWeightLb: 20 }),
+      entry({ entryId: "2", displayName: "B" }),
+    ]);
+    expect(ranked).toHaveLength(1);
+  });
+
+  it("does not rank an entry that is out of the tournament", () => {
+    const ranked = rankField([
+      entry({ entryId: "1", displayName: "A", bestWeightLb: 20, registrationStatus: "WITHDRAWN" }),
+      entry({ entryId: "2", displayName: "B", bestWeightLb: 10 }),
+    ]);
+    expect(ranked.map((row) => row.displayName)).toEqual(["B"]);
+  });
+});
+
+describe("board naming", () => {
+  it("leads with the team, then the boat, then the person", () => {
+    expect(boardName(entry({ entryId: "1", displayName: "M. Rivera", teamName: "Reel Deal", boatName: "Miss Ellie" }))).toBe("Reel Deal");
+    expect(boardName(entry({ entryId: "1", displayName: "M. Rivera", boatName: "Miss Ellie" }))).toBe("Miss Ellie");
+    expect(boardName(entry({ entryId: "1", displayName: "M. Rivera" }))).toBe("M. Rivera");
+  });
+
+  it("does not repeat a boat name that is also the team name", () => {
+    expect(
+      boardSubtitle(entry({ entryId: "1", displayName: "A. Lewis", teamName: "Bluewater", boatName: "Bluewater" })),
+    ).toBe("A. Lewis");
+  });
+
+  it("never repeats the headline in the line under it", () => {
+    expect(boardSubtitle(entry({ entryId: "1", displayName: "M. Rivera", teamName: "Reel Deal", boatName: "Miss Ellie" }))).toBe(
+      "Miss Ellie · M. Rivera",
+    );
+    expect(boardSubtitle(entry({ entryId: "1", displayName: "M. Rivera", boatName: "Miss Ellie" }))).toBe("M. Rivera");
+    expect(boardSubtitle(entry({ entryId: "1", displayName: "M. Rivera" }))).toBeNull();
+  });
+});

--- a/src/features/tournaments/field.test.ts
+++ b/src/features/tournaments/field.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it } from "vitest";
 
-import { boardName, boardSubtitle, fieldSummary, rankField, searchField, type FieldEntry } from "./field";
+import { emptyCategory } from "@/core/tournaments/formats";
+import {
+  boardName,
+  boardSubtitle,
+  fieldSummary,
+  rankField,
+  scoreboardFor,
+  scoreLabel,
+  searchField,
+  speciesName,
+  type FieldEntry,
+} from "./field";
 
 function entry(overrides: Partial<FieldEntry> & Pick<FieldEntry, "entryId" | "displayName">): FieldEntry {
   return {
@@ -15,6 +26,7 @@ function entry(overrides: Partial<FieldEntry> & Pick<FieldEntry, "entryId" | "di
     bestWeightLb: null,
     species: null,
     awaitingReview: false,
+    catches: [],
     ...overrides,
   };
 }
@@ -135,5 +147,82 @@ describe("board naming", () => {
     );
     expect(boardSubtitle(entry({ entryId: "1", displayName: "M. Rivera", boatName: "Miss Ellie" }))).toBe("M. Rivera");
     expect(boardSubtitle(entry({ entryId: "1", displayName: "M. Rivera" }))).toBeNull();
+  });
+});
+
+describe("scoreboardFor", () => {
+  const marlin = {
+    ...emptyCategory("marlin", "Biggest marlin"),
+    species: ["blue_marlin"],
+  };
+  const tuna = {
+    ...emptyCategory("tuna", "Biggest tuna"),
+    species: ["bluefin_tuna"],
+  };
+
+  const field = [
+    entry({
+      entryId: "e1",
+      displayName: "Reel Deal",
+      catches: [
+        { id: "a", speciesId: "blue_marlin", weightLb: 220, lengthIn: null },
+        { id: "b", speciesId: "bluefin_tuna", weightLb: 40, lengthIn: null },
+      ],
+    }),
+    entry({
+      entryId: "e2",
+      displayName: "Second Wind",
+      catches: [{ id: "c", speciesId: "bluefin_tuna", weightLb: 96, lengthIn: null }],
+    }),
+  ];
+
+  it("gives each category its own board out of the same field", () => {
+    expect(scoreboardFor(field, marlin).map((row) => row.displayName)).toEqual(["Reel Deal"]);
+    expect(scoreboardFor(field, tuna).map((row) => row.displayName)).toEqual([
+      "Second Wind",
+      "Reel Deal",
+    ]);
+  });
+
+  it("returns the score in pounds, not the grams the scorer works in", () => {
+    const [top] = scoreboardFor(field, tuna);
+    expect(top.score).toBeCloseTo(96, 1);
+  });
+
+  it("scores a points category on the host's table rather than on weight", () => {
+    const points = {
+      ...emptyCategory("points", "Points"),
+      family: "SPECIES_POINTS" as const,
+      speciesPoints: { blue_marlin: 10, bluefin_tuna: 3 },
+    };
+    const board = scoreboardFor(field, points);
+    expect(board.map((row) => [row.displayName, row.score])).toEqual([
+      ["Reel Deal", 13],
+      ["Second Wind", 3],
+    ]);
+  });
+
+  it("leaves a boat with nothing eligible off the category's board", () => {
+    const dorado = { ...emptyCategory("dorado", "Biggest dorado"), species: ["dorado"] };
+    expect(scoreboardFor(field, dorado)).toEqual([]);
+  });
+});
+
+describe("scoreLabel", () => {
+  it("uses the unit the category is actually scored in", () => {
+    expect(scoreLabel(emptyCategory("a", "A"), 28.64)).toBe("28.6 lb");
+    expect(
+      scoreLabel({ ...emptyCategory("a", "A"), family: "SPECIES_POINTS" }, 13),
+    ).toBe("13 pts");
+    expect(
+      scoreLabel({ ...emptyCategory("a", "A"), family: "BIGGEST_LENGTH" }, 34.5),
+    ).toBe("34.5 in");
+  });
+});
+
+describe("speciesName", () => {
+  it("prints the name an angler uses, not the id the database stores", () => {
+    expect(speciesName("bluefin_tuna")).toBe("Bluefin tuna");
+    expect(speciesName(null)).toBeNull();
   });
 });

--- a/src/features/tournaments/field.ts
+++ b/src/features/tournaments/field.ts
@@ -1,0 +1,157 @@
+/**
+ * The field: who is fishing, and where they stand.
+ *
+ * One shape, used by the roster, the standings board and the organizer's counts, so those
+ * three screens cannot disagree about how many boats are in or who is leading. Before this
+ * existed the leaderboard had its own hardcoded names and the roster did not exist at all,
+ * which is exactly the shape of the bug where a director reads "14 entries" on one screen
+ * and counts 12 rows on the next.
+ *
+ * Pure: no React, no storage, no clock. The demo data and the Supabase reads both produce
+ * `FieldEntry[]` and everything below works the same on either.
+ *
+ * Field names mirror `public.tournament_entry`, `tournament_team` and `tournament_boat`
+ * rather than inventing a parallel vocabulary (UX-001 §15: "UX implementation agents must
+ * consume stabilized contracts rather than create competing domain types").
+ */
+
+export interface FieldEntry {
+  readonly entryId: string;
+  /** The number pinned to the boat. Optional in the schema, so optional here. */
+  readonly entryNumber: string | null;
+  readonly displayName: string;
+  readonly teamName: string | null;
+  readonly boatName: string | null;
+  readonly registrationStatus: string;
+  readonly eligibilityStatus: string;
+  readonly checkInStatus: string;
+  readonly competitionStatus: string;
+  /** The signed-in angler's own entry, so a roster of eighty can still find you. */
+  readonly isYou: boolean;
+  /**
+   * The best approved weight for this entry, in pounds. `null` means nothing of theirs has
+   * been scored yet — which is not the same as zero, and is never rendered as "0.0 lb".
+   */
+  readonly bestWeightLb: number | null;
+  readonly species: string | null;
+  /** Their best catch is logged but a judge has not closed it out. */
+  readonly awaitingReview: boolean;
+}
+
+export interface FieldSummary {
+  /** Entries that are not withdrawn, rejected or cancelled — the real size of the field. */
+  readonly entered: number;
+  readonly confirmed: number;
+  readonly waitlisted: number;
+  readonly checkedIn: number;
+  /** Entries with at least one scored catch. */
+  readonly onTheBoard: number;
+  readonly needsAttention: number;
+}
+
+const OUT_OF_THE_FIELD = new Set(["REJECTED", "WITHDRAWN", "CANCELLED"]);
+
+/** True for an entry that still counts as part of the tournament. */
+export function isInTheField(entry: FieldEntry): boolean {
+  return !OUT_OF_THE_FIELD.has(entry.registrationStatus);
+}
+
+export function fieldSummary(field: readonly FieldEntry[]): FieldSummary {
+  const live = field.filter(isInTheField);
+  return {
+    entered: live.length,
+    confirmed: live.filter((entry) => entry.registrationStatus === "CONFIRMED").length,
+    waitlisted: live.filter((entry) => entry.registrationStatus === "WAITLISTED").length,
+    checkedIn: live.filter((entry) => entry.checkInStatus === "CHECKED_IN").length,
+    onTheBoard: live.filter((entry) => entry.bestWeightLb !== null).length,
+    // What an organizer has to do something about before lines in: a place still pending,
+    // or an eligibility question nobody has answered.
+    needsAttention: live.filter(
+      (entry) =>
+        entry.registrationStatus === "PENDING" ||
+        entry.eligibilityStatus === "INELIGIBLE" ||
+        entry.eligibilityStatus === "PENDING_REVIEW",
+    ).length,
+  };
+}
+
+/**
+ * Search across every name a person might type: the angler, the team, the boat, or the
+ * number on the side of it. A director looking for "Miss Ellie" at a weigh-in should not
+ * have to remember whose boat it is.
+ */
+export function searchField(field: readonly FieldEntry[], query: string): FieldEntry[] {
+  const needle = query.trim().toLowerCase();
+  if (needle.length === 0) return [...field];
+
+  return field.filter((entry) =>
+    [entry.displayName, entry.teamName, entry.boatName, entry.entryNumber]
+      .filter((value): value is string => typeof value === "string")
+      .some((value) => value.toLowerCase().includes(needle)),
+  );
+}
+
+export interface RankedEntry extends FieldEntry {
+  readonly rank: number;
+  /** True when this entry shares its rank with another. */
+  readonly tied: boolean;
+}
+
+/**
+ * Standard competition ranking: equal weights share a place and the next place skips
+ * (1, 2, 2, 4). Two boats on the same fish is an ordinary Saturday, and quietly ordering
+ * one above the other by whichever row the database returned first is how a tournament
+ * ends in an argument.
+ *
+ * Entries with nothing scored are not ranked at all — they are not last, they are simply
+ * not on the board yet, and the roster is where they appear.
+ *
+ * This is presentation-side ranking over already-approved catches, for a board that has to
+ * paint on a phone with no signal. Official standings stay server-authoritative
+ * (`core/tournaments/official-scoring.ts`); when the server sends its own `standing` rows,
+ * those win and this is not consulted.
+ */
+export function rankField(field: readonly FieldEntry[]): RankedEntry[] {
+  const scored = field
+    .filter((entry) => isInTheField(entry) && entry.bestWeightLb !== null)
+    .sort((a, b) => (b.bestWeightLb ?? 0) - (a.bestWeightLb ?? 0));
+
+  const ranked: RankedEntry[] = [];
+  let previousWeight: number | null = null;
+  let previousRank = 0;
+
+  scored.forEach((entry, index) => {
+    const weight = entry.bestWeightLb ?? 0;
+    const rank = weight === previousWeight ? previousRank : index + 1;
+    ranked.push({ ...entry, rank, tied: false });
+    previousWeight = weight;
+    previousRank = rank;
+  });
+
+  // A tie is only visible once the whole list exists, so it is marked in a second pass
+  // rather than guessed at during the first.
+  const counts = new Map<number, number>();
+  for (const entry of ranked) counts.set(entry.rank, (counts.get(entry.rank) ?? 0) + 1);
+  return ranked.map((entry) => ({ ...entry, tied: (counts.get(entry.rank) ?? 0) > 1 }));
+}
+
+/** How an entry is named on a board: the boat if there is one, otherwise the person. */
+export function boardName(entry: FieldEntry): string {
+  return entry.teamName ?? entry.boatName ?? entry.displayName;
+}
+
+/**
+ * The second line under it — who is aboard, without repeating the first line.
+ *
+ * A team and its boat very often share a name ("Bluewater" fishing off *Bluewater*), so
+ * the boat is dropped when it would just say the headline again.
+ */
+export function boardSubtitle(entry: FieldEntry): string | null {
+  const headline = boardName(entry);
+  const parts = [
+    entry.boatName === headline ? null : entry.boatName,
+    entry.displayName === headline ? null : entry.displayName,
+  ];
+  const kept = parts.filter((value): value is string => Boolean(value));
+  return kept.length > 0 ? kept.join(" · ") : null;
+}

--- a/src/features/tournaments/field.ts
+++ b/src/features/tournaments/field.ts
@@ -1,3 +1,11 @@
+import { speciesById } from "@/core/ontology/species";
+import { catchesIn, scoreRuleFor, type FormatCategory } from "@/core/tournaments/formats";
+import {
+  computeOfficialStandings,
+  type EligibleCatch,
+  type ScoringFamily,
+} from "@/core/tournaments/official-scoring";
+
 /**
  * The field: who is fishing, and where they stand.
  *
@@ -14,6 +22,14 @@
  * rather than inventing a parallel vocabulary (UX-001 §15: "UX implementation agents must
  * consume stabilized contracts rather than create competing domain types").
  */
+
+/** One fish an entry landed, in the units the app records them in. */
+export interface FieldCatch {
+  readonly id: string;
+  readonly speciesId: string | null;
+  readonly weightLb: number | null;
+  readonly lengthIn: number | null;
+}
 
 export interface FieldEntry {
   readonly entryId: string;
@@ -36,6 +52,12 @@ export interface FieldEntry {
   readonly species: string | null;
   /** Their best catch is logged but a judge has not closed it out. */
   readonly awaitingReview: boolean;
+  /**
+   * Every scored catch, which is what a category with its own species list has to look at.
+   * A boat's *best* fish is not enough once a tournament has a marlin category and a tuna
+   * category: the best fish belongs to one of them and the other needs the rest of the list.
+   */
+  readonly catches: readonly FieldCatch[];
 }
 
 export interface FieldSummary {
@@ -154,4 +176,119 @@ export function boardSubtitle(entry: FieldEntry): string | null {
   ];
   const kept = parts.filter((value): value is string => Boolean(value));
   return kept.length > 0 ? kept.join(" · ") : null;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Scoring a category                                                          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * One entry's place in one category.
+ *
+ * `score` is in the category's own unit — pounds for a weight family, points for a points
+ * family, inches for a length one — and `scoreLabel` is the only thing that should print it,
+ * so a points total never arrives on a board with "lb" after it.
+ */
+export interface CategoryStanding extends RankedEntry {
+  readonly score: number;
+}
+
+const GRAMS_PER_POUND = 453.59237;
+const MM_PER_INCH = 25.4;
+
+function unitOf(family: ScoringFamily): "weight" | "length" | "points" {
+  switch (family) {
+    case "BIGGEST_FISH":
+    case "TOTAL_WEIGHT":
+    case "BEST_N_WEIGHT":
+      return "weight";
+    case "TOTAL_LENGTH":
+    case "BIGGEST_LENGTH":
+      return "length";
+    default:
+      return "points";
+  }
+}
+
+/**
+ * The board for one category, scored through `core/tournaments/official-scoring.ts`.
+ *
+ * The catches are converted into the scorer's units (grams, millimetres) and the result is
+ * converted back, rather than the scorer being handed pounds in a field named `weightG`.
+ * That shortcut would work perfectly and be wrong the first time anybody else read it.
+ *
+ * This is the on-device board, computed from approved catches so it can paint with no
+ * signal. Official standings remain the server's (`standing` rows); where those exist they
+ * win and this is not consulted.
+ */
+export function scoreboardFor(
+  field: readonly FieldEntry[],
+  category: FormatCategory,
+): CategoryStanding[] {
+  const contenders = field.filter(isInTheField);
+  const unit = unitOf(category.family);
+
+  const catches: EligibleCatch[] = contenders.flatMap((entry) =>
+    catchesIn(category, toEligible(entry)).map((item) => item),
+  );
+
+  const standings = computeOfficialStandings(
+    contenders.map((entry) => entry.entryId),
+    catches,
+    [],
+    scoreRuleFor(category),
+  );
+
+  const byId = new Map(contenders.map((entry) => [entry.entryId, entry]));
+
+  return standings
+    .filter((row) => row.score > 0)
+    .map((row) => {
+      const entry = byId.get(row.entryId)!;
+      const score =
+        unit === "weight"
+          ? row.score / GRAMS_PER_POUND
+          : unit === "length"
+            ? row.score / MM_PER_INCH
+            : row.score;
+      return { ...entry, rank: row.rank, tied: false, score };
+    })
+    .map((row, _index, all) => ({
+      ...row,
+      tied: all.filter((other) => other.rank === row.rank).length > 1,
+    }));
+}
+
+/** An entry's catches in the shape the official scorer reads. */
+function toEligible(entry: FieldEntry): EligibleCatch[] {
+  return entry.catches.map((item) => ({
+    id: item.id,
+    entryId: entry.entryId,
+    speciesId: item.speciesId,
+    weightG: item.weightLb === null ? null : Math.round(item.weightLb * GRAMS_PER_POUND),
+    lengthMm: item.lengthIn === null ? null : Math.round(item.lengthIn * MM_PER_INCH),
+    approved: true,
+    disqualified: false,
+  }));
+}
+
+/**
+ * A species id as a person reads it. Ids are the ontology's (`bluefin_tuna`), and printing
+ * one raw on a board is the same class of mistake as printing a lifecycle enum.
+ */
+export function speciesName(id: string | null): string | null {
+  if (id === null) return null;
+  return speciesById(id)?.commonName ?? id;
+}
+
+/** A score with its unit, so a points total never gets "lb" printed after it. */
+export function scoreLabel(category: FormatCategory, score: number): string {
+  switch (unitOf(category.family)) {
+    case "weight":
+      return `${score.toFixed(1)} lb`;
+    case "length":
+      return `${score.toFixed(1)} in`;
+    default:
+      return `${Math.round(score)} pts`;
+  }
 }

--- a/src/features/tournaments/format-store.ts
+++ b/src/features/tournaments/format-store.ts
@@ -1,0 +1,107 @@
+import { parseFormat, type TournamentFormat } from "@/core/tournaments/formats";
+
+/**
+ * Where a format lives on a device with no tournament server.
+ *
+ * The production path is `save_tournament_format`, which appends a scoring version and
+ * mirrors its categories; this is the same document written to `localStorage` so the
+ * founder can build and run a whole tournament on a phone before Supabase is connected.
+ * Both hand back the same `TournamentFormat`, and every screen reads it through
+ * `use-format.ts` without knowing which one it got.
+ */
+
+const KEY = "fish-log-book:demo-tournament-format";
+
+/**
+ * Formats for the seeded demo events, so the three shapes a host can build are all visible
+ * without creating anything: a multi-category offshore event, a species-points event, and a
+ * plain heaviest-fish one. A format the founder saves over the top of these wins, because
+ * stored values are read first.
+ */
+const SEED: Readonly<Record<string, TournamentFormat>> = {
+  "demo-harbor-shootout": {
+    currency: "USD",
+    categories: [
+      {
+        id: "yellowtail",
+        name: "Biggest yellowtail",
+        family: "BIGGEST_FISH",
+        species: ["yellowtail"],
+        speciesPoints: {},
+        bestN: null,
+        payout: { model: "PLACES", split: [50, 30, 20] },
+        entryFeeMinor: 25_000,
+      },
+      {
+        id: "tuna",
+        name: "Biggest tuna",
+        family: "BIGGEST_FISH",
+        species: ["bluefin_tuna", "yellowfin_tuna", "bigeye_tuna"],
+        speciesPoints: {},
+        bestN: null,
+        payout: { model: "WINNER_TAKE_ALL", split: [] },
+        entryFeeMinor: 25_000,
+      },
+      {
+        id: "dorado",
+        name: "Biggest dorado",
+        family: "BIGGEST_FISH",
+        species: ["dorado"],
+        speciesPoints: {},
+        bestN: null,
+        payout: { model: "WINNER_TAKE_ALL", split: [] },
+        entryFeeMinor: 10_000,
+      },
+    ],
+  },
+  "demo-yellowtail-open": {
+    currency: "USD",
+    categories: [
+      {
+        id: "points",
+        name: "Points",
+        family: "SPECIES_POINTS",
+        species: [],
+        speciesPoints: { yellowtail: 8, white_seabass: 8, kelp_bass: 2, pacific_bonito: 1, pacific_barracuda: 1 },
+        bestN: null,
+        payout: { model: "WINNER_TAKE_ALL", split: [] },
+        entryFeeMinor: null,
+      },
+    ],
+  },
+  "demo-crew-cup": {
+    currency: "USD",
+    categories: [
+      {
+        id: "overall",
+        name: "Heaviest fish",
+        family: "BIGGEST_FISH",
+        species: [],
+        speciesPoints: {},
+        bestN: null,
+        payout: { model: "NONE", split: [] },
+        entryFeeMinor: null,
+      },
+    ],
+  },
+};
+
+function readAll(): Record<string, unknown> {
+  if (typeof window === "undefined") return {};
+  try {
+    return JSON.parse(window.localStorage.getItem(KEY) ?? "{}") as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+export function getDemoFormat(tournamentId: string): TournamentFormat | null {
+  return parseFormat(readAll()[tournamentId]) ?? SEED[tournamentId] ?? null;
+}
+
+export function saveDemoFormat(tournamentId: string, format: TournamentFormat): void {
+  if (typeof window === "undefined") return;
+  const all = readAll();
+  all[tournamentId] = format;
+  window.localStorage.setItem(KEY, JSON.stringify(all));
+}

--- a/src/features/tournaments/format.ts
+++ b/src/features/tournaments/format.ts
@@ -343,36 +343,61 @@ export interface EntryStep {
   readonly hint: string;
 }
 
+/**
+ * The four tables below are the exact `check` constraints on `public.tournament_entry`
+ * (`20260905190000_tournament_registration.sql`), and `entry-states.test.ts` fails if they
+ * ever drift apart.
+ *
+ * They did drift, immediately: the first version of this file invented `DRAFT`,
+ * `SUBMITTED`, `PAYMENT_REQUIRED`, `ACTION_REQUIRED` and `MISSED` from the UX contract's
+ * prose, and missed `REJECTED`, `WITHDRAWN`, `CHECKED_OUT`, `PENDING_REVIEW`, `PAUSED` and
+ * `FINISHED`, which are real states the database can hand us. Nothing broke loudly — the
+ * fallback title-cases whatever it does not know — but "Withdrawn" would have reached an
+ * angler as neutral grey with no explanation, which is precisely the failure this file was
+ * written to prevent.
+ *
+ * Note what is *not* here: a payment state. Money lives in its own domain
+ * (`payment`, `payment_allocation`, `tournament_order`), deliberately, so that paying
+ * cannot silently confirm a place and a confirmed place cannot imply anyone has paid.
+ */
 const REGISTRATION: Readonly<Record<string, Omit<EntryStep, "label">>> = {
-  DRAFT: { value: "Not finished", tone: "attention", hint: "Your entry has not been submitted yet." },
   PENDING: { value: "Submitted", tone: "neutral", hint: "Waiting on the organizer to confirm your place." },
-  SUBMITTED: { value: "Submitted", tone: "neutral", hint: "Waiting on the organizer to confirm your place." },
-  PAYMENT_REQUIRED: { value: "Payment needed", tone: "attention", hint: "Your place is held until the entry fee is paid." },
   CONFIRMED: { value: "Confirmed", tone: "open", hint: "You are in." },
-  WAITLISTED: { value: "Waitlisted", tone: "attention", hint: "You are next in line if a place opens." },
-  CANCELLED: { value: "Cancelled", tone: "stopped", hint: "This entry has been withdrawn." },
+  WAITLISTED: { value: "Waitlisted", tone: "attention", hint: "You are next in line if a place opens up." },
+  REJECTED: { value: "Not accepted", tone: "stopped", hint: "The organizer did not take this entry. They can tell you why." },
+  WITHDRAWN: { value: "Withdrawn", tone: "stopped", hint: "This entry was pulled out of the tournament." },
+  CANCELLED: { value: "Cancelled", tone: "stopped", hint: "This entry no longer stands." },
 };
 
 const ELIGIBILITY: Readonly<Record<string, Omit<EntryStep, "label">>> = {
-  UNKNOWN: { value: "Not checked yet", tone: "neutral", hint: "The organizer has not run eligibility on this entry." },
-  PENDING: { value: "Being checked", tone: "neutral", hint: "The organizer is reviewing your details." },
+  UNKNOWN: { value: "Not checked yet", tone: "neutral", hint: "The organizer has not looked at eligibility for this entry." },
+  PENDING_REVIEW: { value: "Being checked", tone: "neutral", hint: "The organizer is going through your details." },
   ELIGIBLE: { value: "Eligible", tone: "open", hint: "You meet the rules for this event." },
-  ACTION_REQUIRED: { value: "Needs something from you", tone: "attention", hint: "The organizer has asked for more information." },
   INELIGIBLE: { value: "Not eligible", tone: "stopped", hint: "Ask the organizer what would change this." },
 };
 
 const CHECK_IN: Readonly<Record<string, Omit<EntryStep, "label">>> = {
-  NOT_CHECKED_IN: { value: "Not checked in", tone: "neutral", hint: "Check in at the ramp before lines in." },
+  NOT_CHECKED_IN: { value: "Not checked in", tone: "neutral", hint: "Check in with the organizer before lines in." },
   CHECKED_IN: { value: "Checked in", tone: "open", hint: "The organizer has you on the water." },
-  MISSED: { value: "Missed check-in", tone: "attention", hint: "Talk to the organizer before you fish." },
+  CHECKED_OUT: { value: "Checked out", tone: "neutral", hint: "You are back in and off the water." },
 };
 
 const COMPETITION: Readonly<Record<string, Omit<EntryStep, "label">>> = {
   NOT_STARTED: { value: "Not started", tone: "neutral", hint: "Nothing counts until the tournament goes live." },
   ACTIVE: { value: "Fishing", tone: "live", hint: "Your catches are counting." },
+  PAUSED: { value: "Paused", tone: "attention", hint: "Fishing is stopped for now. Anything logged while paused needs a judge." },
+  FINISHED: { value: "Finished", tone: "done", hint: "Your fishing is done. Scoring may still be running." },
   WITHDRAWN: { value: "Withdrawn", tone: "stopped", hint: "You are no longer being scored." },
   DISQUALIFIED: { value: "Disqualified", tone: "stopped", hint: "A judge has recorded a reason for this." },
 };
+
+/** Exported so the drift test can walk them against the migration's check constraints. */
+export const ENTRY_STATE_TABLES = {
+  registration_status: REGISTRATION,
+  eligibility_status: ELIGIBILITY,
+  check_in_status: CHECK_IN,
+  competition_status: COMPETITION,
+} as const;
 
 function step(
   label: string,

--- a/src/features/tournaments/use-field.ts
+++ b/src/features/tournaments/use-field.ts
@@ -1,0 +1,141 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { createClient } from "@/lib/supabase/client";
+import { hasSupabaseBrowserConfig } from "./demo-store";
+import { getDemoField } from "./demo-field";
+import type { FieldEntry } from "./field";
+
+/**
+ * Loads the field for a tournament — the roster, the board and the counts all come through
+ * here so they cannot disagree.
+ *
+ * Two sources, one shape. On a device with no Supabase configured it is the seeded demo
+ * field; otherwise it is `tournament_entry` with the team, the boat and the entrant's
+ * display name embedded. Both hand back `FieldEntry[]` and nothing downstream knows which
+ * it got.
+ */
+
+export type FieldLoad =
+  | { readonly state: "loading" }
+  | { readonly state: "error"; readonly message: string }
+  | { readonly state: "ready"; readonly field: readonly FieldEntry[] };
+
+/**
+ * PostgREST embeds, so one round trip rather than four. `tournament_entry_identity` is a
+ * list because an entry can carry more than one claim over its life (a guest who later
+ * signs up); the first is the one shown.
+ */
+const FIELD_SELECT = `
+  id,
+  entry_number,
+  registration_status,
+  eligibility_status,
+  check_in_status,
+  competition_status,
+  tournament_team ( name ),
+  tournament_boat ( boat ( name ) ),
+  tournament_entry_identity ( display_name, claimed_angler_id )
+`;
+
+interface EntryRow {
+  id: string;
+  entry_number: string | null;
+  registration_status: string;
+  eligibility_status: string;
+  check_in_status: string;
+  competition_status: string;
+  tournament_team: { name: string } | null;
+  tournament_boat: { boat: { name: string } | null } | null;
+  tournament_entry_identity: Array<{ display_name: string; claimed_angler_id: string | null }> | null;
+}
+
+function toFieldEntry(row: EntryRow, viewerId: string | null): FieldEntry {
+  const identity = row.tournament_entry_identity?.[0] ?? null;
+  return {
+    entryId: row.id,
+    entryNumber: row.entry_number,
+    // An entry always has an identity in practice, but the join can come back empty while
+    // one is being created, and a roster row reading "undefined" is worse than one reading
+    // "Entry 12".
+    displayName: identity?.display_name ?? (row.entry_number ? `Entry ${row.entry_number}` : "Entry"),
+    teamName: row.tournament_team?.name ?? null,
+    boatName: row.tournament_boat?.boat?.name ?? null,
+    registrationStatus: row.registration_status,
+    eligibilityStatus: row.eligibility_status,
+    checkInStatus: row.check_in_status,
+    competitionStatus: row.competition_status,
+    isYou: viewerId !== null && identity?.claimed_angler_id === viewerId,
+    // Weights come from approved catches and scored standings, not from the entry row.
+    // Until the scoring service is wired, the server-backed board is honestly empty rather
+    // than filled in from something that is not a score.
+    bestWeightLb: null,
+    species: null,
+    awaitingReview: false,
+  };
+}
+
+export function useField(tournamentId: string): FieldLoad & { readonly reload: () => void } {
+  const [load, setLoad] = useState<FieldLoad>({ state: "loading" });
+  const [token, setToken] = useState(0);
+
+  const reload = useCallback(() => setToken((value) => value + 1), []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      // Yield before the first setState — `localStorage` is not there during the server
+      // render, and a synchronous set inside an effect body is a cascading render.
+      await Promise.resolve();
+      if (cancelled) return;
+
+      if (!hasSupabaseBrowserConfig()) {
+        // Unknown ids are not an error: a tournament the founder just created has no
+        // seeded field, and `getDemoField` returns their own entry alone if they have
+        // entered it, which is exactly right.
+        setLoad({ state: "ready", field: getDemoField(tournamentId) });
+        return;
+      }
+
+      try {
+        const supabase = createClient();
+        const { data: authData } = await supabase.auth.getUser();
+        const { data, error } = await supabase
+          .from("tournament_entry")
+          .select(FIELD_SELECT)
+          .eq("tournament_id", tournamentId)
+          .is("deleted_at", null)
+          .order("entry_number", { ascending: true });
+
+        if (cancelled) return;
+        if (error) {
+          setLoad({ state: "error", message: error.message });
+          return;
+        }
+
+        const viewerId = authData.user?.id ?? null;
+        setLoad({
+          state: "ready",
+          field: ((data ?? []) as unknown as EntryRow[]).map((row) => toFieldEntry(row, viewerId)),
+        });
+      } catch (cause) {
+        if (cancelled) return;
+        setLoad({
+          state: "error",
+          message: cause instanceof Error ? cause.message : "The field could not be loaded.",
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [tournamentId, token]);
+
+  // Memoized so the returned object keeps its identity between renders. Spreading a fresh
+  // object every render would defeat every `useMemo` downstream that depends on it, and
+  // would re-fire any effect that lists it.
+  return useMemo(() => ({ ...load, reload }), [load, reload]);
+}

--- a/src/features/tournaments/use-field.ts
+++ b/src/features/tournaments/use-field.ts
@@ -73,6 +73,7 @@ function toFieldEntry(row: EntryRow, viewerId: string | null): FieldEntry {
     bestWeightLb: null,
     species: null,
     awaitingReview: false,
+    catches: [],
   };
 }
 

--- a/src/features/tournaments/use-format.ts
+++ b/src/features/tournaments/use-format.ts
@@ -1,0 +1,116 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { parseFormat, type TournamentFormat } from "@/core/tournaments/formats";
+import { createClient } from "@/lib/supabase/client";
+import { hasSupabaseBrowserConfig } from "./demo-store";
+import { getDemoFormat, saveDemoFormat } from "./format-store";
+
+/**
+ * Reading and writing the format a tournament is scored under.
+ *
+ * The read is deliberately a second query rather than an embed on the tournament: the
+ * tournament row already carries `active_scoring_version_id`, and asking PostgREST to embed
+ * through it means guessing a foreign-key name that would break silently on a rename.
+ *
+ * `null` is a real answer, not a failure — a draft tournament whose host has not chosen a
+ * format yet, which is what the readiness checklist on the overview is counting.
+ */
+
+export type FormatLoad =
+  | { readonly state: "loading" }
+  | { readonly state: "error"; readonly message: string }
+  | { readonly state: "ready"; readonly format: TournamentFormat | null };
+
+export function useFormat(tournament: {
+  readonly id: string;
+  readonly active_scoring_version_id: string | null;
+}): FormatLoad & { readonly reload: () => void } {
+  const [load, setLoad] = useState<FormatLoad>({ state: "loading" });
+  const [token, setToken] = useState(0);
+  const tournamentId = tournament.id;
+  const versionId = tournament.active_scoring_version_id;
+
+  const reload = useCallback(() => setToken((value) => value + 1), []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      await Promise.resolve();
+      if (cancelled) return;
+
+      if (!hasSupabaseBrowserConfig()) {
+        setLoad({ state: "ready", format: getDemoFormat(tournamentId) });
+        return;
+      }
+
+      if (versionId === null) {
+        setLoad({ state: "ready", format: null });
+        return;
+      }
+
+      try {
+        const supabase = createClient();
+        const { data, error } = await supabase
+          .from("tournament_scoring_version")
+          .select("configuration")
+          .eq("id", versionId)
+          .maybeSingle();
+
+        if (cancelled) return;
+        if (error) {
+          setLoad({ state: "error", message: error.message });
+          return;
+        }
+        setLoad({ state: "ready", format: parseFormat(data?.configuration) });
+      } catch (cause) {
+        if (cancelled) return;
+        setLoad({
+          state: "error",
+          message: cause instanceof Error ? cause.message : "The format could not be loaded.",
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [tournamentId, versionId, token]);
+
+  return useMemo(() => ({ ...load, reload }), [load, reload]);
+}
+
+/**
+ * Saves a format, through the RPC in production and to the device in demo mode.
+ *
+ * The RPC is the only write path: it appends a version rather than editing one, mirrors the
+ * categories into `tournament_award_category`, repoints the tournament at the new version,
+ * and refuses all of it once the tournament has started. None of those four can be done
+ * safely from a phone with table grants, which is why there are no table grants.
+ */
+export async function saveFormat(
+  tournamentId: string,
+  format: TournamentFormat,
+): Promise<{ readonly ok: true } | { readonly ok: false; readonly message: string }> {
+  if (!hasSupabaseBrowserConfig()) {
+    saveDemoFormat(tournamentId, format);
+    return { ok: true };
+  }
+
+  try {
+    const supabase = createClient();
+    const { error } = await supabase.rpc("save_tournament_format", {
+      target_tournament_id: tournamentId,
+      format,
+    });
+    if (error) return { ok: false, message: error.message };
+    return { ok: true };
+  } catch (cause) {
+    return {
+      ok: false,
+      message: cause instanceof Error ? cause.message : "The format could not be saved.",
+    };
+  }
+}

--- a/supabase/migrations/20260905193800_tournament_division_and_award_category.sql
+++ b/supabase/migrations/20260905193800_tournament_division_and_award_category.sql
@@ -1,0 +1,151 @@
+-- Divisions and award categories.
+--
+-- WHY THIS FILE IS DATED BEFORE THE FILE THAT NEEDS IT
+--
+-- `20260905194000_tournament_scoring.sql` already references both of these tables:
+--
+--   standing.division_id                       -> public.tournament_division(id)
+--   final_result_award.tournament_award_category_id -> public.tournament_award_category(id)
+--
+-- Neither table was ever created, in that migration or any other. A fresh `supabase db
+-- reset` therefore fails at 194000 with "relation public.tournament_division does not
+-- exist", which means no database has ever successfully applied it and there is no
+-- deployed environment for an out-of-order version to skip. Creating them here — one
+-- version earlier, so the foreign keys resolve when 194000 runs — is the repair that keeps
+-- the existing file untouched. Everything is `if not exists`, so an environment that
+-- somehow already has these tables is unaffected.
+--
+-- WHAT THEY ARE
+--
+-- A DIVISION is who you are competing against: Junior, Ladies, Masters, Charter. Every
+-- entry sits in at most one.
+--
+-- An AWARD CATEGORY is what you are competing for: Biggest Marlin, Biggest Tuna, Heaviest
+-- Stringer. An entry can be in several at once, each with its own scoring rule, its own
+-- entry fee and its own pot — the shape a Bisbee's-style event needs, and the shape
+-- `core/tournaments/formats.ts` writes.
+--
+-- The two are deliberately separate axes. "Biggest tuna in the Junior division" is the
+-- intersection of one of each, and collapsing them into a single list is how a tournament
+-- ends up unable to express that.
+
+-- Divisions -----------------------------------------------------------------
+
+create table if not exists public.tournament_division (
+  id uuid primary key default gen_random_uuid(),
+  tournament_id uuid not null references public.tournament(id) on delete cascade,
+  organization_id uuid not null references public.organization(id) on delete cascade,
+  name text not null,
+  description text,
+  sort_order integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  deleted_at timestamptz,
+  constraint tournament_division_name_not_blank check (length(btrim(name)) > 0),
+  unique (tournament_id, name)
+);
+
+create index if not exists tournament_division_tournament_lookup
+  on public.tournament_division (tournament_id, sort_order)
+  where deleted_at is null;
+
+-- Award categories ----------------------------------------------------------
+
+create table if not exists public.tournament_award_category (
+  id uuid primary key default gen_random_uuid(),
+  tournament_id uuid not null references public.tournament(id) on delete cascade,
+  organization_id uuid not null references public.organization(id) on delete cascade,
+  -- Stable within the tournament and chosen by the host's format document, so a standing
+  -- row and an award row can both name the same category without a lookup.
+  slug text not null,
+  name text not null,
+  description text,
+  sort_order integer not null default 0,
+
+  -- The same nine families `tournament_scoring_version.scoring_family` allows. A category
+  -- scores on exactly one of them.
+  scoring_family text not null default 'BIGGEST_FISH'
+    check (scoring_family in ('BIGGEST_FISH','TOTAL_WEIGHT','BEST_N_WEIGHT','TOTAL_LENGTH','BIGGEST_LENGTH','POINTS','SPECIES_POINTS','SPECIES_MULTIPLIER','EVERY_FISH_COUNTS','CUSTOM')),
+  -- Species list, points table, best-N — whatever that family needs. Mirrors the category
+  -- as it appears in the frozen scoring version's configuration.
+  configuration jsonb not null default '{}'::jsonb,
+
+  payout_model text not null default 'NONE'
+    check (payout_model in ('NONE','WINNER_TAKE_ALL','PLACES')),
+  -- Percentages, first place first. Empty unless the model is PLACES.
+  payout_split jsonb not null default '[]'::jsonb,
+
+  -- What the host says it costs to enter this category. Declared, never collected here:
+  -- money moves through the payment domain and nowhere else.
+  entry_fee_minor bigint check (entry_fee_minor is null or entry_fee_minor >= 0),
+  currency text check (currency is null or currency ~ '^[A-Z]{3}$'),
+
+  division_id uuid references public.tournament_division(id) on delete set null,
+
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  deleted_at timestamptz,
+
+  constraint tournament_award_category_name_not_blank check (length(btrim(name)) > 0),
+  constraint tournament_award_category_slug_not_blank check (length(btrim(slug)) > 0),
+  unique (tournament_id, slug)
+);
+
+create index if not exists tournament_award_category_tournament_lookup
+  on public.tournament_award_category (tournament_id, sort_order)
+  where deleted_at is null;
+
+-- A category belongs to the same tournament as the division it is scoped to. Enforced
+-- rather than trusted, matching `tg_validate_tournament_entry_scope` and its siblings in
+-- 20260905190500 — a cross-tournament reference here would silently mis-score an event.
+create or replace function public.tg_validate_award_category_scope()
+returns trigger language plpgsql as $$
+declare
+  division_tournament uuid;
+begin
+  if new.division_id is not null then
+    select tournament_id into division_tournament
+      from public.tournament_division
+     where id = new.division_id;
+
+    if division_tournament is null or division_tournament <> new.tournament_id then
+      raise exception 'award category division must belong to the same tournament'
+        using errcode = 'foreign_key_violation';
+    end if;
+  end if;
+  return new;
+end $$;
+
+drop trigger if exists tg_award_category_scope on public.tournament_award_category;
+create trigger tg_award_category_scope
+  before insert or update on public.tournament_award_category
+  for each row execute function public.tg_validate_award_category_scope();
+
+-- Row level security --------------------------------------------------------
+
+alter table public.tournament_division enable row level security;
+alter table public.tournament_award_category enable row level security;
+
+revoke all on public.tournament_division from anon;
+revoke all on public.tournament_award_category from anon;
+grant select on public.tournament_division to authenticated;
+grant select on public.tournament_award_category to authenticated;
+
+-- Reads follow the tournament: anyone in the organization can see its divisions and
+-- categories. Writes are not granted to `authenticated` at all — categories are written by
+-- `save_tournament_format`, a security-definer function that checks the caller is an owner
+-- or admin and that the tournament is not already locked. There is no direct write path,
+-- deliberately: a category edited out from under a running tournament changes what
+-- everybody was fishing for.
+create policy tournament_division_org_read on public.tournament_division
+  for select to authenticated
+  using (public.is_organization_member(organization_id));
+
+create policy tournament_award_category_org_read on public.tournament_award_category
+  for select to authenticated
+  using (public.is_organization_member(organization_id));
+
+comment on table public.tournament_division is
+  'Who an entry competes against (Junior, Ladies, Charter). One per entry at most.';
+comment on table public.tournament_award_category is
+  'What an entry competes for (Biggest Marlin, Heaviest Stringer). Several per entry, each with its own rule, fee and pot. Written only by save_tournament_format.';

--- a/supabase/migrations/20260906090000_tournament_format.sql
+++ b/supabase/migrations/20260906090000_tournament_format.sql
@@ -1,0 +1,157 @@
+-- Saving the format a host chose for their tournament.
+--
+-- The format — the categories, what scores in each, what each costs, how each pays out —
+-- is written as one document into `tournament_scoring_version.configuration`, and mirrored
+-- into `tournament_award_category` rows so that standings and final awards have something
+-- durable to point at.
+--
+-- It goes through a function rather than through table grants for three reasons:
+--
+-- 1. The two writes have to happen together. A scoring version without its categories, or
+--    categories without the version that froze them, is a tournament that cannot be scored.
+-- 2. Versions are the audit trail. Every save appends a new version and repoints
+--    `tournament.active_scoring_version_id`; nothing is edited in place, so what a
+--    tournament was scored under is always recoverable.
+-- 3. A locked version is immutable and a running tournament's rules must not move under
+--    the people fishing it. Both are checked here, in one place, rather than hoped for.
+
+create or replace function public.save_tournament_format(
+  target_tournament_id uuid,
+  format jsonb
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  uid uuid := auth.uid();
+  target public.tournament;
+  next_version integer;
+  new_version_id uuid;
+  category jsonb;
+  ordinal integer := 0;
+  family text;
+  currency text;
+  kept text[] := array[]::text[];
+begin
+  if uid is null then
+    raise exception 'authentication required' using errcode = '42501';
+  end if;
+
+  select * into target
+    from public.tournament
+   where id = target_tournament_id
+     and deleted_at is null;
+
+  if target.id is null then
+    raise exception 'tournament not found' using errcode = 'no_data_found';
+  end if;
+
+  -- Setting the terms of a competition is an owner/admin act, not something any member of
+  -- the organization can do on the morning of the event.
+  if not public.is_organization_member(target.organization_id, array['OWNER','ADMIN']) then
+    raise exception 'not permitted to set the format for this tournament' using errcode = '42501';
+  end if;
+
+  -- Before the boats leave, and not after. LIVE, PAUSED, COMPLETED, RESULTS_PENDING, FINAL
+  -- and CANCELLED are all refused: changing what counts once anybody has fished is the one
+  -- thing that makes a result impossible to defend.
+  if target.status not in ('DRAFT','REGISTRATION_OPEN','REGISTRATION_CLOSED','READY') then
+    raise exception 'the format cannot change once the tournament has started (status %)', target.status
+      using errcode = 'check_violation';
+  end if;
+
+  if format is null or jsonb_typeof(format -> 'categories') <> 'array'
+     or jsonb_array_length(format -> 'categories') = 0 then
+    raise exception 'a format needs at least one category' using errcode = 'check_violation';
+  end if;
+
+  currency := coalesce(format ->> 'currency', 'USD');
+  if currency !~ '^[A-Z]{3}$' then
+    raise exception 'currency must be a three letter code' using errcode = 'check_violation';
+  end if;
+
+  -- One family when every category agrees, CUSTOM when they do not. Mirrors
+  -- `familyColumnFor` in core/tournaments/formats.ts; the column holds one value and the
+  -- configuration document is the truth.
+  select case when count(distinct value ->> 'family') = 1
+              then min(value ->> 'family')
+              else 'CUSTOM' end
+    into family
+    from jsonb_array_elements(format -> 'categories') as value;
+
+  select coalesce(max(version), 0) + 1 into next_version
+    from public.tournament_scoring_version
+   where tournament_id = target_tournament_id;
+
+  insert into public.tournament_scoring_version (
+    tournament_id, version, scoring_family, configuration, created_by
+  )
+  values (target_tournament_id, next_version, family, format, uid)
+  returning id into new_version_id;
+
+  -- Categories are upserted by slug rather than replaced, because `final_result_award`
+  -- references them `on delete restrict`: a category that has already awarded somebody a
+  -- prize cannot be deleted, and should not be. One the host dropped is soft-deleted
+  -- instead, so the award it produced still resolves.
+  for category in select * from jsonb_array_elements(format -> 'categories')
+  loop
+    ordinal := ordinal + 1;
+    kept := kept || (category ->> 'id');
+
+    insert into public.tournament_award_category (
+      tournament_id, organization_id, slug, name, sort_order,
+      scoring_family, configuration, payout_model, payout_split,
+      entry_fee_minor, currency, deleted_at
+    )
+    values (
+      target_tournament_id,
+      target.organization_id,
+      category ->> 'id',
+      category ->> 'name',
+      ordinal,
+      coalesce(category ->> 'family', 'BIGGEST_FISH'),
+      coalesce(category - 'id' - 'name' - 'family', '{}'::jsonb),
+      coalesce(category -> 'payout' ->> 'model', 'NONE'),
+      coalesce(category -> 'payout' -> 'split', '[]'::jsonb),
+      nullif(category ->> 'entryFeeMinor', '')::bigint,
+      currency,
+      null
+    )
+    on conflict (tournament_id, slug) do update set
+      name = excluded.name,
+      sort_order = excluded.sort_order,
+      scoring_family = excluded.scoring_family,
+      configuration = excluded.configuration,
+      payout_model = excluded.payout_model,
+      payout_split = excluded.payout_split,
+      entry_fee_minor = excluded.entry_fee_minor,
+      currency = excluded.currency,
+      deleted_at = null,
+      updated_at = now();
+  end loop;
+
+  update public.tournament_award_category
+     set deleted_at = now(), updated_at = now()
+   where tournament_id = target_tournament_id
+     and deleted_at is null
+     and not (slug = any (kept));
+
+  update public.tournament
+     set active_scoring_version_id = new_version_id,
+         updated_at = now()
+   where id = target_tournament_id;
+
+  return new_version_id;
+end $$;
+
+revoke all on function public.save_tournament_format(uuid, jsonb) from public;
+grant execute on function public.save_tournament_format(uuid, jsonb) to authenticated;
+
+comment on function public.save_tournament_format(uuid, jsonb) is
+  'Appends a scoring version holding the host''s format document, mirrors its categories into tournament_award_category, and makes it the active version. Owner/admin only, and refused once the tournament has started.';
+
+-- Reading a tournament's active format back is a plain select on
+-- `tournament_scoring_version`, which already carries an organization-scoped read policy
+-- from 20260905184500. Nothing new is granted here.


### PR DESCRIPTION
Stacked on #122 so the diff here is only the format work. When #122 merges this retargets to `main` on its own.

## What changed

Every event was "heaviest fish and hope". A host now picks a format, and the four shapes asked for turn out to be one model:

> **a tournament is a list of CATEGORIES · a category has a SCORING RULE and a PAYOUT**

| Shape | How it falls out of the model |
|---|---|
| Heaviest fish, winner takes all | One category |
| First / second / third | One category, percentage split |
| Points per species (Captain's Cup) | One category whose rule is a species points table |
| Several categories (Bisbee's) | Three categories, each with its own fee and pot |

That is why a fifth shape later is data rather than code, and why a host who wants the simple thing never meets the complicated thing (UX-001 §13).

It is presented like the Boat Games mode cards, which is the reference the request named: four preset cards that each build a **complete, valid** tournament, and only then the handful of things worth changing. Tapping "Heaviest fish wins" then Next produces everything the scorer needs.

- **Points per species** starts from a table for our water and is entirely the host's to edit — a calico bass is an ordinary afternoon in Newport and a notable day off Seattle, so the app has no opinion. A species not on the table scores nothing, which the screen says out loud: the table *is* the rules.
- **Several categories** gives standings a chip per category, and each is a genuinely different board — the marlin board and the tuna board share nothing but the entry list.

## Scoring and money

`core/tournaments/formats.ts` holds the model, presets, validation, plain-English description and payout maths. Scoring is **not** reimplemented: a category maps onto `official-scoring.ts`'s `ScoreRule`, which stays the one place a score is computed. Catches are converted into the scorer's units and back, rather than pounds being passed in a field named `weightG`.

Prize splits are exact integer minor units, and three rules exist because the naive version is wrong somewhere real:

1. An unfilled place does not vanish — a 50/30/20 category fished by two boats pays the whole pot in the ratio 50:30.
2. Whole minor units only, so nothing is invented or lost.
3. The remainder goes to first place, which is the convention.

**Money is declared, never collected.** A category can carry an entry fee and the board shows what the pot would be and how it splits; nothing charges anybody, and every screen showing a figure says so.

## Production write path

`save_tournament_format` appends a scoring version holding the format document, mirrors its categories into `tournament_award_category`, and repoints `tournament.active_scoring_version_id`. It is a function rather than table grants because the two writes have to happen together, versions are the audit trail, and a running tournament's rules must not move under the people fishing it — owner/admin only, and refused once the tournament has started. Categories are upserted by slug and soft-deleted, because `final_result_award` references them `on delete restrict`.

## Also fixes the migration that could never have run

`20260905194000_tournament_scoring.sql` references `tournament_division` and `tournament_award_category`, and **no migration ever created either**, so a fresh `db reset` failed at that file. Both are now created one version earlier so the foreign keys resolve. Everything is `if not exists`. This was the thing blocking a real deployment, and it is also what was blocking divisions and award categories — the two features every competitor in this market leads with.

## How it was checked

- `npm run verify` (tokens, tripwires, migrations, lint, `tsc --noEmit`, tests) and `npm run build` pass. 939 tests, 40 new: every preset validates, splits that do not total 100 are rejected, ties share a place, an unfilled place redistributes without losing a cent, a points category scores on points and a weight category on pounds, and a format round-trips through JSON.
- Walked the whole wizard in a headless browser at 390px — both editors, the review, all three category boards, the rules screen. No console or page errors.

## What this does not do

**The migrations and the RPC have never been run.** No Supabase is configured in this sandbox, so they are written against the schema and reviewed, not executed. Applying them and walking one real tournament through is the next step, and until that happens "production" is a claim rather than a fact.

Divisions have a table now but no UI. Boards are still computed on the device from approved catches — the server-side scorer is unwired. No weigh-in screen yet; that is the natural next piece, now that categories exist for an official weight to land in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K73Uhpp8p52X4hxr9HJKuv

---
_Generated by [Claude Code](https://claude.ai/code/session_01K73Uhpp8p52X4hxr9HJKuv)_