### PR TITLE
Tighten tournament entry, results, and host flow

### DIFF
--- a/src/features/tournaments/components/tournament-chrome.tsx
+++ b/src/features/tournaments/components/tournament-chrome.tsx
@@ -162,26 +162,25 @@ export function TournamentHero({
   );
 }
 
-/**
- * Navigation follows the competitor's mental model rather than the underlying feature names:
- * understand the event, finish the entry, compete, see results, reference the rules.
- */
 const TABS = [
-  ["Home", "overview"],
-  ["My entry", "register"],
-  ["Compete", "catches"],
-  ["Results", "leaderboard"],
-  ["Rules", "rules"],
+  { label: "Home", route: "overview", step: null },
+  { label: "Entry", route: "register", step: "1" },
+  { label: "Compete", route: "catches", step: "2" },
+  { label: "Results", route: "leaderboard", step: "3" },
+  { label: "Rules", route: "rules", step: null },
 ] as const;
 
 export function TournamentTabs({ tournamentId }: { tournamentId: string }) {
   const pathname = usePathname();
 
   return (
-    <nav aria-label="Tournament menu" className="flex flex-col gap-space-2">
-      <span className="text-caption text-text-muted">Tournament menu</span>
+    <nav aria-label="Tournament flow" className="flex flex-col gap-space-2">
+      <div className="flex flex-wrap items-end justify-between gap-space-2">
+        <span className="text-label text-text-primary">Tournament flow</span>
+        <span className="text-caption text-text-muted">Entry → Compete → Results</span>
+      </div>
       <ul className="grid grid-cols-2 gap-space-2 sm:grid-cols-5">
-        {TABS.map(([label, route]) => {
+        {TABS.map(({ label, route, step }) => {
           const href = `/tournaments/${tournamentId}/${route}`;
           const active = pathname === href;
           return (
@@ -189,13 +188,23 @@ export function TournamentTabs({ tournamentId }: { tournamentId: string }) {
               <Link
                 href={href}
                 aria-current={active ? "page" : undefined}
-                className={`flex min-h-touch-floor w-full items-center justify-center rounded-lg border px-space-3 text-center text-label transition-colors ${FOCUS_RING} ${
+                className={`flex min-h-touch-floor w-full items-center justify-center gap-space-2 rounded-lg border px-space-3 text-center text-label transition-colors ${FOCUS_RING} ${
                   active
                     ? "border-signal-orange bg-signal-orange text-ink-on-orange"
                     : "border-border-interactive bg-surface text-text-link hover:border-text-link"
                 }`}
               >
-                {label}
+                {step ? (
+                  <span
+                    aria-hidden="true"
+                    className={`flex h-space-5 w-space-5 items-center justify-center rounded-full border text-caption ${
+                      active ? "border-ink-on-orange/50" : "border-border-interactive text-text-muted"
+                    }`}
+                  >
+                    {step}
+                  </span>
+                ) : null}
+                <span>{label}</span>
               </Link>
             </li>
           );

--- a/src/features/tournaments/components/tournament-leaderboard.tsx
+++ b/src/features/tournaments/components/tournament-leaderboard.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { getDemoStandings, type DemoStanding } from "../demo-store";
 import { tournamentPhase } from "../format";
 import { getDemoTournamentCatches, type DemoTournamentCatch } from "../live-catch-demo";
 import { useDemoMode, useTournament } from "../use-tournament";
-import { CARD, CARD_PADDED, INSET, PAGE, TABULAR } from "../ui-classes";
+import { CARD, CARD_PADDED, INSET, PAGE, SECONDARY_BUTTON, TABULAR } from "../ui-classes";
 import { TrophyIcon } from "./icons";
 import {
   BackLink,
@@ -19,23 +20,6 @@ import {
   TournamentTabs,
 } from "./tournament-chrome";
 
-/**
- * /tournaments/[id]/leaderboard — the board.
- *
- * This used to be the "Leaderboard" tab of the operations screen, which meant an angler
- * who wanted to know whether they were winning had to open a screen headed "Tournament
- * operations" and sit next to the payout controls. Standings are the most-looked-at screen
- * in any tournament and they belong to everybody, so they are their own place now.
- *
- * Two rules hold this screen honest:
- *
- * 1. **Provisional is said out loud.** A rank that could still move is not presented as a
- *    result. Only FINAL gets called official.
- * 2. **Public-safe fields only** (`core/tournaments/public-projection.ts`): a name, a
- *    species, a measurement, a rank. No positions, no evidence, no review notes — not
- *    because they are secret, but because a leaderboard is the one tournament screen that
- *    gets screenshotted and sent to a group chat.
- */
 export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }) {
   const load = useTournament(tournamentId);
   const demoMode = useDemoMode();
@@ -59,34 +43,47 @@ export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }
   if (load.state === "error") return <ErrorScreen message={load.message} />;
 
   const tournament = load.tournament;
+  const phase = tournamentPhase(tournament.status);
   const official = tournament.status === "FINAL";
-  const finished = tournamentPhase(tournament.status) === "after";
+  const finished = phase === "after";
   const leader = standings.find((row) => row.rank === 1) ?? null;
   const rest = standings.filter((row) => row !== leader);
 
   return (
     <div className={PAGE}>
       <header className="flex flex-col gap-space-3">
-        <BackLink href={`/tournaments/${tournament.id}/overview`}>{tournament.name}</BackLink>
-        <div className="flex flex-wrap items-end justify-between gap-space-3">
-          <h1 className="text-h1 text-text-primary">Standings</h1>
-          <TonePill tone={official ? "done" : "attention"}>{official ? "Official" : "Provisional"}</TonePill>
+        <BackLink href={`/tournaments/${tournament.id}/overview`}>Tournament home</BackLink>
+        <div className="flex flex-col gap-space-1">
+          <span className="text-label text-signal-orange">Step 3 of 3</span>
+          <div className="flex flex-wrap items-end justify-between gap-space-3">
+            <h1 className="text-h1 text-text-primary">Results</h1>
+            <TonePill tone={official ? "done" : "attention"}>{official ? "Official" : "Provisional"}</TonePill>
+          </div>
         </div>
         <p className="text-body text-text-muted">
           {official
-            ? "Every review is closed. This is the result."
+            ? "The tournament is settled. These are the official final standings."
             : finished
-              ? "Fishing is over, but reviews are still open. Places can still move."
-              : "Places move as catches are approved. Nothing here is final until the organizer says so."}
+              ? "Fishing is over, but judging is still being settled. Places can still move."
+              : "Standings update as catches are approved. Nothing is final until the host closes the event."}
         </p>
       </header>
 
       <TournamentTabs tournamentId={tournament.id} />
 
+      <ResultsHandoff tournamentId={tournament.id} phase={phase} />
+
       {standings.length === 0 ? (
         <EmptyState
           title="Nothing has been scored yet"
-          body="Catches appear here once a judge has approved them. A catch on a phone is not a score — that is the point."
+          body="Approved catches will appear here. A catch saved on a phone is not automatically a score."
+          action={
+            phase === "during" ? (
+              <Link href={`/tournaments/${tournament.id}/catches`} className={SECONDARY_BUTTON}>
+                Go to Compete
+              </Link>
+            ) : undefined
+          }
         />
       ) : (
         <section className="flex flex-col gap-space-3" aria-label="Standings">
@@ -136,11 +133,10 @@ export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }
       {mine.length > 0 ? (
         <section className={`${CARD_PADDED} flex flex-col gap-space-3`} aria-labelledby="mine-heading">
           <SectionHeading aside={`${mine.length} on this phone`}>
-            <span id="mine-heading">Your catches, not yet scored</span>
+            <span id="mine-heading">Your catch status</span>
           </SectionHeading>
           <p className="text-caption text-text-muted">
-            These are on this phone. They are not on the board until the tournament has them and a
-            judge has approved them.
+            These catches exist on this phone. They only affect the standings after the tournament receives them and a judge approves them.
           </p>
           <ul className="flex flex-col gap-space-2">
             {mine.slice(0, 5).map((item) => (
@@ -152,15 +148,49 @@ export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }
               </li>
             ))}
           </ul>
+          <Link href={`/tournaments/${tournament.id}/catches`} className={SECONDARY_BUTTON}>
+            Review my catches
+          </Link>
         </section>
       ) : null}
 
       <p className="text-caption text-text-muted">
-        A public board shows a name, the fish, and the measurement. It never shows where anybody was
-        fishing, their photos, or anything a judge wrote.
+        Public results show names, fish, measurements, and rank. They never expose fishing positions, private evidence, or judge notes.
       </p>
 
       {demoMode ? <DemoNote /> : null}
     </div>
   );
+}
+
+function ResultsHandoff({ tournamentId, phase }: { tournamentId: string; phase: "before" | "during" | "after" }) {
+  if (phase === "during") {
+    return (
+      <section className={`${INSET} flex flex-col gap-space-3`} aria-label="Still competing">
+        <div className="flex flex-col gap-space-1">
+          <p className="text-body-strong text-text-primary">Still fishing?</p>
+          <p className="text-caption text-text-muted">Results are only one part of the live event. Head back to Compete whenever you need to log or review a catch.</p>
+        </div>
+        <Link href={`/tournaments/${tournamentId}/catches`} className={SECONDARY_BUTTON}>
+          Back to Compete
+        </Link>
+      </section>
+    );
+  }
+
+  if (phase === "before") {
+    return (
+      <section className={`${INSET} flex flex-col gap-space-3`} aria-label="Before the tournament">
+        <div className="flex flex-col gap-space-1">
+          <p className="text-body-strong text-text-primary">The board starts when approved catches arrive</p>
+          <p className="text-caption text-text-muted">Before lines in, the important thing is making sure your entry is ready.</p>
+        </div>
+        <Link href={`/tournaments/${tournamentId}/register`} className={SECONDARY_BUTTON}>
+          Check my entry
+        </Link>
+      </section>
+    );
+  }
+
+  return null;
 }

--- a/src/features/tournaments/components/tournament-operations.tsx
+++ b/src/features/tournaments/components/tournament-operations.tsx
@@ -38,37 +38,30 @@ import {
   TonePill,
 } from "./tournament-chrome";
 
-/**
- * /tournaments/[id]/operations — running the event.
- *
- * Three lanes, because the domain model keeps them apart and the UI must not be the place
- * that quietly rejoins them: the person who runs the event, the person who judges a catch,
- * and the person who is allowed to move money are three different authorities even when
- * they happen to be the same human on a Saturday.
- *
- * What changed from the first version, beyond the styling: the lifecycle controls are no
- * longer two hardcoded disabled buttons labelled "Close registration" and "Start
- * tournament". They are computed from `core/tournaments/lifecycle.ts` — the same transition
- * table the server enforces — so this screen shows the moves that are actually legal from
- * where the tournament is, and, when LIVE is refused, says which of the four frozen inputs
- * is missing. The judge queue is built from real catches carrying real Fair Play flags
- * rather than one invented "Yellowtail · evidence review" card, and the finance panel no
- * longer displays $1,250 of money nobody took.
- */
-
 type Lane = "organizer" | "judge" | "finance";
 
 const LANES: Array<{ value: Lane; label: string }> = [
-  { value: "organizer", label: "Organizer" },
+  { value: "organizer", label: "Event" },
   { value: "judge", label: "Judging" },
   { value: "finance", label: "Money" },
 ];
 
 const PHASE_HEADING: Readonly<Record<Phase, string>> = {
-  before: "Before the event",
-  during: "While it is being fished",
-  after: "After lines out",
+  before: "Set the event up and get the field ready.",
+  during: "Keep the event moving while anglers are on the water.",
+  after: "Settle judging, publish the result, and close out the event.",
 };
+
+const HOST_FLOW: ReadonlyArray<{
+  phase: Phase;
+  number: string;
+  title: string;
+  detail: string;
+}> = [
+  { phase: "before", number: "1", title: "Set up", detail: "Entries, rules, scoring, proof, and boundaries." },
+  { phase: "during", number: "2", title: "Run", detail: "Live event status, catches, pauses, and judging." },
+  { phase: "after", number: "3", title: "Settle", detail: "Reviews, final standings, and payouts." },
+];
 
 export function TournamentOperations({
   tournamentId,
@@ -107,19 +100,22 @@ export function TournamentOperations({
   return (
     <div className={PAGE}>
       <header className="flex flex-col gap-space-3">
-        <BackLink href={`/tournaments/${tournament.id}/overview`}>{tournament.name}</BackLink>
-        <div className="flex flex-wrap items-end justify-between gap-space-3">
-          <h1 className="text-h1 text-text-primary">Run the event</h1>
-          <StatusPill status={tournament.status} />
+        <BackLink href={`/tournaments/${tournament.id}/overview`}>Tournament home</BackLink>
+        <div className="flex flex-col gap-space-1">
+          <span className="text-label text-signal-orange">Host controls</span>
+          <div className="flex flex-wrap items-end justify-between gap-space-3">
+            <h1 className="text-h1 text-text-primary">Run the tournament</h1>
+            <StatusPill status={tournament.status} />
+          </div>
         </div>
-        <p className="text-body text-text-muted">
-          {PHASE_HEADING[phase]}. Judging, the public board, and anything to do with money each sit
-          behind their own permission — nobody gets all three by accident.
-        </p>
+        <p className="text-body text-text-muted">{PHASE_HEADING[phase]}</p>
       </header>
 
-      <nav aria-label="Organizer tools" className="-mx-4 overflow-x-auto px-4">
-        <ul className="flex min-w-max gap-space-2 pb-1">
+      <HostLifecycle activePhase={phase} />
+
+      <nav aria-label="Host work areas" className="flex flex-col gap-space-2">
+        <span className="text-label text-text-primary">Host work areas</span>
+        <ul className="flex flex-wrap gap-space-2">
           {LANES.map((item) => (
             <li key={item.value}>
               <button
@@ -133,6 +129,9 @@ export function TournamentOperations({
             </li>
           ))}
         </ul>
+        <p className="text-caption text-text-muted">
+          Event operations, judging decisions, and money stay separate so one permission never silently grants another.
+        </p>
       </nav>
 
       {lane === "organizer" ? (
@@ -146,9 +145,47 @@ export function TournamentOperations({
   );
 }
 
-/* -------------------------------------------------------------------------- */
-/* Organizer                                                                   */
-/* -------------------------------------------------------------------------- */
+function HostLifecycle({ activePhase }: { activePhase: Phase }) {
+  const activeIndex = HOST_FLOW.findIndex((item) => item.phase === activePhase);
+
+  return (
+    <section className={`${CARD_PADDED} flex flex-col gap-space-3`} aria-labelledby="host-flow-heading">
+      <SectionHeading>
+        <span id="host-flow-heading">Host flow</span>
+      </SectionHeading>
+      <ol className="grid gap-space-3 sm:grid-cols-3">
+        {HOST_FLOW.map((item, index) => {
+          const active = item.phase === activePhase;
+          const complete = index < activeIndex;
+          return (
+            <li
+              key={item.phase}
+              className={`flex items-start gap-space-3 rounded-lg border p-space-3 ${
+                active ? "border-signal-orange bg-signal-orange/10" : "border-hairline bg-surface"
+              }`}
+            >
+              <span
+                className={`flex h-space-7 w-space-7 shrink-0 items-center justify-center rounded-full border text-caption ${
+                  active
+                    ? "border-signal-orange text-signal-orange"
+                    : complete
+                      ? "border-success-green text-success-green"
+                      : "border-border-interactive text-text-muted"
+                }`}
+              >
+                {item.number}
+              </span>
+              <span className="flex flex-col gap-space-1">
+                <span className={`text-body-strong ${active ? "text-signal-orange" : "text-text-primary"}`}>{item.title}</span>
+                <span className="text-caption text-text-muted">{item.detail}</span>
+              </span>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}
 
 const READINESS = [
   ["active_rule_set_version_id", "Rules"],
@@ -157,7 +194,6 @@ const READINESS = [
   ["active_boundary_version_id", "Where you can fish"],
 ] as const;
 
-/** What a director would call each transition, rather than the enum it moves to. */
 const TRANSITION_LABEL: Readonly<Record<TournamentStatus, string>> = {
   DRAFT: "Back to draft",
   REGISTRATION_OPEN: "Open entries",
@@ -171,11 +207,6 @@ const TRANSITION_LABEL: Readonly<Record<TournamentStatus, string>> = {
   CANCELLED: "Cancel the tournament",
 };
 
-/**
- * High-risk moves, per UX-001 §6 — the ones that need a confirmation and an explanation of
- * consequences before they fire. They are marked here so that whoever wires these controls
- * to the server cannot miss which three they are.
- */
 const HIGH_RISK: ReadonlySet<TournamentStatus> = new Set(["LIVE", "FINAL", "CANCELLED"]);
 
 function OrganizerLane({
@@ -207,9 +238,6 @@ function OrganizerLane({
 
   const from = isTournamentStatus(tournament.status) ? tournament.status : null;
 
-  // Every state the transition table allows from here, each carrying the server's own
-  // reason when it would be refused. Computing it from `core/` rather than hardcoding a
-  // pair of buttons means this screen cannot drift from the rules the server enforces.
   const moves = from
     ? TOURNAMENT_STATUSES.filter((to) => canTransitionTournament(from, to)).map((to) => ({
         to,
@@ -219,10 +247,6 @@ function OrganizerLane({
 
   return (
     <div className="flex flex-col gap-space-5">
-      {/*
-        Two across on a phone rather than one. Three full-width cards each holding a single
-        digit is a lot of scrolling to learn three numbers.
-      */}
       <section className="grid grid-cols-2 gap-space-3 sm:grid-cols-3" aria-label="Event at a glance">
         <StatTile label="Catches logged" value={String(catches)} />
         <StatTile label="For a judge" value={String(flagged)} tone={flagged > 0 ? "attention" : "neutral"} />
@@ -232,7 +256,7 @@ function OrganizerLane({
       {phase === "before" ? (
         <section className={`${CARD_PADDED} flex flex-col gap-space-3`}>
           <SectionHeading aside={`${READINESS.filter(([key]) => tournament[key] !== null).length} of 4`}>
-            Locked before fishing starts
+            Ready for lines in
           </SectionHeading>
           <ul className="flex flex-col gap-space-3">
             {READINESS.map(([key, label]) => (
@@ -248,11 +272,9 @@ function OrganizerLane({
       ) : null}
 
       <section className={`${CARD_PADDED} flex flex-col gap-space-3`}>
-        <SectionHeading>What you can do next</SectionHeading>
+        <SectionHeading>What happens next</SectionHeading>
         {moves.length === 0 ? (
-          <p className="text-body text-text-muted">
-            This tournament is finished. Nothing moves from here.
-          </p>
+          <p className="text-body text-text-muted">This tournament is finished. Nothing moves from here.</p>
         ) : (
           <ul className="flex flex-col gap-space-3">
             {moves.map(({ to, result }) => (
@@ -279,21 +301,16 @@ function OrganizerLane({
         <p className="inline-flex items-start gap-space-2 border-t border-hairline pt-space-3 text-caption text-text-muted">
           <LockIcon size="h-space-4 w-space-4" />
           These controls are shown, and disabled, on purpose. Moving a tournament between states is
-          the server&apos;s decision, not the phone&apos;s, and that half is not switched on in this
-          build yet.
+          the server&apos;s decision, not the phone&apos;s, and that half is not switched on in this build yet.
         </p>
       </section>
 
       <Link href={`/tournaments/${tournament.id}/leaderboard`} className={SECONDARY_BUTTON}>
-        Open the public board
+        Open public Results
       </Link>
     </div>
   );
 }
-
-/* -------------------------------------------------------------------------- */
-/* Judging                                                                     */
-/* -------------------------------------------------------------------------- */
 
 function JudgeLane({ flagged }: { flagged: readonly DemoTournamentCatch[] }) {
   return (
@@ -352,31 +369,16 @@ function JudgeLane({ flagged }: { flagged: readonly DemoTournamentCatch[] }) {
   );
 }
 
-/* -------------------------------------------------------------------------- */
-/* Money                                                                       */
-/* -------------------------------------------------------------------------- */
-
-/**
- * The finance lane shows no numbers.
- *
- * The first version displayed "$1,250" of entry receipts and a "$1,000" prize pool on every
- * tournament, which were invented. Money is the one place in this product where a
- * placeholder is not a harmless mock — an organizer who reads a payout figure off a screen
- * and repeats it at a weigh-in has been misled by us. Until there is a real ledger to read,
- * this lane explains the guarantee it enforces and offers nothing to press.
- */
 function FinanceLane() {
   return (
     <div className="flex flex-col gap-space-4">
       <section className={`${CARD_PADDED} flex flex-col gap-space-3`}>
         <SectionHeading>Entry money and payouts</SectionHeading>
         <p className="text-body text-text-primary">
-          Nothing has been taken and nothing is owed. Payments are not switched on for this
-          tournament.
+          Nothing has been taken and nothing is owed. Payments are not switched on for this tournament.
         </p>
         <p className="text-caption text-text-muted">
-          When they are, this is where entry receipts and the prize pool are read from the ledger —
-          never estimated on the phone.
+          When they are, this is where entry receipts and the prize pool are read from the ledger — never estimated on the phone.
         </p>
       </section>
 

--- a/src/features/tournaments/components/tournament-registration.tsx
+++ b/src/features/tournaments/components/tournament-registration.tsx
@@ -5,9 +5,9 @@ import { useCallback, useEffect, useId, useState } from "react";
 
 import { createClient } from "@/lib/supabase/client";
 import { getDemoEntry, hasSupabaseBrowserConfig, registerDemoEntry, type DemoEntry } from "../demo-store";
-import { entrySteps, statusPresentation, TONE_CLASSES } from "../format";
+import { entrySteps, statusPresentation, TONE_CLASSES, type StatusTone } from "../format";
 import { useDemoMode, useTournament } from "../use-tournament";
-import { BIG_ACTION, CARD_PADDED, INPUT, PAGE, SECONDARY_BUTTON } from "../ui-classes";
+import { BIG_ACTION, CARD_PADDED, INPUT, INSET, PAGE, SECONDARY_BUTTON } from "../ui-classes";
 import { AlertIcon, CheckIcon, PendingIcon } from "./icons";
 import {
   BackLink,
@@ -15,6 +15,7 @@ import {
   ErrorScreen,
   LoadingScreen,
   SectionHeading,
+  TonePill,
   TournamentHero,
   TournamentTabs,
 } from "./tournament-chrome";
@@ -24,15 +25,15 @@ type ExistingEntry = Pick<
   "id" | "registration_status" | "eligibility_status" | "check_in_status" | "competition_status"
 >;
 
-/**
- * /tournaments/[id]/register — entering, and knowing where your entry stands.
- *
- * UX-001 §5: "Do not collapse all state into 'registered'." The old screen technically
- * obeyed that — it printed all four states — but as a 2×2 grid of lowercased enums
- * (`not_checked_in`, `unknown`), which tells an angler standing on a dock exactly nothing
- * about whether they are allowed to fish. Each state now gets a line, a plain word, and
- * the sentence that says what to do about it.
- */
+type EntryGuidance = {
+  readonly tone: StatusTone;
+  readonly label: string;
+  readonly title: string;
+  readonly body: string;
+  readonly href?: string;
+  readonly action?: string;
+};
+
 export function TournamentRegistration({ tournamentId }: { tournamentId: string }) {
   const load = useTournament(tournamentId);
   const demoMode = useDemoMode();
@@ -53,9 +54,6 @@ export function TournamentRegistration({ tournamentId }: { tournamentId: string 
     const { data: authData } = await supabase.auth.getUser();
     if (!authData.user) return;
 
-    // An entry is reached through the identity claim rather than by user id, because a
-    // tournament keeps its own participant identity — the same person can be an entrant in
-    // an event they later stop having an account for, and the result still has to stand.
     const { data: identityRows } = await supabase
       .from("tournament_entry_identity")
       .select("tournament_entry_id")
@@ -125,63 +123,32 @@ export function TournamentRegistration({ tournamentId }: { tournamentId: string 
     <div className={PAGE}>
       <TournamentHero
         tournament={tournament}
-        // The hero repeats the tournament name directly below, so the eyebrow names the
-        // destination instead of saying the same words twice.
-        eyebrow={<BackLink href={`/tournaments/${tournament.id}/overview`}>Overview</BackLink>}
+        eyebrow={<BackLink href={`/tournaments/${tournament.id}/overview`}>Tournament home</BackLink>}
       />
 
       <TournamentTabs tournamentId={tournament.id} />
 
+      <div className="flex flex-col gap-space-1">
+        <span className="text-label text-signal-orange">Step 1 of 3</span>
+        <h2 className="text-h2 text-text-primary">My entry</h2>
+        <p className="text-body text-text-muted">Know exactly what is complete, what is waiting, and what you need to do next.</p>
+      </div>
+
       {entry ? (
-        <section className={`${CARD_PADDED} flex flex-col gap-space-4`} aria-labelledby="entry-heading">
-          <SectionHeading>
-            <span id="entry-heading">You are entered</span>
-          </SectionHeading>
-
-          {/*
-            Four separate states, deliberately. Payment, eligibility, check-in and
-            competition move independently — one being green does not make the others
-            green, and an entry that is confirmed but not checked in is a real situation a
-            person needs to be able to see on a phone at 5am.
-          */}
-          <ol className="flex flex-col gap-space-4">
-            {entrySteps(entry).map((item) => {
-              const classes = TONE_CLASSES[item.tone];
-              const Icon =
-                item.tone === "open" || item.tone === "live"
-                  ? CheckIcon
-                  : item.tone === "attention" || item.tone === "stopped"
-                    ? AlertIcon
-                    : PendingIcon;
-              return (
-                <li key={item.label} className="flex items-start gap-space-3">
-                  <span className={`mt-space-1 ${classes.text}`}>
-                    <Icon />
-                  </span>
-                  <span className="flex flex-col gap-space-1">
-                    <span className="text-caption text-text-muted">{item.label}</span>
-                    <span className={`text-body-strong ${classes.text}`}>{item.value}</span>
-                    <span className="text-caption text-text-muted">{item.hint}</span>
-                  </span>
-                </li>
-              );
-            })}
-          </ol>
-
-          <p className="border-t border-hairline pt-space-3 text-caption text-text-muted">
-            These four are tracked separately on purpose, so that none of them can quietly change
-            another. Paying does not make you eligible, and checking in does not score you.
-          </p>
-
-          <Link href={`/tournaments/${tournament.id}/rules`} className={SECONDARY_BUTTON}>
-            What am I signing up to?
-          </Link>
-        </section>
+        <EntryStatus tournamentId={tournament.id} tournamentStatus={tournament.status} entry={entry} />
       ) : tournament.status === "REGISTRATION_OPEN" ? (
         <form onSubmit={register} className={`${CARD_PADDED} flex flex-col gap-space-4`}>
-          <SectionHeading>Enter this tournament</SectionHeading>
+          <div className="flex flex-col gap-space-1">
+            <SectionHeading>Start your entry</SectionHeading>
+            <p className="text-body text-text-muted">Your tournament identity starts here. Any additional host requirements can follow this entry.</p>
+          </div>
+
+          <Link href={`/tournaments/${tournament.id}/rules`} className={SECONDARY_BUTTON}>
+            Review tournament rules
+          </Link>
+
           <label className="flex flex-col gap-space-2">
-            <span className="text-label text-text-primary">What name should show on the board?</span>
+            <span className="text-label text-text-primary">Name on the standings</span>
             <input
               id={`${fieldId}-name`}
               required
@@ -192,10 +159,7 @@ export function TournamentRegistration({ tournamentId }: { tournamentId: string 
               placeholder="How your crew knows you"
               autoComplete="nickname"
             />
-            <span className="text-caption text-text-muted">
-              This is what other anglers see. Your account stays linked to the entry behind the
-              scenes, so the tournament keeps its own record even if your account changes later.
-            </span>
+            <span className="text-caption text-text-muted">This is the name other anglers will see on tournament screens.</span>
           </label>
 
           {error ? (
@@ -208,7 +172,7 @@ export function TournamentRegistration({ tournamentId }: { tournamentId: string 
             {submitting ? "Entering…" : "Enter tournament"}
           </button>
           {displayName.trim().length === 0 ? (
-            <p className="text-caption text-text-muted">Add a name to enter.</p>
+            <p className="text-caption text-text-muted">Add the name you want shown on the standings.</p>
           ) : null}
         </form>
       ) : (
@@ -217,11 +181,11 @@ export function TournamentRegistration({ tournamentId }: { tournamentId: string 
           <p className="text-body text-text-primary">{statusPresentation(tournament.status).blurb}</p>
           <p className="text-caption text-text-muted">
             {tournament.status === "DRAFT"
-              ? "The organizer has not opened this one up yet."
-              : "If you think you should be in this tournament, the organizer can add you."}
+              ? "The host has not opened registration yet."
+              : "If you believe you should already be entered, contact the tournament host."}
           </p>
           <Link href={`/tournaments/${tournament.id}/overview`} className={SECONDARY_BUTTON}>
-            Back to the tournament
+            Tournament home
           </Link>
         </section>
       )}
@@ -229,4 +193,200 @@ export function TournamentRegistration({ tournamentId }: { tournamentId: string 
       {demoMode ? <DemoNote /> : null}
     </div>
   );
+}
+
+function EntryStatus({
+  tournamentId,
+  tournamentStatus,
+  entry,
+}: {
+  tournamentId: string;
+  tournamentStatus: string;
+  entry: ExistingEntry;
+}) {
+  const steps = entrySteps(entry);
+  const guidance = entryGuidance(entry, tournamentStatus, tournamentId);
+
+  return (
+    <section className={`${CARD_PADDED} flex flex-col gap-space-5`} aria-labelledby="entry-heading">
+      <div className={`${INSET} flex flex-col gap-space-3`}>
+        <div className="flex flex-wrap items-center justify-between gap-space-2">
+          <TonePill tone={guidance.tone}>{guidance.label}</TonePill>
+          <span className="text-caption text-text-muted">Your next move</span>
+        </div>
+        <div className="flex flex-col gap-space-1">
+          <h3 className="text-h3 text-text-primary">{guidance.title}</h3>
+          <p className="text-body text-text-muted">{guidance.body}</p>
+        </div>
+        {guidance.href && guidance.action ? (
+          <Link href={guidance.href} className={SECONDARY_BUTTON}>
+            {guidance.action}
+          </Link>
+        ) : null}
+      </div>
+
+      <div className="flex flex-col gap-space-3">
+        <SectionHeading>
+          <span id="entry-heading">Entry checklist</span>
+        </SectionHeading>
+        <ol className="flex flex-col gap-space-4">
+          {steps.map((item, index) => {
+            const classes = TONE_CLASSES[item.tone];
+            const Icon =
+              item.tone === "open" || item.tone === "live"
+                ? CheckIcon
+                : item.tone === "attention" || item.tone === "stopped"
+                  ? AlertIcon
+                  : PendingIcon;
+            return (
+              <li key={item.label} className="grid grid-cols-[auto_auto_1fr] items-start gap-space-3">
+                <span className="flex h-space-7 w-space-7 items-center justify-center rounded-full border border-hairline text-caption text-text-muted">
+                  {index + 1}
+                </span>
+                <span className={`mt-space-1 ${classes.text}`}>
+                  <Icon />
+                </span>
+                <span className="flex flex-col gap-space-1">
+                  <span className="text-caption text-text-muted">{item.label}</span>
+                  <span className={`text-body-strong ${classes.text}`}>{item.value}</span>
+                  <span className="text-caption text-text-muted">{item.hint}</span>
+                </span>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+
+      <div className="flex flex-wrap gap-space-2 border-t border-hairline pt-space-4">
+        <Link href={`/tournaments/${tournamentId}/rules`} className={SECONDARY_BUTTON}>
+          Review rules
+        </Link>
+        {entry.competition_status === "ACTIVE" ? (
+          <Link href={`/tournaments/${tournamentId}/catches`} className={SECONDARY_BUTTON}>
+            Go to Compete
+          </Link>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function entryGuidance(entry: ExistingEntry, tournamentStatus: string, tournamentId: string): EntryGuidance {
+  if (entry.competition_status === "ACTIVE") {
+    return {
+      tone: "live",
+      label: "Fishing now",
+      title: "You are active in this tournament",
+      body: "Your entry is live. Log catches as you land them and watch their submission status from the Compete screen.",
+      href: `/tournaments/${tournamentId}/catches`,
+      action: "Go to Compete",
+    };
+  }
+
+  if (entry.competition_status === "DISQUALIFIED") {
+    return {
+      tone: "stopped",
+      label: "Needs attention",
+      title: "This entry is disqualified",
+      body: "A judge has recorded this state. Review the tournament rules and contact the host if you need the decision explained.",
+      href: `/tournaments/${tournamentId}/rules`,
+      action: "Review rules",
+    };
+  }
+
+  if (entry.competition_status === "WITHDRAWN" || entry.registration_status === "CANCELLED") {
+    return {
+      tone: "stopped",
+      label: "Not competing",
+      title: "This entry is no longer active",
+      body: "You are not currently part of the competitive field for this tournament.",
+    };
+  }
+
+  if (entry.registration_status === "PAYMENT_REQUIRED") {
+    return {
+      tone: "attention",
+      label: "Action needed",
+      title: "Payment is the next requirement",
+      body: "Your place is being held, but the entry is not fully confirmed until the tournament's payment requirement is satisfied.",
+    };
+  }
+
+  if (entry.registration_status !== "CONFIRMED") {
+    return {
+      tone: entry.registration_status === "WAITLISTED" ? "attention" : "neutral",
+      label: entry.registration_status === "WAITLISTED" ? "Waitlisted" : "Waiting",
+      title: entry.registration_status === "WAITLISTED" ? "You are waiting for a spot" : "Your entry is with the host",
+      body: entry.registration_status === "WAITLISTED"
+        ? "You are not in the active field yet. The host can confirm you if a place opens."
+        : "Your entry has been submitted. The host still needs to confirm your place.",
+    };
+  }
+
+  if (entry.eligibility_status === "ACTION_REQUIRED") {
+    return {
+      tone: "attention",
+      label: "Action needed",
+      title: "The host needs something from you",
+      body: "Your place is confirmed, but eligibility is waiting on additional information. Check with the tournament host before lines in.",
+    };
+  }
+
+  if (entry.eligibility_status === "INELIGIBLE") {
+    return {
+      tone: "stopped",
+      label: "Not eligible",
+      title: "You are not cleared to compete",
+      body: "The entry is confirmed, but the eligibility check did not clear. Ask the host what would need to change.",
+    };
+  }
+
+  if (entry.eligibility_status !== "ELIGIBLE") {
+    return {
+      tone: "neutral",
+      label: "Being checked",
+      title: "Eligibility is the next checkpoint",
+      body: "Your place is confirmed. The host still needs to clear the eligibility requirements for this tournament.",
+    };
+  }
+
+  if (entry.check_in_status === "MISSED") {
+    return {
+      tone: "attention",
+      label: "Action needed",
+      title: "Check-in was missed",
+      body: "Talk to the host before fishing. A confirmed and eligible entry can still be held out if check-in is unresolved.",
+    };
+  }
+
+  if (entry.check_in_status !== "CHECKED_IN") {
+    return {
+      tone: tournamentStatus === "LIVE" ? "attention" : "neutral",
+      label: tournamentStatus === "LIVE" ? "Check in now" : "Next: check-in",
+      title: tournamentStatus === "LIVE" ? "The tournament is live, but you are not checked in" : "You are cleared — check-in is next",
+      body: tournamentStatus === "LIVE"
+        ? "Resolve check-in with the host before you fish so your entry status is clear."
+        : "Your place and eligibility are good. Check in at the event before lines in.",
+    };
+  }
+
+  if (tournamentStatus === "FINAL" || tournamentStatus === "COMPLETED" || tournamentStatus === "RESULTS_PENDING") {
+    return {
+      tone: tournamentStatus === "FINAL" ? "done" : "neutral",
+      label: tournamentStatus === "FINAL" ? "Finished" : "Fishing finished",
+      title: tournamentStatus === "FINAL" ? "This tournament is complete" : "Your fishing is done",
+      body: tournamentStatus === "FINAL"
+        ? "Results are official. Head to Results to see the final standings."
+        : "Lines are out. Results can still move while judging is completed.",
+      href: `/tournaments/${tournamentId}/leaderboard`,
+      action: "View Results",
+    };
+  }
+
+  return {
+    tone: "open",
+    label: "Ready",
+    title: "You are ready for lines in",
+    body: "Your place is confirmed, eligibility is clear, and check-in is complete. Nothing else is blocking your entry.",
+  };
 }


### PR DESCRIPTION
## Goal
Continue the tournament UX redesign after #125 by making each handoff obvious: what an angler needs to do next, how the competitive flow progresses, and how a host thinks about the event lifecycle.

## What changed
- Tournament navigation now reads as an explicit flow: **1 Entry → 2 Compete → 3 Results**, with Home and Rules kept as reference destinations.
- **My Entry** now leads with a plain-language "Your next move" card instead of forcing an angler to interpret four independent status values.
- Entry status is presented as a numbered checklist: place, eligibility, check-in, competing.
- Context-aware guidance covers payment required, waitlist, eligibility action, missed check-in, live competition, withdrawn/disqualified state, and post-event results.
- **Results** now clearly hands users back to Compete while the event is live and back to Entry before it starts.
- The user's locally saved catches are framed as catch status, with a direct route back to review them.
- **Host controls** now show a simple lifecycle: **Set up → Run → Settle**.
- Host work areas are simplified to **Event / Judging / Money**, while preserving their separate permission boundaries.

## Scope
UX/UI and information architecture only. No scoring logic, migrations, payment processing, tournament lifecycle rules, judging decisions, or database behavior changed.

## Review focus
At phone width, a new angler should be able to answer immediately:
1. Where am I in the tournament?
2. What do I need to do next?
3. Where do I go to compete or see results?

A host should be able to answer:
1. Am I setting up, running, or settling the event?
2. Which work area do I need right now?
