### PR TITLE
Redesign tournament flow for faster wayfinding

### DIFF
--- a/src/features/tournaments/components/tournament-chrome.tsx
+++ b/src/features/tournaments/components/tournament-chrome.tsx
@@ -12,29 +12,21 @@ import {
   type StatusTone,
 } from "../format";
 import { useNow, useOnline } from "../use-now";
-import { BACK_LINK, CARD, CARD_PADDED, FOCUS_RING, PAGE, SECONDARY_BUTTON, TABULAR } from "../ui-classes";
+import {
+  BACK_LINK,
+  CARD,
+  CARD_PADDED,
+  FOCUS_RING,
+  PAGE,
+  SECONDARY_BUTTON,
+  TABULAR,
+} from "../ui-classes";
 import { AlertIcon, BackIcon, CheckIcon, ClockIcon, PendingIcon } from "./icons";
-
-/**
- * The furniture every tournament screen shares: the page frame, the hero header, the tab
- * strip, status pills, stat tiles, empty and error states, and the loading skeleton.
- *
- * It lives in one file on purpose. The old section had six screens that each rolled their
- * own header, their own "← Overview" link, their own status pill and their own sentence
- * for "loading", and the result read as six half-finished screens rather than one product.
- * A tournament should feel like a place you are inside of, and that only happens if the
- * chrome is literally the same object on every screen.
- */
-
-/* -------------------------------------------------------------------------- */
-/* Frame                                                                       */
-/* -------------------------------------------------------------------------- */
 
 export function TournamentPage({ children }: { children: React.ReactNode }) {
   return <div className={PAGE}>{children}</div>;
 }
 
-/** The eyebrow link back up the hierarchy. 48px of tap target, not a 16px word. */
 export function BackLink({ href, children }: { href: string; children: React.ReactNode }) {
   return (
     <Link href={href} className={BACK_LINK}>
@@ -44,18 +36,6 @@ export function BackLink({ href, children }: { href: string; children: React.Rea
   );
 }
 
-/* -------------------------------------------------------------------------- */
-/* Status                                                                      */
-/* -------------------------------------------------------------------------- */
-
-/**
- * A lifecycle state, as a pill.
- *
- * Colour is never the only signal (`docs/design/01-foundations.md` §1.3): the pill always
- * carries the word, and the dot gives it a second, non-hue channel. The live state is the
- * one that pulses, because "is this thing running right now" is the single question the
- * screen most often has to answer from across a cockpit.
- */
 export function StatusPill({ status, className = "" }: { status: string; className?: string }) {
   const { label, tone } = statusPresentation(status);
   const classes = TONE_CLASSES[tone];
@@ -74,7 +54,6 @@ export function StatusPill({ status, className = "" }: { status: string; classNa
   );
 }
 
-/** The same pill shape for anything that is not a lifecycle state — sync, QR, eligibility. */
 export function TonePill({ tone, children }: { tone: StatusTone; children: React.ReactNode }) {
   const classes = TONE_CLASSES[tone];
   return (
@@ -87,12 +66,6 @@ export function TonePill({ tone, children }: { tone: StatusTone; children: React
   );
 }
 
-/**
- * One requirement or check, as a row: icon, what it is, and what it means right now.
- *
- * `state` drives both the glyph and the colour, and the label is always present, so this
- * row survives being read by someone who cannot separate green from amber.
- */
 export function CheckRow({
   state,
   label,
@@ -119,18 +92,6 @@ export function CheckRow({
   );
 }
 
-/* -------------------------------------------------------------------------- */
-/* Hero header                                                                 */
-/* -------------------------------------------------------------------------- */
-
-/**
- * The tournament's identity, at the top of every screen inside it: name, what state it is
- * in, when it runs, and how long is left.
- *
- * The clock is the part that earns its space. "Starts in 6 days" and "4h 30m left" are the
- * two things a competitor actually wants from a tournament header, and neither was
- * anywhere in the old design — it printed an ISO date through `Intl` and stopped.
- */
 export function TournamentHero({
   tournament,
   eyebrow,
@@ -144,13 +105,18 @@ export function TournamentHero({
     readonly starts_at: string | null;
     readonly ends_at: string | null;
   };
-  /** Overridden on sub-screens so the back link points one level up, not to the list. */
   eyebrow?: React.ReactNode;
-  /** The screen's primary action, if it has one. */
   children?: React.ReactNode;
 }) {
   const now = useNow();
-  const clock = now === 0 ? null : countdown(now, { status: tournament.status, startsAt: tournament.starts_at, endsAt: tournament.ends_at });
+  const clock =
+    now === 0
+      ? null
+      : countdown(now, {
+          status: tournament.status,
+          startsAt: tournament.starts_at,
+          endsAt: tournament.ends_at,
+        });
   const { blurb } = statusPresentation(tournament.status);
 
   return (
@@ -159,16 +125,25 @@ export function TournamentHero({
 
       <div className="overflow-hidden rounded-lg border border-hairline bg-linear-to-b from-surface-raised to-surface">
         <div className="flex flex-col gap-space-4 p-space-5">
-          <div className="flex flex-wrap items-start justify-between gap-space-3">
+          <div className="flex flex-col gap-space-3">
+            <div className="flex flex-wrap items-center gap-space-2">
+              <StatusPill status={tournament.status} />
+              <span className="text-caption text-text-muted">{visibilityLabel(tournament.visibility)}</span>
+            </div>
             <h1 className="text-h1 text-text-primary">{tournament.name}</h1>
-            <StatusPill status={tournament.status} />
           </div>
 
-          <div className="flex flex-col gap-space-1">
-            <p className="text-body text-text-primary">{formatSchedule(tournament.starts_at, tournament.ends_at)}</p>
-            <p className="text-caption text-text-muted">
-              {visibilityLabel(tournament.visibility)} · {blurb}
-            </p>
+          <div className="grid gap-space-3 sm:grid-cols-2">
+            <div className="flex flex-col gap-space-1">
+              <span className="text-caption text-text-muted">When</span>
+              <span className="text-body-strong text-text-primary">
+                {formatSchedule(tournament.starts_at, tournament.ends_at)}
+              </span>
+            </div>
+            <div className="flex flex-col gap-space-1">
+              <span className="text-caption text-text-muted">Right now</span>
+              <span className="text-body text-text-primary">{blurb}</span>
+            </div>
           </div>
 
           {clock ? (
@@ -187,23 +162,15 @@ export function TournamentHero({
   );
 }
 
-/* -------------------------------------------------------------------------- */
-/* Tabs                                                                        */
-/* -------------------------------------------------------------------------- */
-
 /**
- * The five places a competitor goes inside a tournament.
- *
- * Organizer tools are deliberately not in this row. UX-001 §7 is blunt about it — do not
- * make an angler hunt through administrative navigation while on the water — so "Run the
- * event" is a card on the overview for the person who owns the event, and everyone else
- * never sees the word "operations" at all.
+ * Navigation follows the competitor's mental model rather than the underlying feature names:
+ * understand the event, finish the entry, compete, see results, reference the rules.
  */
 const TABS = [
-  ["Overview", "overview"],
-  ["Enter", "register"],
-  ["Catches", "catches"],
-  ["Standings", "leaderboard"],
+  ["Home", "overview"],
+  ["My entry", "register"],
+  ["Compete", "catches"],
+  ["Results", "leaderboard"],
   ["Rules", "rules"],
 ] as const;
 
@@ -211,14 +178,9 @@ export function TournamentTabs({ tournamentId }: { tournamentId: string }) {
   const pathname = usePathname();
 
   return (
-    <nav aria-label="Tournament sections">
-      {/*
-        Wrapped, not scrolled. A horizontal scroller put "Standings" half off the right
-        edge of a 390px phone, and a tab you cannot see is a tab you do not know exists —
-        the same finding that put the nav drawer in the app shell. Two rows of five costs
-        24px and hides nothing.
-      */}
-      <ul className="flex flex-wrap gap-space-2">
+    <nav aria-label="Tournament menu" className="flex flex-col gap-space-2">
+      <span className="text-caption text-text-muted">Tournament menu</span>
+      <ul className="grid grid-cols-2 gap-space-2 sm:grid-cols-5">
         {TABS.map(([label, route]) => {
           const href = `/tournaments/${tournamentId}/${route}`;
           const active = pathname === href;
@@ -227,7 +189,7 @@ export function TournamentTabs({ tournamentId }: { tournamentId: string }) {
               <Link
                 href={href}
                 aria-current={active ? "page" : undefined}
-                className={`inline-flex min-h-touch-floor items-center rounded-full border px-space-4 text-label transition-colors ${FOCUS_RING} ${
+                className={`flex min-h-touch-floor w-full items-center justify-center rounded-lg border px-space-3 text-center text-label transition-colors ${FOCUS_RING} ${
                   active
                     ? "border-signal-orange bg-signal-orange text-ink-on-orange"
                     : "border-border-interactive bg-surface text-text-link hover:border-text-link"
@@ -243,10 +205,6 @@ export function TournamentTabs({ tournamentId }: { tournamentId: string }) {
   );
 }
 
-/* -------------------------------------------------------------------------- */
-/* Small parts                                                                 */
-/* -------------------------------------------------------------------------- */
-
 export function SectionHeading({ children, aside }: { children: React.ReactNode; aside?: React.ReactNode }) {
   return (
     <div className="flex flex-wrap items-baseline justify-between gap-space-2">
@@ -256,7 +214,6 @@ export function SectionHeading({ children, aside }: { children: React.ReactNode;
   );
 }
 
-/** A number worth looking at, with the word for what it counts underneath it. */
 export function StatTile({
   label,
   value,
@@ -269,7 +226,9 @@ export function StatTile({
   return (
     <article className={`${CARD} flex flex-col gap-space-1 p-space-4`}>
       <span className="text-caption text-text-muted">{label}</span>
-      <span className={`text-h2 ${TABULAR} ${tone === "neutral" ? "text-text-primary" : TONE_CLASSES[tone].text}`}>
+      <span
+        className={`text-h2 ${TABULAR} ${tone === "neutral" ? "text-text-primary" : TONE_CLASSES[tone].text}`}
+      >
         {value}
       </span>
     </article>
@@ -294,13 +253,6 @@ export function EmptyState({
   );
 }
 
-/**
- * The demo-mode note.
- *
- * Said once, quietly, at the bottom of a screen rather than shouted at the top of five of
- * them. It is a truthful caveat, not a feature, and the old design gave it the same
- * prominence as the tournament's name.
- */
 export function DemoNote({ children }: { children?: React.ReactNode }) {
   return (
     <p className="text-caption text-text-muted">
@@ -309,41 +261,33 @@ export function DemoNote({ children }: { children?: React.ReactNode }) {
   );
 }
 
-/** The radio state, for the one screen where being offline changes what the app promises. */
 export function ConnectionPill() {
   const online = useOnline();
-  return (
-    <TonePill tone={online ? "open" : "attention"}>{online ? "Online" : "No service"}</TonePill>
-  );
+  return <TonePill tone={online ? "open" : "attention"}>{online ? "Online" : "No service"}</TonePill>;
 }
 
-/* -------------------------------------------------------------------------- */
-/* Loading and failure                                                         */
-/* -------------------------------------------------------------------------- */
-
-/**
- * A skeleton rather than the word "Loading…".
- *
- * On a boat, a cold load can take a while, and a blank screen with one grey word looks
- * broken. Blocks in the shape of the content that is coming look like the app working.
- */
 export function LoadingScreen({ label = "Loading tournament" }: { label?: string }) {
   return (
     <div className={PAGE} aria-busy="true">
       <span className="sr-only" role="status">
         {label}
       </span>
-      <div className="h-space-12 w-full animate-pulse rounded-lg bg-surface motion-reduce:animate-none" aria-hidden="true" />
-      <div className="h-space-16 w-full animate-pulse rounded-lg bg-surface motion-reduce:animate-none" aria-hidden="true" />
-      <div className="h-space-16 w-full animate-pulse rounded-lg bg-surface motion-reduce:animate-none" aria-hidden="true" />
+      <div
+        className="h-space-12 w-full animate-pulse rounded-lg bg-surface motion-reduce:animate-none"
+        aria-hidden="true"
+      />
+      <div
+        className="h-space-16 w-full animate-pulse rounded-lg bg-surface motion-reduce:animate-none"
+        aria-hidden="true"
+      />
+      <div
+        className="h-space-16 w-full animate-pulse rounded-lg bg-surface motion-reduce:animate-none"
+        aria-hidden="true"
+      />
     </div>
   );
 }
 
-/**
- * A failure the person can act on: what happened, in a sentence, and a way out of it.
- * Never a bare error string on a blank page.
- */
 export function ErrorScreen({
   title = "That did not load",
   message,

--- a/src/features/tournaments/components/tournament-hub.tsx
+++ b/src/features/tournaments/components/tournament-hub.tsx
@@ -7,19 +7,17 @@ import { createClient } from "@/lib/supabase/client";
 import { getDemoTournaments, hasSupabaseBrowserConfig, type DemoTournament } from "../demo-store";
 import { countdown, formatSchedule, tournamentPhase, visibilityLabel } from "../format";
 import { useNow } from "../use-now";
-import { BIG_ACTION, CARD, FOCUS_RING, PAGE, PRIMARY_BUTTON, TABULAR } from "../ui-classes";
+import {
+  BIG_ACTION,
+  CARD,
+  CARD_PADDED,
+  FOCUS_RING,
+  PAGE,
+  PRIMARY_BUTTON,
+  TABULAR,
+} from "../ui-classes";
 import { DemoNote, EmptyState, ErrorScreen, LoadingScreen, SectionHeading, StatusPill } from "./tournament-chrome";
 import { ChevronIcon, ClockIcon, PlusIcon } from "./icons";
-
-/**
- * /tournaments — the way in.
- *
- * The old version was two flat lists titled "My tournaments" and "Public tournaments",
- * sorted by creation date, with a tournament being fished *right now* sitting below one
- * created yesterday that starts in March. The fix is to sort by what a person is about to
- * do rather than by when a row was written: what is happening now, then what is yours,
- * then what you could enter.
- */
 
 type TournamentCard = Pick<
   DemoTournament,
@@ -44,8 +42,6 @@ export function TournamentHub() {
     let cancelled = false;
 
     void (async () => {
-      // Yield before the first `setState` so nothing is set synchronously inside the
-      // effect body — see `use-tournament.ts` for the full reason.
       await Promise.resolve();
       if (cancelled) return;
       setLoad({ state: "loading" });
@@ -119,23 +115,26 @@ export function TournamentHub() {
     <div className={PAGE}>
       <header className="flex flex-col gap-space-4">
         <div className="flex flex-col gap-space-2">
-          <h1 className="text-h1 text-text-primary">Tournaments</h1>
+          <span className="text-label text-signal-orange">Tournament center</span>
+          <h1 className="text-h1 text-text-primary">Know what is happening. Know what to do next.</h1>
           <p className="text-body text-text-muted">
-            A Saturday bet with three friends, or a hundred boats and a payout. Same engine, and you
-            only meet the parts you need.
+            Enter events, compete, follow results, or run your own tournament from one place.
           </p>
         </div>
         <Link href="/tournaments/new" className={BIG_ACTION}>
           <PlusIcon />
-          Create a tournament
+          Host a tournament
         </Link>
       </header>
 
+      <TournamentFlowIntro />
+
       {live.length > 0 ? (
         <section className="flex flex-col gap-space-3" aria-labelledby="live-heading">
-          <SectionHeading aside={live.length > 1 ? `${live.length} running` : undefined}>
-            <span id="live-heading">Happening now</span>
+          <SectionHeading aside={live.length > 1 ? `${live.length} live events` : "Live now"}>
+            <span id="live-heading">Compete now</span>
           </SectionHeading>
+          <p className="text-body text-text-muted">These events are on the water right now.</p>
           <ul className="flex flex-col gap-space-3">
             {live.map((item) => (
               <li key={item.id}>
@@ -148,15 +147,16 @@ export function TournamentHub() {
 
       <section className="flex flex-col gap-space-3" aria-labelledby="yours-heading">
         <SectionHeading>
-          <span id="yours-heading">Your tournaments</span>
+          <span id="yours-heading">Your events</span>
         </SectionHeading>
+        <p className="text-body text-text-muted">Tournaments you created or are already responsible for.</p>
         {yours.length === 0 ? (
           <EmptyState
-            title="You have not run one yet"
-            body="Name it, pick a day, decide who can see it. That is the whole setup — the rest can wait until you need it."
+            title="You have not hosted a tournament yet"
+            body="Start with the event basics. Rules, scoring, verification, registration, and payouts can be configured as the tournament takes shape."
             action={
               <Link href="/tournaments/new" className={PRIMARY_BUTTON}>
-                Create a tournament
+                Host a tournament
               </Link>
             }
           />
@@ -173,9 +173,10 @@ export function TournamentHub() {
 
       {toEnter.length > 0 ? (
         <section className="flex flex-col gap-space-3" aria-labelledby="open-heading">
-          <SectionHeading>
-            <span id="open-heading">Open to enter</span>
+          <SectionHeading aside={`${toEnter.length} available`}>
+            <span id="open-heading">Find a tournament</span>
           </SectionHeading>
+          <p className="text-body text-text-muted">Open events you can review and enter.</p>
           <ul className="flex flex-col gap-space-3">
             {toEnter.map((item) => (
               <li key={item.id}>
@@ -191,11 +192,39 @@ export function TournamentHub() {
   );
 }
 
-/**
- * Sorting a mixed list of dates so it reads the way a person expects: the next thing
- * first, then the rest of the future, then anything undated, then the past most-recent
- * first. Creation order — what the old list used — is the one order nobody is looking for.
- */
+function TournamentFlowIntro() {
+  const steps = [
+    ["1", "Choose", "Find an event or create one."],
+    ["2", "Enter", "Registration, eligibility, waivers, and payment live here."],
+    ["3", "Compete", "Check in, submit catches, and follow event status."],
+    ["4", "Results", "See standings, judging outcomes, and final winners."],
+  ] as const;
+
+  return (
+    <section className={`${CARD_PADDED} flex flex-col gap-space-4`} aria-labelledby="flow-heading">
+      <div className="flex flex-col gap-space-1">
+        <SectionHeading>
+          <span id="flow-heading">The tournament flow</span>
+        </SectionHeading>
+        <p className="text-body text-text-muted">Every tournament follows the same simple path, even when the rules are different.</p>
+      </div>
+      <ol className="grid gap-space-3 sm:grid-cols-2">
+        {steps.map(([number, title, detail]) => (
+          <li key={number} className="flex items-start gap-space-3">
+            <span className="flex h-space-8 w-space-8 shrink-0 items-center justify-center rounded-full border border-border-interactive text-label text-signal-orange">
+              {number}
+            </span>
+            <span className="flex flex-col gap-space-1">
+              <span className="text-body-strong text-text-primary">{title}</span>
+              <span className="text-caption text-text-muted">{detail}</span>
+            </span>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
 function sortForReading(items: readonly TournamentCard[]): TournamentCard[] {
   const now = Date.now();
   const key = (item: TournamentCard) => {
@@ -212,13 +241,6 @@ function sortForReading(items: readonly TournamentCard[]): TournamentCard[] {
   });
 }
 
-/**
- * One tournament, as a whole-card link.
- *
- * The card is the target, not a word inside it — design 04 allows a card to be tappable as
- * a unit as long as it takes the button's pressed and focus behaviour, which it does here.
- * On a phone that is the difference between a 300px target and a 90px one.
- */
 function TournamentRow({ tournament, emphasis = false }: { tournament: TournamentCard; emphasis?: boolean }) {
   const now = useNow();
   const clock =
@@ -237,18 +259,14 @@ function TournamentRow({ tournament, emphasis = false }: { tournament: Tournamen
         emphasis ? "border-signal-orange/50 bg-linear-to-b from-surface-raised to-surface" : ""
       }`}
     >
-      {/*
-        Name on its own line, everything else under it. Putting the pill inline with the
-        name meant a short name kept it on the same row and a long one pushed it onto the
-        next, so a list of three tournaments had three different shapes.
-      */}
       <span className="flex min-w-0 flex-1 flex-col gap-space-2">
         <span className="text-body-strong text-text-primary">{tournament.name}</span>
         <span className="flex flex-wrap items-center gap-space-2">
           <StatusPill status={tournament.status} />
+          <span className="text-caption text-text-muted">{visibilityLabel(tournament.visibility)}</span>
         </span>
         <span className="text-caption text-text-muted">
-          {formatSchedule(tournament.starts_at, tournament.ends_at)} · {visibilityLabel(tournament.visibility)}
+          {formatSchedule(tournament.starts_at, tournament.ends_at)}
         </span>
         {clock ? (
           <span
@@ -259,7 +277,10 @@ function TournamentRow({ tournament, emphasis = false }: { tournament: Tournamen
           </span>
         ) : null}
       </span>
-      <ChevronIcon size="h-space-5 w-space-5" className="text-text-muted" />
+      <span className="flex shrink-0 items-center gap-space-1 text-label text-text-link">
+        Open
+        <ChevronIcon size="h-space-5 w-space-5" />
+      </span>
     </Link>
   );
 }

--- a/src/features/tournaments/components/tournament-overview.tsx
+++ b/src/features/tournaments/components/tournament-overview.tsx
@@ -7,7 +7,15 @@ import { getDemoEntry, getDemoStandings, type DemoEntry, type DemoStanding } fro
 import { entrySteps, formatDateTime, tournamentPhase, visibilityPresentation } from "../format";
 import { getDemoTournamentCatches } from "../live-catch-demo";
 import { useDemoMode, useTournament } from "../use-tournament";
-import { BIG_ACTION, CARD, CARD_PADDED, FOCUS_RING, PAGE, SECONDARY_BUTTON, TABULAR } from "../ui-classes";
+import {
+  BIG_ACTION,
+  CARD,
+  CARD_PADDED,
+  FOCUS_RING,
+  PAGE,
+  SECONDARY_BUTTON,
+  TABULAR,
+} from "../ui-classes";
 import { ChevronIcon, LockIcon, TrophyIcon } from "./icons";
 import {
   CheckRow,
@@ -20,45 +28,30 @@ import {
   TournamentTabs,
 } from "./tournament-chrome";
 
-/**
- * /tournaments/[id]/overview — the tournament's home.
- *
- * The question this screen answers is "what do I do about this tournament right now",
- * and the answer changes completely depending on where the event is in its life. So the
- * screen leads with one action sized like it matters — enter it, log a catch, finish
- * setting it up, see who won — and only then explains itself.
- *
- * The old version led with a progress bar labelled "4 locked inputs selected" over the
- * sentence "Rules, scoring, verification policy and tournament boundaries must all be
- * frozen before READY can move to LIVE." That is the domain model talking to itself. The
- * checklist below says the same thing in the words a person running a fishing tournament
- * would use, and it is a checklist rather than a bar because a bar cannot tell you which
- * one is missing.
- */
-
-/** The four frozen competition inputs, in the order a director would work through them. */
 const READINESS = [
   {
     key: "active_rule_set_version_id",
-    label: "The rules",
-    detail: "What counts, what does not, and the penalties. Locked so they cannot change mid-event.",
+    label: "Rules",
+    detail: "What counts, what does not, and any penalties.",
   },
   {
     key: "active_scoring_version_id",
-    label: "How it is scored",
-    detail: "Heaviest fish, total weight, points by species — whatever this event runs on.",
+    label: "Scoring",
+    detail: "How catches turn into the result.",
   },
   {
     key: "active_verification_policy_version_id",
-    label: "What counts as proof",
-    detail: "Photo, GPS, a scanned code, a measured length. Set once, applied to everyone.",
+    label: "Catch verification",
+    detail: "What proof is required for a catch to count.",
   },
   {
     key: "active_boundary_version_id",
-    label: "Where you can fish",
-    detail: "The water this tournament covers.",
+    label: "Fishing area",
+    detail: "Where competitors are allowed to fish.",
   },
 ] as const;
+
+type TournamentPhase = "before" | "during" | "after";
 
 export function TournamentOverview({ tournamentId }: { tournamentId: string }) {
   const load = useTournament(tournamentId);
@@ -70,8 +63,6 @@ export function TournamentOverview({ tournamentId }: { tournamentId: string }) {
   useEffect(() => {
     let cancelled = false;
     void (async () => {
-      // Deferred so nothing is set synchronously inside the effect body, and because these
-      // reads touch `localStorage`, which does not exist during the server render.
       await Promise.resolve();
       if (cancelled) return;
       setEntry(demoMode ? getDemoEntry(tournamentId) : null);
@@ -100,11 +91,23 @@ export function TournamentOverview({ tournamentId }: { tournamentId: string }) {
 
       <TournamentTabs tournamentId={tournament.id} />
 
+      <TournamentJourney
+        tournamentId={tournament.id}
+        status={tournament.status}
+        phase={phase}
+        entry={entry}
+        ready={ready}
+        hasStandings={standings.length > 0}
+      />
+
       {entry ? (
         <section className={`${CARD_PADDED} flex flex-col gap-space-3`} aria-labelledby="your-entry-heading">
-          <SectionHeading>
-            <span id="your-entry-heading">Your entry</span>
+          <SectionHeading aside="Your status">
+            <span id="your-entry-heading">Ready to fish?</span>
           </SectionHeading>
+          <p className="text-body text-text-muted">
+            Registration, eligibility, check-in, and competition status move separately. This is the fastest place to see what still needs attention.
+          </p>
           <ul className="flex flex-wrap gap-space-2">
             {entrySteps(entry).map((item) => (
               <li key={item.label}>
@@ -114,17 +117,23 @@ export function TournamentOverview({ tournamentId }: { tournamentId: string }) {
               </li>
             ))}
           </ul>
-          <Link href={`/tournaments/${tournament.id}/register`} className="text-caption text-text-link">
-            See what each of these means →
+          <Link
+            href={`/tournaments/${tournament.id}/register`}
+            className={`${FOCUS_RING} inline-flex min-h-touch-floor items-center text-label text-text-link`}
+          >
+            Open my entry
           </Link>
         </section>
       ) : null}
 
       {phase === "before" ? (
         <section className={`${CARD_PADDED} flex flex-col gap-space-4`} aria-labelledby="readiness-heading">
-          <SectionHeading aside={`${locked.length} of ${READINESS.length} locked`}>
-            <span id="readiness-heading">Before it can go live</span>
+          <SectionHeading aside={`${locked.length} of ${READINESS.length} complete`}>
+            <span id="readiness-heading">Host setup before launch</span>
           </SectionHeading>
+          <p className="text-body text-text-muted">
+            These are the four competition decisions that must be settled before anglers are on the water.
+          </p>
 
           <div
             className="flex h-space-2 gap-space-1 overflow-hidden rounded-full"
@@ -147,7 +156,7 @@ export function TournamentOverview({ tournamentId }: { tournamentId: string }) {
                 key={item.key}
                 state={tournament[item.key] !== null ? "done" : "pending"}
                 label={item.label}
-                detail={tournament[item.key] !== null ? "Locked." : item.detail}
+                detail={tournament[item.key] !== null ? "Locked for the event." : item.detail}
               />
             ))}
           </ul>
@@ -155,21 +164,23 @@ export function TournamentOverview({ tournamentId }: { tournamentId: string }) {
           <p className="inline-flex items-start gap-space-2 text-caption text-text-muted">
             <LockIcon size="h-space-4 w-space-4" />
             {ready
-              ? "All four are locked. Nothing can change underneath the anglers once fishing starts."
-              : "Once locked, these cannot change while the tournament is running. That is what makes a result defensible."}
+              ? "Competition settings are locked. They cannot move underneath anglers once fishing starts."
+              : "Lock these before launch so every competitor fishes under the same event."}
           </p>
         </section>
       ) : null}
 
       {standings.length > 0 ? (
         <section className={`${CARD_PADDED} flex flex-col gap-space-3`} aria-labelledby="standings-heading">
-          <SectionHeading aside={phase === "after" ? "Official" : "Provisional"}>
-            <span id="standings-heading">{phase === "after" ? "Final result" : "Leading"}</span>
+          <SectionHeading aside={phase === "after" ? "Official" : "Live / provisional"}>
+            <span id="standings-heading">{phase === "after" ? "Final result" : "At the top right now"}</span>
           </SectionHeading>
           <ol className="flex flex-col gap-space-2">
             {standings.slice(0, 3).map((row) => (
               <li key={row.rank} className="flex items-center gap-space-3">
-                <span className={`text-h3 ${TABULAR} ${row.rank === 1 ? "text-signal-orange" : "text-text-muted"}`}>
+                <span
+                  className={`text-h3 ${TABULAR} ${row.rank === 1 ? "text-signal-orange" : "text-text-muted"}`}
+                >
                   {row.rank}
                 </span>
                 <span className="flex-1 text-body text-text-primary">{row.display_name}</span>
@@ -184,35 +195,36 @@ export function TournamentOverview({ tournamentId }: { tournamentId: string }) {
             className={`${FOCUS_RING} inline-flex min-h-touch-floor items-center gap-space-2 text-label text-text-link`}
           >
             <TrophyIcon />
-            Full standings
+            See all results
           </Link>
         </section>
       ) : null}
 
-      <section className="grid gap-space-3 sm:grid-cols-2" aria-label="Tournament details">
-        <DetailCard label="Lines in" value={formatDateTime(tournament.starts_at) ?? "Not set yet"} />
-        <DetailCard label="Lines out" value={formatDateTime(tournament.ends_at) ?? "Not set yet"} />
-        <DetailCard label="Who can see it" value={visibility.label} hint={visibility.blurb} />
-        <DetailCard
-          label="Catches on this phone"
-          value={String(deviceCatches)}
-          hint="Recorded here, whether or not they have reached the scorer yet."
-        />
+      <section className="flex flex-col gap-space-3" aria-labelledby="details-heading">
+        <SectionHeading>
+          <span id="details-heading">Event details</span>
+        </SectionHeading>
+        <div className="grid gap-space-3 sm:grid-cols-2">
+          <DetailCard label="Starts" value={formatDateTime(tournament.starts_at) ?? "Not set yet"} />
+          <DetailCard label="Ends" value={formatDateTime(tournament.ends_at) ?? "Not set yet"} />
+          <DetailCard label="Visibility" value={visibility.label} hint={visibility.blurb} />
+          <DetailCard
+            label="Catches saved on this phone"
+            value={String(deviceCatches)}
+            hint="Saved here whether or not they have reached the scorer yet."
+          />
+        </div>
       </section>
 
-      {/*
-        Organizer tools, as one card rather than a sixth tab. An angler fishing this
-        tournament has no use for the word "operations" and should not have to scroll past
-        it every time they open the standings (UX-001 §7).
-      */}
       <Link
         href={`/tournaments/${tournament.id}/operations`}
         className={`${CARD} ${FOCUS_RING} flex items-center gap-space-3 p-space-4 transition-colors hover:border-border-interactive`}
       >
         <span className="flex flex-1 flex-col gap-space-1">
-          <span className="text-body-strong text-text-primary">Run the event</span>
+          <span className="text-caption text-text-muted">For organizers</span>
+          <span className="text-body-strong text-text-primary">Host controls</span>
           <span className="text-caption text-text-muted">
-            Entries, the review queue, standings and the money — each behind its own permission.
+            Manage entries, review catches, watch standings, and run the event.
           </span>
         </span>
         <ChevronIcon className="text-text-muted" />
@@ -220,6 +232,96 @@ export function TournamentOverview({ tournamentId }: { tournamentId: string }) {
 
       {demoMode ? <DemoNote /> : null}
     </div>
+  );
+}
+
+function TournamentJourney({
+  tournamentId,
+  status,
+  phase,
+  entry,
+  ready,
+  hasStandings,
+}: {
+  tournamentId: string;
+  status: string;
+  phase: TournamentPhase;
+  entry: DemoEntry | null;
+  ready: boolean;
+  hasStandings: boolean;
+}) {
+  const steps = [
+    {
+      number: "1",
+      title: "Enter",
+      href: `/tournaments/${tournamentId}/register`,
+      detail: entry
+        ? "Your entry exists. Check eligibility and check-in."
+        : status === "REGISTRATION_OPEN"
+          ? "Registration is open now."
+          : "See registration status and requirements.",
+    },
+    {
+      number: "2",
+      title: "Know the rules",
+      href: `/tournaments/${tournamentId}/rules`,
+      detail: ready
+        ? "Rules, scoring, proof, and boundaries are locked."
+        : "Review what counts before fishing starts.",
+    },
+    {
+      number: "3",
+      title: "Compete",
+      href: `/tournaments/${tournamentId}/catches`,
+      detail:
+        phase === "during"
+          ? "The tournament is live. Log and review catches here."
+          : phase === "before"
+            ? "This opens into your on-the-water catch flow."
+            : "Fishing is complete. Your catch record stays here.",
+    },
+    {
+      number: "4",
+      title: "Results",
+      href: `/tournaments/${tournamentId}/leaderboard`,
+      detail: hasStandings
+        ? phase === "after"
+          ? "Official results are available."
+          : "Live standings are available now."
+        : "Standings appear as catches are approved.",
+    },
+  ] as const;
+
+  return (
+    <section className="flex flex-col gap-space-3" aria-labelledby="journey-heading">
+      <div className="flex flex-col gap-space-1">
+        <SectionHeading>
+          <span id="journey-heading">How this tournament works</span>
+        </SectionHeading>
+        <p className="text-body text-text-muted">
+          Four steps. Start here whenever you are unsure where to go next.
+        </p>
+      </div>
+      <ol className="grid gap-space-3 sm:grid-cols-2">
+        {steps.map((step) => (
+          <li key={step.number}>
+            <Link
+              href={step.href}
+              className={`${CARD} ${FOCUS_RING} flex h-full items-start gap-space-3 p-space-4 transition-colors hover:border-border-interactive`}
+            >
+              <span className="flex h-space-8 w-space-8 shrink-0 items-center justify-center rounded-full border border-border-interactive text-label text-signal-orange">
+                {step.number}
+              </span>
+              <span className="flex min-w-0 flex-1 flex-col gap-space-1">
+                <span className="text-body-strong text-text-primary">{step.title}</span>
+                <span className="text-caption text-text-muted">{step.detail}</span>
+              </span>
+              <ChevronIcon className="mt-space-1 text-text-muted" />
+            </Link>
+          </li>
+        ))}
+      </ol>
+    </section>
   );
 }
 
@@ -233,13 +335,6 @@ function DetailCard({ label, value, hint }: { label: string; value: string; hint
   );
 }
 
-/**
- * The one big control, chosen by state.
- *
- * Exactly one primary action per screen (`docs/design/03-touch-and-interaction.md` §1), and
- * it is whatever the tournament's current state makes most likely: enter it while entries
- * are open, log a catch while it is being fished, look at the result once it is over.
- */
 function PrimaryAction({
   tournament,
   entry,
@@ -247,12 +342,12 @@ function PrimaryAction({
 }: {
   tournament: { readonly id: string; readonly status: string };
   entry: DemoEntry | null;
-  phase: "before" | "during" | "after";
+  phase: TournamentPhase;
 }) {
   if (phase === "during") {
     return (
       <Link href={`/tournaments/${tournament.id}/catches`} className={BIG_ACTION}>
-        Log a catch
+        Compete now — log a catch
       </Link>
     );
   }
@@ -260,7 +355,7 @@ function PrimaryAction({
   if (phase === "after") {
     return (
       <Link href={`/tournaments/${tournament.id}/leaderboard`} className={BIG_ACTION}>
-        See the result
+        View final results
       </Link>
     );
   }
@@ -268,7 +363,7 @@ function PrimaryAction({
   if (tournament.status === "REGISTRATION_OPEN") {
     return (
       <Link href={`/tournaments/${tournament.id}/register`} className={BIG_ACTION}>
-        {entry ? "Your entry" : "Enter this tournament"}
+        {entry ? "Check my entry" : "Enter this tournament"}
       </Link>
     );
   }
@@ -276,14 +371,14 @@ function PrimaryAction({
   if (tournament.status === "DRAFT") {
     return (
       <Link href={`/tournaments/${tournament.id}/operations`} className={BIG_ACTION}>
-        Finish setting it up
+        Continue host setup
       </Link>
     );
   }
 
   return (
     <Link href={`/tournaments/${tournament.id}/rules`} className={SECONDARY_BUTTON}>
-      Read the rules
+      Review the rules
     </Link>
   );
 }


### PR DESCRIPTION
## Goal
Make the tournament experience understandable at a glance on a phone, without changing tournament rules, scoring, payments, judging, persistence, or database behavior.

## What changed
- Reframed `/tournaments` as a clear tournament center with a four-step mental model: **Choose → Enter → Compete → Results**.
- Renamed tournament navigation around user intent: **Home / My entry / Compete / Results / Rules**.
- Reworked the shared tournament hero so status, visibility, schedule, and current event state scan in a predictable order.
- Added a four-step journey to tournament Home so an angler always has an obvious next destination.
- Separated participant information from organizer concerns more clearly; pre-launch readiness is explicitly labeled as host setup, and organizer tools are labeled **Host controls**.
- Simplified detail labels and primary actions (`Check my entry`, `Compete now — log a catch`, `View final results`).

## Scope
UX/UI and information architecture only. No migrations, scoring rules, registration RPC behavior, verification policy logic, payment logic, or tournament format model changes.

This is intentionally based on `main` and kept separate from the open tournament-format work so the redesign can be reviewed on its own merits.

## Review focus
Please review primarily at phone width: can a new angler answer, within a few seconds, **what is this tournament, what stage is it in, and what should I tap next?**
