### PR TITLE
Harden the tournament section and close the flow's loops

### DIFF
--- a/docs/team/worklog/2026-09-07-03-ux-ui.md
+++ b/docs/team/worklog/2026-09-07-03-ux-ui.md
@@ -49,6 +49,15 @@ show. No console errors.
   components/{create-tournament-form,registration-page,tournament-chrome}.tsx,
   use-tournament.ts, queries/use-events.ts, demo-store.ts,
   supabase/migrations/{20260907140000,20260907150000}.
+**Standings had the worst version of the silent-blank problem.** Three screens did
+`demoMode ? getDemoStandings(id) : []`, so against a real database the leaderboard always
+rendered "Nothing has been scored yet — approved catches will appear here." That sentence
+is not true: nothing would ever have appeared, because nothing was ever asked for. A
+reassuring empty state over a missing query is worse than an error, because nobody reports
+it — it just looks like a quiet tournament. There is a loader now reading
+`public_leaderboard` joined to `public_tournament_entry`, and the screens tell "still
+loading", "the standings did not load" and "nobody has scored" apart.
+
 - Next: host admin (part three) is still not built — `/tournaments/[id]/operations` exists
-  and is where it goes. Standings, live catches and entries are still demo-only on the real
-  path. No payment gateway, and none of this has been on a real phone.
+  and is where it goes. Live catches and entry writes are still device-local. No payment
+  gateway, and none of this has been on a real phone.

--- a/docs/team/worklog/2026-09-07-03-ux-ui.md
+++ b/docs/team/worklog/2026-09-07-03-ux-ui.md
@@ -1,0 +1,54 @@
+### 2026-09-07 | ux-ui + head-dev | 3h
+
+Tidy-and-harden pass on the tournament section, ahead of production. No new screens — this
+is the flow closing its loops and the production data path being made honest.
+
+**The flow had a hole in the middle.** The create form asked for a name, a visibility and
+two dates. The event calendar shipped two days earlier answers three questions — where it
+is, what the pot is at, how long you have to enter — and the form collected none of them.
+So every event a host actually made appeared on the calendar as "Not announced", no price
+and no deadline. Added a step for where it is, what it costs, when entries close, and the
+refund policy, and the review screen now shows the card as an angler will read it.
+
+**Two things would have failed outright against a real database.** Both silent, both found
+by reading rather than by a test:
+
+- The public projection of a tournament did not carry `location_name`, `entry_fee_minor` or
+  `currency`, and PostgREST rejects a request for a column a view does not have — so the
+  entire events list would have failed for everyone, not just hidden a field. There is now
+  a test that reads the migrations and fails if the code asks the view for something it does
+  not select. I broke the view on purpose to check the test catches it.
+- Jackpots were read straight from the demo seed with no database path, so the founder's
+  headline feature would have rendered nothing at all — no error, no empty state, just no
+  jackpot section on any event.
+
+**Other things that were quietly wrong:**
+- Opening a public event you did not host said "not shared with you". The loader only read
+  the members-only table; it now falls back to the public projection.
+- `entered` was hardcoded false on the real path, so My Tournaments would have been empty
+  for every signed-in angler.
+- Every screen did `data as TournamentRecord` on network input. A cast is not a check; rows
+  are narrowed now, and a missing price reads as "not known", never as free.
+- The type was still called `DemoTournament` while the production path cast real rows to
+  it. Renamed.
+- The section had grown a **second** `BackLink` component with a different type scale, so
+  half of it went back in one size and half in another — the exact inconsistency the shell
+  round removed from the rest of the app. One now, with a test that fails if a third
+  appears.
+- Entry fees went through `Number(x) * 100`, which cannot represent most decimal fractions:
+  `1.005` becomes 100 cents rather than 101. Prices are parsed as text now.
+
+Checked: `npm run verify` clean, 955 tests across 92 files, `npm run build` clean. Walked
+it in a browser at 390px against the production build — hosted an event with a location, a
+$175.50 fee, a deadline and a refund policy, watched it appear on the calendar with all of
+it, then registered for a seeded event and confirmed the jackpots and the host's policy
+show. No console errors.
+
+- Files: src/features/tournaments/types.ts (+test), queries/{tournament-facts,use-divisions}.ts,
+  src/core/tournaments/money.ts (+test), src/components/back-link.test.ts,
+  components/{create-tournament-form,registration-page,tournament-chrome}.tsx,
+  use-tournament.ts, queries/use-events.ts, demo-store.ts,
+  supabase/migrations/{20260907140000,20260907150000}.
+- Next: host admin (part three) is still not built — `/tournaments/[id]/operations` exists
+  and is where it goes. Standings, live catches and entries are still demo-only on the real
+  path. No payment gateway, and none of this has been on a real phone.

--- a/src/app/(app)/tournaments/new/page.tsx
+++ b/src/app/(app)/tournaments/new/page.tsx
@@ -12,7 +12,8 @@ export default function NewTournamentPage() {
         <BackLink href="/tournaments" label="Tournaments" />
         <h1 className="text-h1 text-text-primary">Create a tournament</h1>
         <p className="text-body text-text-muted">
-          Three questions. The rest waits until you need it.
+          The name, where it is and what it costs, and who can see it. The rest waits
+          until you need it.
         </p>
       </header>
       <CreateTournamentForm />

--- a/src/components/back-link.test.ts
+++ b/src/components/back-link.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * There is one way to go back, and it is this component.
+ *
+ * The shell round removed five spellings of "back" from the app — "← Passport",
+ * "‹ Calendar", "Back to the Fish Log", a chevron-and-word, and eight screens with nothing
+ * at all — and replaced them with `BackLink`. Within days the tournament section had grown
+ * a *second* component with the same name, a different type scale, and its own class
+ * constant, so half that section went back in `text-caption` and the other half in
+ * `text-label`.
+ *
+ * That is not a thing anyone does on purpose; it is what happens when a feature needs a
+ * back link and the shared one is one directory further away than a local one. So the rule
+ * is a test rather than a convention.
+ */
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+
+function sourceFiles(): readonly string[] {
+  return execSync("git ls-files 'src/**/*.tsx' 'src/**/*.ts'", { cwd: repoRoot, encoding: "utf8" })
+    .split("\n")
+    .filter(Boolean);
+}
+
+describe("one back link", () => {
+  const files = sourceFiles();
+
+  it("finds the source tree, so a moved directory cannot make this vacuous", () => {
+    expect(files.length).toBeGreaterThan(50);
+    expect(files).toContain("src/components/back-link.tsx");
+  });
+
+  it("is declared exactly once, in src/components", () => {
+    const declarations = files.filter((file) =>
+      /export function BackLink\b/.test(readFileSync(`${repoRoot}${file}`, "utf8")),
+    );
+    expect(
+      declarations,
+      `A second BackLink means two ways back with two different type scales, which is the ` +
+        `inconsistency the shared component was created to end. Import ` +
+        `\`@/components/back-link\` instead of declaring another.`,
+    ).toEqual(["src/components/back-link.tsx"]);
+  });
+
+  it("is what the tournament section uses, since that is where the second one grew", () => {
+    const usesShared = files.filter(
+      (file) =>
+        file.startsWith("src/features/tournaments/") &&
+        readFileSync(`${repoRoot}${file}`, "utf8").includes('from "@/components/back-link"'),
+    );
+    expect(usesShared.length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/back-link.test.ts
+++ b/src/components/back-link.test.ts
@@ -24,7 +24,11 @@ const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
 function sourceFiles(): readonly string[] {
   return execSync("git ls-files 'src/**/*.tsx' 'src/**/*.ts'", { cwd: repoRoot, encoding: "utf8" })
     .split("\n")
-    .filter(Boolean);
+    .filter(Boolean)
+    // Test files are excluded because this one contains the very pattern it searches for,
+    // written out in its own assertion. It failed on itself the moment it was committed —
+    // which is at least proof the search works.
+    .filter((file) => !/\.test\.tsx?$/.test(file));
 }
 
 describe("one back link", () => {

--- a/src/core/tournaments/money.test.ts
+++ b/src/core/tournaments/money.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { minorToInput, parseMoneyToMinor } from "./money";
+
+describe("parseMoneyToMinor", () => {
+  it("reads whole dollars and cents exactly", () => {
+    expect(parseMoneyToMinor("40")).toEqual({ ok: true, minor: 4000 });
+    expect(parseMoneyToMinor("40.10")).toEqual({ ok: true, minor: 4010 });
+    expect(parseMoneyToMinor("40.1")).toEqual({ ok: true, minor: 4010 });
+    expect(parseMoneyToMinor(".5")).toEqual({ ok: true, minor: 50 });
+  });
+
+  it("does not go through a float, so the classic rounding bug cannot happen", () => {
+    // Math.round(1.005 * 100) is 100 in IEEE 754, not 101. This must be 101.
+    expect(parseMoneyToMinor("1.005")).toEqual({ ok: false, reason: "too-precise" });
+    expect(parseMoneyToMinor("1.01")).toEqual({ ok: true, minor: 101 });
+    expect(parseMoneyToMinor("8.165")).toEqual({ ok: false, reason: "too-precise" });
+  });
+
+  it("accepts a price written the way a person writes one", () => {
+    expect(parseMoneyToMinor("$250")).toEqual({ ok: true, minor: 25000 });
+    expect(parseMoneyToMinor(" 1,250.00 ")).toEqual({ ok: true, minor: 125000 });
+  });
+
+  it("treats free as a real price, not as empty", () => {
+    expect(parseMoneyToMinor("0")).toEqual({ ok: true, minor: 0 });
+    expect(parseMoneyToMinor("0.00")).toEqual({ ok: true, minor: 0 });
+  });
+
+  it("refuses what is not a price rather than guessing", () => {
+    expect(parseMoneyToMinor("")).toEqual({ ok: false, reason: "not-a-number" });
+    expect(parseMoneyToMinor("free")).toEqual({ ok: false, reason: "not-a-number" });
+    expect(parseMoneyToMinor("40.00.00")).toEqual({ ok: false, reason: "not-a-number" });
+    expect(parseMoneyToMinor("-40")).toEqual({ ok: false, reason: "negative" });
+  });
+
+  it("refuses an implausible number rather than storing a typo as a fee", () => {
+    expect(parseMoneyToMinor("99999999999")).toEqual({ ok: false, reason: "too-large" });
+  });
+});
+
+describe("minorToInput", () => {
+  it("is the exact inverse for anything the parser accepts", () => {
+    for (const value of ["0", "40", "40.10", "1250", "0.05", "9.99"]) {
+      const parsed = parseMoneyToMinor(value);
+      expect(parsed.ok).toBe(true);
+      if (!parsed.ok) throw new Error("unreachable");
+      expect(parseMoneyToMinor(minorToInput(parsed.minor))).toEqual(parsed);
+    }
+  });
+
+  it("shows an unset price as an empty field, not as zero", () => {
+    // Null is "not priced"; zero is "free". A field pre-filled with 0 would turn every
+    // unpriced draft into a free event the first time somebody saved it.
+    expect(minorToInput(null)).toBe("");
+    expect(minorToInput(0)).toBe("0");
+  });
+});

--- a/src/core/tournaments/money.ts
+++ b/src/core/tournaments/money.ts
@@ -1,0 +1,44 @@
+/**
+ * Reading a price a person typed, into the integer minor units the schema stores.
+ *
+ * Every money column in this schema is `bigint` minor units, and every screen that takes a
+ * price takes it as text. This is the one place that crossing happens, so it is the one
+ * place a rounding error could be introduced — which is why it does not go near a float.
+ *
+ * `Math.round(Number("40.10") * 100)` looks fine and mostly is, but binary floating point
+ * cannot hold most decimal fractions exactly, and the failures are quiet: `1.005 * 100` is
+ * `100.49999999999999`, which rounds to 10049 rather than 10050. Splitting the string on
+ * its decimal point and padding the fraction is exact for every input, always.
+ */
+
+export type MoneyParse =
+  | { readonly ok: true; readonly minor: number }
+  | { readonly ok: false; readonly reason: "not-a-number" | "negative" | "too-precise" | "too-large" };
+
+/** A price is at most this many minor units — roughly ten million dollars. Beyond that it
+ *  is a typo, and refusing it is friendlier than accepting a fee nobody meant. */
+const MAX_MINOR = 1_000_000_000;
+
+export function parseMoneyToMinor(raw: string): MoneyParse {
+  const trimmed = raw.trim().replace(/[$,\s]/g, "");
+  if (trimmed === "") return { ok: false, reason: "not-a-number" };
+  if (trimmed.startsWith("-")) return { ok: false, reason: "negative" };
+  if (!/^\d*(?:\.\d*)?$/.test(trimmed)) return { ok: false, reason: "not-a-number" };
+
+  const [whole, fraction = ""] = trimmed.split(".");
+  if (fraction.length > 2) return { ok: false, reason: "too-precise" };
+  if (whole === "" && fraction === "") return { ok: false, reason: "not-a-number" };
+
+  const minor = Number(`${whole || "0"}${fraction.padEnd(2, "0")}`);
+  if (!Number.isSafeInteger(minor)) return { ok: false, reason: "too-large" };
+  if (minor > MAX_MINOR) return { ok: false, reason: "too-large" };
+  return { ok: true, minor };
+}
+
+/** Minor units back into the text a price field should show. The exact inverse. */
+export function minorToInput(minor: number | null): string {
+  if (minor === null) return "";
+  const whole = Math.trunc(minor / 100);
+  const cents = Math.abs(minor % 100);
+  return cents === 0 ? String(whole) : `${whole}.${String(cents).padStart(2, "0")}`;
+}

--- a/src/features/tournaments/components/create-tournament-form.tsx
+++ b/src/features/tournaments/components/create-tournament-form.tsx
@@ -4,14 +4,17 @@ import { useRouter } from "next/navigation";
 import { useId, useState } from "react";
 
 import { createClient } from "@/lib/supabase/client";
+import { parseMoneyToMinor } from "@/core/tournaments/money";
 import { createDemoTournament, hasSupabaseBrowserConfig } from "../demo-store";
-import { formatSchedule, visibilityPresentation } from "../format";
+import { formatMoney } from "../event-card";
+import { formatDateTime, formatSchedule, visibilityPresentation } from "../format";
 import {
   BIG_ACTION,
   CARD_PADDED,
   FOCUS_RING,
   INPUT,
   SECONDARY_BUTTON,
+  TABULAR,
   TERTIARY_BUTTON,
 } from "../ui-classes";
 import { CheckRow, DemoNote } from "./tournament-chrome";
@@ -38,7 +41,17 @@ const VISIBILITIES = ["PRIVATE", "INVITE_ONLY", "UNLISTED", "PUBLIC"] as const;
 
 type Visibility = (typeof VISIBILITIES)[number];
 
-const STEPS = ["The basics", "Who can see it", "Check it over"] as const;
+/*
+  A fourth step, added when the event calendar shipped. The calendar's whole job is to
+  answer three questions about an event — where it is, what it costs, and how long you have
+  to enter — and this form collected none of them, so every event a host actually created
+  appeared on it as "Not announced", no fee and no deadline. A create form that cannot fill
+  in the screen it feeds is the flow being broken in the middle.
+
+  Its own step rather than more fields on "The basics", which already carries a name and two
+  datetimes; six inputs in one column is the wall this wizard was built to avoid.
+*/
+const STEPS = ["The basics", "Where and what it costs", "Who can see it", "Check it over"] as const;
 
 function toIsoOrNull(value: string) {
   return value ? new Date(value).toISOString() : null;
@@ -53,6 +66,10 @@ export function CreateTournamentForm() {
   const [visibility, setVisibility] = useState<Visibility>("PRIVATE");
   const [startsAt, setStartsAt] = useState("");
   const [endsAt, setEndsAt] = useState("");
+  const [locationName, setLocationName] = useState("");
+  const [entryFee, setEntryFee] = useState("");
+  const [registrationClosesAt, setRegistrationClosesAt] = useState("");
+  const [refundPolicy, setRefundPolicy] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -68,7 +85,25 @@ export function CreateTournamentForm() {
       ? "The finish has to be after the start."
       : null;
 
-  const stepReady = step === 0 ? name.trim().length > 0 && !scheduleProblem : true;
+  /*
+    An empty fee is "not priced yet", which is a legitimate state to create a draft in. A fee
+    that was typed and cannot be read is not — that is somebody meaning to charge $40 and
+    getting no fee at all, which they would discover from an angler who entered for free.
+  */
+  const feeParse = entryFee.trim() === "" ? null : parseMoneyToMinor(entryFee);
+  const feeProblem =
+    feeParse && !feeParse.ok
+      ? feeParse.reason === "negative"
+        ? "An entry fee cannot be negative."
+        : feeParse.reason === "too-precise"
+          ? "Entry fees go to the cent — two decimal places."
+          : feeParse.reason === "too-large"
+            ? "That is larger than any entry fee. Check the number."
+            : "Write the entry fee as a number, like 250 or 250.00."
+      : null;
+
+  const stepReady =
+    step === 0 ? name.trim().length > 0 && !scheduleProblem : step === 1 ? !feeProblem : true;
 
   async function create() {
     setSubmitting(true);
@@ -80,6 +115,10 @@ export function CreateTournamentForm() {
         visibility,
         starts_at: toIsoOrNull(startsAt),
         ends_at: toIsoOrNull(endsAt),
+        location_name: locationName.trim() || null,
+        registration_closes_at: toIsoOrNull(registrationClosesAt),
+        entry_fee_minor: feeParse && feeParse.ok ? feeParse.minor : null,
+        refund_policy: refundPolicy.trim() || null,
       });
       router.push(`/tournaments/${tournament.id}/overview`);
       router.refresh();
@@ -111,6 +150,10 @@ export function CreateTournamentForm() {
           status: "DRAFT",
           starts_at: toIsoOrNull(startsAt),
           ends_at: toIsoOrNull(endsAt),
+          location_name: locationName.trim() || null,
+          registration_closes_at: toIsoOrNull(registrationClosesAt),
+          entry_fee_minor: feeParse && feeParse.ok ? feeParse.minor : null,
+          refund_policy: refundPolicy.trim() || null,
           created_by: authData.user.id,
         })
         .select("id")
@@ -209,6 +252,98 @@ export function CreateTournamentForm() {
       ) : null}
 
       {step === 1 ? (
+        <section className={`${CARD_PADDED} flex flex-col gap-space-5`}>
+          <div className="flex flex-col gap-space-2">
+            <label htmlFor={`${fieldId}-location`} className="text-label text-text-primary">
+              Where is it fished?
+            </label>
+            <input
+              id={`${fieldId}-location`}
+              maxLength={160}
+              value={locationName}
+              onChange={(event) => setLocationName(event.target.value)}
+              className={INPUT}
+              placeholder="Dana Point Harbor"
+            />
+            {/* Free text on purpose: an event is announced as "the Rockpile" long before
+                anybody plots it, and demanding a coordinate would block publishing. */}
+            <p className="text-caption text-text-muted">
+              However you would say it out loud. This is what people see on the calendar.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-space-2">
+            <label htmlFor={`${fieldId}-fee`} className="text-label text-text-primary">
+              What does it cost to enter?
+            </label>
+            <input
+              id={`${fieldId}-fee`}
+              inputMode="decimal"
+              value={entryFee}
+              onChange={(event) => setEntryFee(event.target.value)}
+              className={INPUT}
+              placeholder="250"
+              aria-invalid={feeProblem ? true : undefined}
+              aria-describedby={feeProblem ? `${fieldId}-fee-error` : undefined}
+            />
+            {feeProblem ? (
+              <p id={`${fieldId}-fee-error`} role="alert" className="text-body text-error-red">
+                {feeProblem}
+              </p>
+            ) : (
+              <p className="text-caption text-text-muted">
+                Leave it empty if you have not decided. Put 0 if it is free — that is a
+                different thing, and the calendar says so.
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-space-2">
+            <label htmlFor={`${fieldId}-closes`} className="text-label text-text-primary">
+              When do entries close?
+            </label>
+            <input
+              id={`${fieldId}-closes`}
+              type="datetime-local"
+              value={registrationClosesAt}
+              onChange={(event) => setRegistrationClosesAt(event.target.value)}
+              className={INPUT}
+            />
+            {/* Deliberately allowed to fall after the start: dock registration on the
+                morning of is normal, and the schema permits it for the same reason. */}
+            <p className="text-caption text-text-muted">
+              The calendar counts down to this. It is fine for it to be on the morning of,
+              if you take entries at the dock.
+            </p>
+          </div>
+
+          {/*
+            Shown to every angler directly above the pay button (ADR 010 §4). It is the
+            host's promise about the host's money, so the app collects it and repeats it
+            rather than writing one — an event with none says so, which is also information.
+          */}
+          <div className="flex flex-col gap-space-2">
+            <label htmlFor={`${fieldId}-refunds`} className="text-label text-text-primary">
+              What happens if somebody withdraws, or you cancel?
+            </label>
+            <textarea
+              id={`${fieldId}-refunds`}
+              rows={4}
+              maxLength={1000}
+              value={refundPolicy}
+              onChange={(event) => setRefundPolicy(event.target.value)}
+              className={`${INPUT} h-auto`}
+              placeholder="Full refund up to 48 hours before the start. If we cancel for weather, everything is refunded."
+            />
+            <p className="text-caption text-text-muted">
+              Anglers read this before they pay. Leave it empty and the app will say you have
+              not published one — it will not invent terms for you.
+            </p>
+          </div>
+        </section>
+      ) : null}
+
+      {step === 2 ? (
         <fieldset className={`${CARD_PADDED} flex flex-col gap-space-3`}>
           <legend className="text-label text-text-primary">Who can see it?</legend>
           <p className="text-caption text-text-muted">
@@ -242,7 +377,7 @@ export function CreateTournamentForm() {
         </fieldset>
       ) : null}
 
-      {step === 2 ? (
+      {step === 3 ? (
         <section className={`${CARD_PADDED} flex flex-col gap-space-4`}>
           <div className="flex flex-col gap-space-2">
             <h2 className="text-h3 text-text-primary">{name.trim() || "Untitled tournament"}</h2>
@@ -251,6 +386,42 @@ export function CreateTournamentForm() {
               {visibilityPresentation(visibility).label} · {visibilityPresentation(visibility).blurb}
             </p>
           </div>
+
+          {/*
+            The event card, as an angler will read it. Reviewing the name and the dates but
+            not the three facts the calendar leads with would let somebody confirm an event
+            without ever seeing that it has no location and no price.
+          */}
+          <dl className="flex flex-wrap gap-x-space-6 gap-y-space-3 border-t border-hairline pt-space-4">
+            <div className="min-w-0">
+              <dt className="text-caption text-text-muted">Where</dt>
+              <dd className="text-body text-text-primary">
+                {locationName.trim() || "Not announced"}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-caption text-text-muted">Entry</dt>
+              <dd className={`text-body text-text-primary ${TABULAR}`}>
+                {feeParse && feeParse.ok
+                  ? feeParse.minor === 0
+                    ? "Free to enter"
+                    : (formatMoney(feeParse.minor, "USD") ?? "—")
+                  : "Not priced"}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-caption text-text-muted">Entries close</dt>
+              <dd className="text-body text-text-primary">
+                {formatDateTime(toIsoOrNull(registrationClosesAt)) ?? "No deadline set"}
+              </dd>
+            </div>
+            <div className="w-full">
+              <dt className="text-caption text-text-muted">Refunds</dt>
+              <dd className="text-body text-text-primary">
+                {refundPolicy.trim() || "No policy published — the checkout will say so."}
+              </dd>
+            </div>
+          </dl>
 
           <div className="flex flex-col gap-space-3 border-t border-hairline pt-space-4">
             <p className="text-label text-text-primary">What happens next</p>
@@ -300,9 +471,13 @@ export function CreateTournamentForm() {
           </button>
         )}
 
-        {step === 0 && !stepReady ? (
+        {!stepReady ? (
           <p id={`${fieldId}-next-hint`} className="text-caption text-text-muted">
-            {scheduleProblem ? "Fix the times to carry on." : "Give it a name to carry on."}
+            {step === 1
+              ? "Fix the entry fee to carry on."
+              : scheduleProblem
+                ? "Fix the times to carry on."
+                : "Give it a name to carry on."}
           </p>
         ) : null}
 

--- a/src/features/tournaments/components/registration-page.tsx
+++ b/src/features/tournaments/components/registration-page.tsx
@@ -13,8 +13,9 @@ import {
   type EventOption,
 } from "@/core/tournaments/registration";
 
-import { getDemoDivisions, getDemoRefundPolicy, registerDemoEntry } from "../demo-store";
-import { registrationState, type TournamentEvent } from "../event-card";
+import { registerDemoEntry } from "../demo-store";
+import { registrationState } from "../event-card";
+import { useDivisions } from "../queries/use-divisions";
 import { useEvents } from "../queries/use-events";
 import { useNow } from "../use-now";
 import { CARD_PADDED, INSET, PAGE } from "../ui-classes";
@@ -55,31 +56,51 @@ export function RegistrationPage({ tournamentId }: { tournamentId: string }) {
 
   /* Only events still taking entries can be added. Offering a closed one and refusing it at
      checkout would waste the one decision the screen is asking for. */
-  const options: EventOption[] = useMemo(() => {
+  const enterable = useMemo(() => {
     if (load.state !== "ready") return [];
-    const enterable = load.events.filter((event) => {
+    return load.events.filter((event) => {
       const kind = registrationState(event, nowMs).kind;
       return event.id === tournamentId || kind === "open" || kind === "open-no-deadline";
     });
-    return enterable.map(toOption);
   }, [load, nowMs, tournamentId]);
+
+  /*
+    Jackpots come from a loader now rather than straight out of the demo seed. Read from the
+    seed, they were invisible against a real database — no error, no empty state, just no
+    jackpot section on any event, which is the founder's headline feature quietly absent.
+  */
+  const divisions = useDivisions(useMemo(() => enterable.map((event) => event.id), [enterable]));
+
+  const options: EventOption[] = useMemo(
+    () =>
+      enterable.map((event) => ({
+        id: event.id,
+        name: event.name,
+        entryFeeMinor: event.entry_fee_minor,
+        currency: event.currency,
+        divisions:
+          divisions.state === "ready" ? (divisions.byTournament.get(event.id) ?? []) : [],
+      })),
+    [enterable, divisions],
+  );
 
   const selection = useMemo(() => ({ eventIds, divisionIds }), [eventIds, divisionIds]);
   const build = useMemo(() => buildOrder(options, selection), [options, selection]);
   const problems = useMemo(() => crewProblems(crew), [crew]);
 
   const arrivedFrom = options.find((option) => option.id === tournamentId);
-  /* One policy per event on the order — see the note in `checkout-panel.tsx`. */
+  /* One policy per event on the order — see the note in `checkout-panel.tsx`. It comes off
+     the event itself now, so a host who writes one actually has it shown. */
   const refundPolicies = useMemo(
     () =>
-      options
-        .filter((option) => eventIds.includes(option.id))
-        .map((option) => ({
-          eventId: option.id,
-          eventName: option.name,
-          policy: getDemoRefundPolicy(option.id),
+      enterable
+        .filter((event) => eventIds.includes(event.id))
+        .map((event) => ({
+          eventId: event.id,
+          eventName: event.name,
+          policy: event.refund_policy,
         })),
-    [options, eventIds],
+    [enterable, eventIds],
   );
 
   if (load.state === "loading") return <LoadingScreen label="Loading registration" />;
@@ -187,22 +208,4 @@ function blockedReason(input: { problems: number; policyAcknowledged: boolean })
   if (input.problems > 0) return "Finish the crew details above before paying.";
   if (!input.policyAcknowledged) return "Tick the box above to confirm you have read the policy.";
   return null;
-}
-
-function toOption(event: TournamentEvent): EventOption {
-  return {
-    id: event.id,
-    name: event.name,
-    entryFeeMinor: event.entry_fee_minor,
-    currency: event.currency,
-    divisions: getDemoDivisions(event.id).map((division) => ({
-      id: division.id,
-      name: division.name,
-      description: division.description,
-      kind: division.kind,
-      entryFeeMinor: division.entry_fee_minor,
-      poolMinor: division.pool_minor,
-      participantCount: division.participant_count,
-    })),
-  };
 }

--- a/src/features/tournaments/components/tournament-chrome.tsx
+++ b/src/features/tournaments/components/tournament-chrome.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import Link from "next/link";
+
+import { BackLink } from "@/components/back-link";
 import { usePathname } from "next/navigation";
 
 import {
@@ -11,9 +13,10 @@ import {
   visibilityLabel,
   type StatusTone,
 } from "../format";
+import { entryFeeLabel, formatMoney } from "../event-card";
+import type { TournamentRecord } from "../types";
 import { useNow, useOnline } from "../use-now";
 import {
-  BACK_LINK,
   CARD,
   CARD_PADDED,
   FOCUS_RING,
@@ -21,20 +24,20 @@ import {
   SECONDARY_BUTTON,
   TABULAR,
 } from "../ui-classes";
-import { AlertIcon, BackIcon, CheckIcon, ClockIcon, PendingIcon } from "./icons";
+import { AlertIcon, CheckIcon, ClockIcon, PendingIcon } from "./icons";
 
 export function TournamentPage({ children }: { children: React.ReactNode }) {
   return <div className={PAGE}>{children}</div>;
 }
 
-export function BackLink({ href, children }: { href: string; children: React.ReactNode }) {
-  return (
-    <Link href={href} className={BACK_LINK}>
-      <BackIcon />
-      {children}
-    </Link>
-  );
-}
+/*
+  The section's own `BackLink` used to live here — a second component with the same name and
+  a different type scale (`text-caption`) from the app-wide one in `@/components/back-link`
+  (`text-label`). That is the "five spellings of back" problem the shell round removed from
+  the rest of the app, quietly re-grown inside this feature. There is one now, and it is the
+  shared one; a component that knows no domain noun belongs in `src/components/` by
+  ADR 005 §3 anyway.
+*/
 
 export function StatusPill({ status, className = "" }: { status: string; className?: string }) {
   const { label, tone } = statusPresentation(status);
@@ -97,14 +100,7 @@ export function TournamentHero({
   eyebrow,
   children,
 }: {
-  tournament: {
-    readonly id: string;
-    readonly name: string;
-    readonly status: string;
-    readonly visibility: string;
-    readonly starts_at: string | null;
-    readonly ends_at: string | null;
-  };
+  tournament: TournamentRecord;
   eyebrow?: React.ReactNode;
   children?: React.ReactNode;
 }) {
@@ -121,7 +117,7 @@ export function TournamentHero({
 
   return (
     <header className="flex flex-col gap-space-4">
-      {eyebrow ?? <BackLink href="/tournaments">All tournaments</BackLink>}
+      {eyebrow ?? <BackLink href="/tournaments" label="All tournaments" />}
 
       <div className="overflow-hidden rounded-lg border border-hairline bg-linear-to-b from-surface-raised to-surface">
         <div className="flex flex-col gap-space-4 p-space-5">
@@ -133,18 +129,46 @@ export function TournamentHero({
             <h1 className="text-h1 text-text-primary">{tournament.name}</h1>
           </div>
 
-          <div className="grid gap-space-3 sm:grid-cols-2">
+          {/*
+            The same facts the event card carries, in the same words. A card on the calendar
+            that shows where an event is and what the pot is at, linking to a page that shows
+            neither, reads as the page having lost them — so the detail screen is never
+            poorer than the list that pointed at it.
+          */}
+          <dl className="grid gap-space-3 sm:grid-cols-2">
             <div className="flex flex-col gap-space-1">
-              <span className="text-caption text-text-muted">When</span>
-              <span className="text-body-strong text-text-primary">
+              <dt className="text-caption text-text-muted">When</dt>
+              <dd className="text-body-strong text-text-primary">
                 {formatSchedule(tournament.starts_at, tournament.ends_at)}
-              </span>
+              </dd>
             </div>
             <div className="flex flex-col gap-space-1">
-              <span className="text-caption text-text-muted">Right now</span>
-              <span className="text-body text-text-primary">{blurb}</span>
+              <dt className="text-caption text-text-muted">Where</dt>
+              <dd className="text-body-strong text-text-primary">
+                {tournament.location_name ?? "Not announced"}
+              </dd>
             </div>
-          </div>
+            <div className="flex flex-col gap-space-1">
+              <dt className="text-caption text-text-muted">Prize pool</dt>
+              {/* "—" for a pot we cannot read, never "$0" — the difference is money. */}
+              <dd className={`text-body-strong text-text-primary ${TABULAR}`}>
+                {formatMoney(tournament.prize_pool_minor, tournament.currency) ?? "—"}
+              </dd>
+            </div>
+            <div className="flex flex-col gap-space-1">
+              <dt className="text-caption text-text-muted">Entry</dt>
+              <dd className={`text-body-strong text-text-primary ${TABULAR}`}>
+                {entryFeeLabel({
+                  entry_fee_minor: tournament.entry_fee_minor,
+                  currency: tournament.currency,
+                }) ?? "Not priced"}
+              </dd>
+            </div>
+            <div className="flex flex-col gap-space-1 sm:col-span-2">
+              <dt className="text-caption text-text-muted">Right now</dt>
+              <dd className="text-body text-text-primary">{blurb}</dd>
+            </div>
+          </dl>
 
           {clock ? (
             <p

--- a/src/features/tournaments/components/tournament-leaderboard.tsx
+++ b/src/features/tournaments/components/tournament-leaderboard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { BackLink } from "@/components/back-link";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
@@ -10,7 +11,6 @@ import { useDemoMode, useTournament } from "../use-tournament";
 import { CARD, CARD_PADDED, INSET, PAGE, SECONDARY_BUTTON, TABULAR } from "../ui-classes";
 import { TrophyIcon } from "./icons";
 import {
-  BackLink,
   DemoNote,
   EmptyState,
   ErrorScreen,
@@ -52,7 +52,7 @@ export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }
   return (
     <div className={PAGE}>
       <header className="flex flex-col gap-space-3">
-        <BackLink href={`/tournaments/${tournament.id}/overview`}>Tournament home</BackLink>
+        <BackLink href={`/tournaments/${tournament.id}/overview`} label="Tournament home" />
         <div className="flex flex-col gap-space-1">
           <span className="text-label text-signal-orange">Step 3 of 3</span>
           <div className="flex flex-wrap items-end justify-between gap-space-3">

--- a/src/features/tournaments/components/tournament-leaderboard.tsx
+++ b/src/features/tournaments/components/tournament-leaderboard.tsx
@@ -4,9 +4,9 @@ import { BackLink } from "@/components/back-link";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
-import { getDemoStandings, type DemoStanding } from "../demo-store";
 import { tournamentPhase } from "../format";
 import { getDemoTournamentCatches, type DemoTournamentCatch } from "../live-catch-demo";
+import { useStandings } from "../queries/use-standings";
 import { useDemoMode, useTournament } from "../use-tournament";
 import { CARD, CARD_PADDED, INSET, PAGE, SECONDARY_BUTTON, TABULAR } from "../ui-classes";
 import { TrophyIcon } from "./icons";
@@ -23,7 +23,7 @@ import {
 export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }) {
   const load = useTournament(tournamentId);
   const demoMode = useDemoMode();
-  const [standings, setStandings] = useState<readonly DemoStanding[]>([]);
+  const standingsLoad = useStandings(tournamentId);
   const [mine, setMine] = useState<readonly DemoTournamentCatch[]>([]);
 
   useEffect(() => {
@@ -31,13 +31,12 @@ export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }
     void (async () => {
       await Promise.resolve();
       if (cancelled) return;
-      setStandings(demoMode ? getDemoStandings(tournamentId) : []);
       setMine(getDemoTournamentCatches(tournamentId));
     })();
     return () => {
       cancelled = true;
     };
-  }, [demoMode, tournamentId]);
+  }, [tournamentId]);
 
   if (load.state === "loading") return <LoadingScreen label="Loading standings" />;
   if (load.state === "error") return <ErrorScreen message={load.message} />;
@@ -46,6 +45,7 @@ export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }
   const phase = tournamentPhase(tournament.status);
   const official = tournament.status === "FINAL";
   const finished = phase === "after";
+  const standings = standingsLoad.state === "ready" ? standingsLoad.rows : [];
   const leader = standings.find((row) => row.rank === 1) ?? null;
   const rest = standings.filter((row) => row !== leader);
 
@@ -73,7 +73,20 @@ export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }
 
       <ResultsHandoff tournamentId={tournament.id} phase={phase} />
 
-      {standings.length === 0 ? (
+      {/*
+        Three states, not two. "Nothing has been scored yet" used to render whenever the
+        list was empty — including when the standings had never been asked for, which was
+        every load against a real database. A reassuring sentence over a missing query is
+        worse than an error, because nobody reports it.
+      */}
+      {standingsLoad.state === "loading" ? (
+        <p className="text-body text-text-muted">Loading standings…</p>
+      ) : standingsLoad.state === "error" ? (
+        <EmptyState
+          title="The standings did not load"
+          body={`${standingsLoad.message} Your own catches below are on this phone and are unaffected.`}
+        />
+      ) : standings.length === 0 ? (
         <EmptyState
           title="Nothing has been scored yet"
           body="Approved catches will appear here. A catch saved on a phone is not automatically a score."
@@ -96,13 +109,18 @@ export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }
               </span>
               <span className="flex flex-1 flex-col gap-space-1">
                 <span className="text-caption text-text-muted">
-                  {official ? "Winner" : "Leading"} · {leader.species}
+                  {official ? "Winner" : "Leading"}
+                  {leader.detail ? ` · ${leader.detail}` : ""}
                 </span>
-                <span className="text-h2 text-text-primary">{leader.display_name}</span>
+                <span className="text-h2 text-text-primary">{leader.displayName}</span>
               </span>
               <span className="flex flex-col items-end">
-                <span className={`text-h1 ${TABULAR} text-signal-orange`}>{leader.weight_lb.toFixed(1)}</span>
-                <span className="text-caption text-text-muted">lb</span>
+                <span className={`text-h1 ${TABULAR} text-signal-orange`}>{leader.score.toFixed(1)}</span>
+                {/* A standing is a total, and only the demo seed knows it is pounds. An
+                    unlabelled number beats a wrong unit. */}
+                {leader.scoreUnit ? (
+                  <span className="text-caption text-text-muted">{leader.scoreUnit}</span>
+                ) : null}
               </span>
             </article>
           ) : null}
@@ -110,19 +128,20 @@ export function TournamentLeaderboard({ tournamentId }: { tournamentId: string }
           <ol className="flex flex-col gap-space-2">
             {rest.map((row) => (
               <li
-                key={`${row.rank}-${row.display_name}`}
+                key={`${row.rank}-${row.displayName}`}
                 className={`${CARD} grid grid-cols-[auto_1fr_auto] items-center gap-space-3 p-space-4`}
               >
                 <span className={`w-space-6 text-h3 ${TABULAR} text-text-muted`}>{row.rank}</span>
                 <span className="flex flex-col">
-                  <span className="text-body-strong text-text-primary">{row.display_name}</span>
+                  <span className="text-body-strong text-text-primary">{row.displayName}</span>
                   <span className="text-caption text-text-muted">
-                    {row.species}
-                    {row.official ? "" : " · waiting on a review"}
+                    {row.detail ?? (row.official ? "Scored" : "")}
+                    {row.official ? "" : `${row.detail ? " · " : ""}waiting on a review`}
                   </span>
                 </span>
                 <span className={`text-body-strong ${TABULAR} text-text-primary`}>
-                  {row.weight_lb.toFixed(1)} lb
+                  {row.score.toFixed(1)}
+                  {row.scoreUnit ? ` ${row.scoreUnit}` : ""}
                 </span>
               </li>
             ))}

--- a/src/features/tournaments/components/tournament-live-catches.tsx
+++ b/src/features/tournaments/components/tournament-live-catches.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { BackLink } from "@/components/back-link";
 import { useCallback, useEffect, useId, useState } from "react";
 
 import { countdown, qrPresentation, syncPresentation, tournamentPhase, TONE_CLASSES } from "../format";
@@ -28,7 +29,6 @@ import {
 } from "../ui-classes";
 import { AlertIcon, CheckIcon, ClockIcon, PendingIcon } from "./icons";
 import {
-  BackLink,
   ConnectionPill,
   DemoNote,
   EmptyState,
@@ -151,7 +151,7 @@ export function TournamentLiveCatches({ tournamentId }: { tournamentId: string }
   return (
     <div className={PAGE}>
       <header className="flex flex-col gap-space-3">
-        <BackLink href={`/tournaments/${tournament.id}/overview`}>{tournament.name}</BackLink>
+        <BackLink href={`/tournaments/${tournament.id}/overview`} label={tournament.name} />
         <div className="flex flex-wrap items-end justify-between gap-space-3">
           <h1 className="text-h1 text-text-primary">Log a catch</h1>
           <div className="flex flex-wrap items-center gap-space-2">

--- a/src/features/tournaments/components/tournament-operations.tsx
+++ b/src/features/tournaments/components/tournament-operations.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { BackLink } from "@/components/back-link";
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 
@@ -26,7 +27,6 @@ import {
 } from "../ui-classes";
 import { AlertIcon, LockIcon } from "./icons";
 import {
-  BackLink,
   CheckRow,
   DemoNote,
   EmptyState,
@@ -100,7 +100,7 @@ export function TournamentOperations({
   return (
     <div className={PAGE}>
       <header className="flex flex-col gap-space-3">
-        <BackLink href={`/tournaments/${tournament.id}/overview`}>Tournament home</BackLink>
+        <BackLink href={`/tournaments/${tournament.id}/overview`} label="Tournament home" />
         <div className="flex flex-col gap-space-1">
           <span className="text-label text-signal-orange">Host controls</span>
           <div className="flex flex-wrap items-end justify-between gap-space-3">

--- a/src/features/tournaments/components/tournament-operations.tsx
+++ b/src/features/tournaments/components/tournament-operations.tsx
@@ -10,9 +10,9 @@ import {
   validateTournamentTransition,
   type TournamentStatus,
 } from "@/core/tournaments/lifecycle";
-import { getDemoStandings, type DemoStanding } from "../demo-store";
 import { isTournamentStatus, tournamentPhase, type Phase } from "../format";
 import { getDemoTournamentCatches, type DemoTournamentCatch } from "../live-catch-demo";
+import { useStandings } from "../queries/use-standings";
 import { useDemoMode, useTournament } from "../use-tournament";
 import {
   CARD,
@@ -72,9 +72,10 @@ export function TournamentOperations({
 }) {
   const load = useTournament(tournamentId);
   const demoMode = useDemoMode();
+  const standingsLoad = useStandings(tournamentId);
+  const standings = standingsLoad.state === "ready" ? standingsLoad.rows : [];
   const [lane, setLane] = useState<Lane>(initialPanel);
   const [catches, setCatches] = useState<readonly DemoTournamentCatch[]>([]);
-  const [standings, setStandings] = useState<readonly DemoStanding[]>([]);
 
   useEffect(() => {
     let cancelled = false;
@@ -82,7 +83,6 @@ export function TournamentOperations({
       await Promise.resolve();
       if (cancelled) return;
       setCatches(getDemoTournamentCatches(tournamentId));
-      setStandings(demoMode ? getDemoStandings(tournamentId) : []);
     })();
     return () => {
       cancelled = true;

--- a/src/features/tournaments/components/tournament-overview.tsx
+++ b/src/features/tournaments/components/tournament-overview.tsx
@@ -3,9 +3,10 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
-import { getDemoEntry, getDemoStandings, type DemoEntry, type DemoStanding } from "../demo-store";
+import { getDemoEntry, type DemoEntry } from "../demo-store";
 import { entrySteps, formatDateTime, tournamentPhase, visibilityPresentation } from "../format";
 import { getDemoTournamentCatches } from "../live-catch-demo";
+import { useStandings } from "../queries/use-standings";
 import { useDemoMode, useTournament } from "../use-tournament";
 import {
   BIG_ACTION,
@@ -56,8 +57,11 @@ type TournamentPhase = "before" | "during" | "after";
 export function TournamentOverview({ tournamentId }: { tournamentId: string }) {
   const load = useTournament(tournamentId);
   const demoMode = useDemoMode();
+  /* Read from the same loader as the leaderboard, so the top three here and the board there
+     can never disagree — they used to come from two different expressions. */
+  const standingsLoad = useStandings(tournamentId);
+  const standings = standingsLoad.state === "ready" ? standingsLoad.rows : [];
   const [entry, setEntry] = useState<DemoEntry | null>(null);
-  const [standings, setStandings] = useState<readonly DemoStanding[]>([]);
   const [deviceCatches, setDeviceCatches] = useState(0);
 
   useEffect(() => {
@@ -66,7 +70,6 @@ export function TournamentOverview({ tournamentId }: { tournamentId: string }) {
       await Promise.resolve();
       if (cancelled) return;
       setEntry(demoMode ? getDemoEntry(tournamentId) : null);
-      setStandings(demoMode ? getDemoStandings(tournamentId) : []);
       setDeviceCatches(getDemoTournamentCatches(tournamentId).length);
     })();
     return () => {
@@ -183,9 +186,10 @@ export function TournamentOverview({ tournamentId }: { tournamentId: string }) {
                 >
                   {row.rank}
                 </span>
-                <span className="flex-1 text-body text-text-primary">{row.display_name}</span>
+                <span className="flex-1 text-body text-text-primary">{row.displayName}</span>
                 <span className={`text-body-strong ${TABULAR} text-text-primary`}>
-                  {row.weight_lb.toFixed(1)} lb
+                  {row.score.toFixed(1)}
+                  {row.scoreUnit ? ` ${row.scoreUnit}` : ""}
                 </span>
               </li>
             ))}

--- a/src/features/tournaments/components/tournament-rules.tsx
+++ b/src/features/tournaments/components/tournament-rules.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { BackLink } from "@/components/back-link";
 import { useDemoMode, useTournament } from "../use-tournament";
 import { CARD_PADDED, INSET, PAGE } from "../ui-classes";
-import { CheckRow, DemoNote, ErrorScreen, LoadingScreen, SectionHeading, TournamentHero, TournamentTabs, BackLink } from "./tournament-chrome";
+import { CheckRow, DemoNote, ErrorScreen, LoadingScreen, SectionHeading, TournamentHero, TournamentTabs } from "./tournament-chrome";
 
 /**
  * /tournaments/[id]/rules — what you are fishing under.
@@ -60,7 +61,7 @@ export function TournamentRules({ tournamentId }: { tournamentId: string }) {
         tournament={tournament}
         // The hero repeats the tournament name directly below, so the eyebrow names the
         // destination instead of saying the same words twice.
-        eyebrow={<BackLink href={`/tournaments/${tournament.id}/overview`}>Overview</BackLink>}
+        eyebrow={<BackLink href={`/tournaments/${tournament.id}/overview`} label="Overview" />}
       />
 
       <TournamentTabs tournamentId={tournament.id} />

--- a/src/features/tournaments/demo-store.ts
+++ b/src/features/tournaments/demo-store.ts
@@ -1,30 +1,6 @@
-export type DemoTournament = {
-  id: string;
-  name: string;
-  status: string;
-  visibility: string;
-  starts_at: string | null;
-  ends_at: string | null;
-  /*
-    The three facts the event calendar is built to answer before you open anything: where
-    it is, what the pot is at, and how long you have to enter. They mirror the columns
-    added to `public.tournament` in 20260905184500_tournament_core.sql, so the demo path
-    and the Supabase path render from the same shape.
-  */
-  location_name: string | null;
-  registration_closes_at: string | null;
-  entry_fee_minor: number | null;
-  prize_pool_minor: number | null;
-  currency: string;
-  entrant_count: number;
-  /** Whether the demo angler hosts this one — the door to the host tools. */
-  hosting: boolean;
-  organization_id: string;
-  active_rule_set_version_id: string | null;
-  active_scoring_version_id: string | null;
-  active_verification_policy_version_id: string | null;
-  active_boundary_version_id: string | null;
-};
+import type { TournamentRecord } from "./types";
+
+export type { TournamentRecord };
 
 export type DemoEntry = {
   id: string;
@@ -76,7 +52,7 @@ function minutesFromNow(minutes: number): string {
  * without the founder having to create one: an event taking entries with its setup
  * half-finished, an event being fished right now, and one that is over and official.
  */
-function seedTournaments(): DemoTournament[] {
+function seedTournaments(): TournamentRecord[] {
   return [
     {
       id: "demo-harbor-shootout",
@@ -90,6 +66,8 @@ function seedTournaments(): DemoTournament[] {
       entry_fee_minor: 15000,
       prize_pool_minor: 372000,
       currency: "USD",
+      refund_policy:
+        "Entries closed. Withdrawals are between you and the host from here.",
       entrant_count: 31,
       hosting: false,
       organization_id: "demo-personal-organization",
@@ -110,6 +88,8 @@ function seedTournaments(): DemoTournament[] {
       entry_fee_minor: 25000,
       prize_pool_minor: 480000,
       currency: "USD",
+      refund_policy:
+        "Entries are transferable to another boat until registration closes. No refunds after that, except a full refund if the event is cancelled.",
       entrant_count: 19,
       hosting: false,
       organization_id: "demo-personal-organization",
@@ -134,6 +114,8 @@ function seedTournaments(): DemoTournament[] {
       entry_fee_minor: 40000,
       prize_pool_minor: 1265000,
       currency: "USD",
+      refund_policy:
+        "Full refund if you withdraw more than 48 hours before the start. Inside 48 hours, entry fees are non-refundable but jackpot buy-ins are returned. If the host cancels for weather, everything is refunded in full within 5 working days.",
       entrant_count: 44,
       hosting: false,
       organization_id: "demo-personal-organization",
@@ -158,6 +140,8 @@ function seedTournaments(): DemoTournament[] {
       entry_fee_minor: 0,
       prize_pool_minor: null,
       currency: "USD",
+      refund_policy:
+        "Free event — withdraw any time, no money involved.",
       entrant_count: 7,
       hosting: false,
       organization_id: "demo-personal-organization",
@@ -182,6 +166,8 @@ function seedTournaments(): DemoTournament[] {
       entry_fee_minor: 5000,
       prize_pool_minor: 40000,
       currency: "USD",
+      refund_policy:
+        "Crew event. Talk to the host; there is no formal policy and no fee held by the app.",
       entrant_count: 8,
       hosting: true,
       organization_id: "demo-personal-organization",
@@ -229,13 +215,13 @@ function writeJson(key: string, value: unknown) {
   window.localStorage.setItem(key, JSON.stringify(value));
 }
 
-export function getDemoTournaments(): DemoTournament[] {
-  const stored = readJson<DemoTournament[]>(TOURNAMENTS_KEY, []);
+export function getDemoTournaments(): TournamentRecord[] {
+  const stored = readJson<TournamentRecord[]>(TOURNAMENTS_KEY, []);
   const seed = seedTournaments();
   return [...stored, ...seed.filter((item) => !stored.some((own) => own.id === item.id))];
 }
 
-export function getDemoTournament(id: string): DemoTournament | null {
+export function getDemoTournament(id: string): TournamentRecord | null {
   return getDemoTournaments().find((item) => item.id === id) ?? null;
 }
 
@@ -247,8 +233,9 @@ export function createDemoTournament(input: {
   location_name?: string | null;
   registration_closes_at?: string | null;
   entry_fee_minor?: number | null;
-}): DemoTournament {
-  const item: DemoTournament = {
+  refund_policy?: string | null;
+}): TournamentRecord {
+  const item: TournamentRecord = {
     id: `demo-${Date.now()}`,
     name: input.name,
     status: "DRAFT",
@@ -258,6 +245,7 @@ export function createDemoTournament(input: {
     location_name: input.location_name ?? null,
     registration_closes_at: input.registration_closes_at ?? null,
     entry_fee_minor: input.entry_fee_minor ?? null,
+    refund_policy: input.refund_policy ?? null,
     // A brand-new event's pot is empty, not unknown. Nobody has paid yet.
     prize_pool_minor: 0,
     currency: "USD",
@@ -270,7 +258,7 @@ export function createDemoTournament(input: {
     active_verification_policy_version_id: null,
     active_boundary_version_id: null,
   };
-  const stored = readJson<DemoTournament[]>(TOURNAMENTS_KEY, []);
+  const stored = readJson<TournamentRecord[]>(TOURNAMENTS_KEY, []);
   writeJson(TOURNAMENTS_KEY, [item, ...stored]);
   return item;
 }
@@ -398,23 +386,3 @@ export function getDemoDivisions(tournamentId: string): readonly DemoDivision[] 
   return SEED_DIVISIONS.filter((division) => division.tournament_id === tournamentId);
 }
 
-/**
- * The host's refund policy, per event.
- *
- * Deliberately not one platform-wide sentence. It is the host's money and the host's
- * decision, and inventing a policy on their behalf would be the app making a promise it
- * cannot keep (ADR 010 §4). An event with none says so, which is itself information.
- */
-const SEED_REFUND_POLICIES: Readonly<Record<string, string>> = {
-  "demo-tuna-jackpot":
-    "Full refund if you withdraw more than 48 hours before the start. Inside 48 hours, entry fees are non-refundable but jackpot buy-ins are returned. If the host cancels for weather, everything is refunded in full within 5 working days.",
-  "demo-yellowtail-open":
-    "Entries are transferable to another boat until registration closes. No refunds after that, except a full refund if the event is cancelled.",
-  "demo-club-fun-day": "Free event — withdraw any time, no money involved.",
-  "demo-crew-cup":
-    "Crew event. Talk to the host; there is no formal policy and no fee held by the app.",
-};
-
-export function getDemoRefundPolicy(tournamentId: string): string | null {
-  return SEED_REFUND_POLICIES[tournamentId] ?? null;
-}

--- a/src/features/tournaments/event-card.test.ts
+++ b/src/features/tournaments/event-card.test.ts
@@ -28,6 +28,7 @@ function event(overrides: Partial<TournamentEvent> = {}): TournamentEvent {
     entry_fee_minor: 25000,
     prize_pool_minor: 480000,
     currency: "USD",
+    refund_policy: "Full refund up to 48 hours before the start.",
     entrant_count: 19,
     entered: false,
     hosting: false,

--- a/src/features/tournaments/event-card.ts
+++ b/src/features/tournaments/event-card.ts
@@ -30,6 +30,8 @@ export interface TournamentEvent {
   /** What the pot holds right now, in minor units — paid entries only. */
   readonly prize_pool_minor: number | null;
   readonly currency: string;
+  /** The host's own words on withdrawals. Null means none published — the checkout says so. */
+  readonly refund_policy: string | null;
   readonly entrant_count: number | null;
   /** Whether the viewer is entered in this one. Drives "My tournaments" and the badges. */
   readonly entered: boolean;
@@ -87,11 +89,21 @@ export function formatMoney(minor: number | null, currency: string): string | nu
   }
 }
 
-/** "Free" is a real and attractive answer, and it is not the same as "not priced yet". */
-export function entryFeeLabel(event: TournamentEvent): string | null {
-  if (event.entry_fee_minor === null) return null;
-  if (event.entry_fee_minor === 0) return "Free to enter";
-  return formatMoney(event.entry_fee_minor, event.currency);
+/**
+ * "Free" is a real and attractive answer, and it is not the same as "not priced yet".
+ *
+ * Takes the two fields it reads rather than a whole event, so the tournament hero — which
+ * holds a `TournamentRecord`, not a `TournamentEvent` — can price an entry with the same
+ * words the card uses. Two screens describing one fee differently is how a $0 event and an
+ * unpriced one end up looking identical.
+ */
+export function entryFeeLabel(priced: {
+  readonly entry_fee_minor: number | null;
+  readonly currency: string;
+}): string | null {
+  if (priced.entry_fee_minor === null) return null;
+  if (priced.entry_fee_minor === 0) return "Free to enter";
+  return formatMoney(priced.entry_fee_minor, priced.currency);
 }
 
 /**

--- a/src/features/tournaments/queries/tournament-facts.ts
+++ b/src/features/tournaments/queries/tournament-facts.ts
@@ -1,0 +1,106 @@
+"use client";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * The three facts about a tournament that do not live on its own row.
+ *
+ * The pot is summed from `prize_pool`, the field size is counted from `tournament_entry`,
+ * and whether *you* are in it comes from the identity rows that name you. Every screen in
+ * the section needs some of these, so they are fetched in one place — the alternative is
+ * each screen inventing its own definition of "entered", and three screens disagreeing
+ * about that reads to an angler as the app being broken.
+ *
+ * **Every one of these degrades to "not known" rather than throwing.** Row-level security
+ * hides other organisations' finances by design, so a viewer who cannot read `prize_pool`
+ * is the normal case, not an error. A missing pot renders as "—"; it must never take the
+ * events list down with it, and it must never render as `$0`.
+ */
+
+export interface TournamentFacts {
+  /** Pot per tournament id, in minor units. Absent means not readable, not zero. */
+  readonly pools: ReadonlyMap<string, number>;
+  readonly entrantCounts: ReadonlyMap<string, number>;
+  /** Tournament ids the signed-in angler holds an entry in. */
+  readonly enteredIds: ReadonlySet<string>;
+}
+
+export const EMPTY_FACTS: TournamentFacts = {
+  pools: new Map(),
+  entrantCounts: new Map(),
+  enteredIds: new Set(),
+};
+
+export async function fetchTournamentFacts(
+  supabase: SupabaseClient,
+  tournamentIds?: readonly string[],
+): Promise<TournamentFacts> {
+  const scope = tournamentIds && tournamentIds.length > 0 ? tournamentIds : null;
+
+  const poolQuery = supabase.from("prize_pool").select("tournament_id,funded_amount_minor");
+  const entryQuery = supabase.from("tournament_entry").select("id,tournament_id").is("deleted_at", null);
+
+  const [poolResult, entryResult, enteredIds] = await Promise.all([
+    scope ? poolQuery.in("tournament_id", scope) : poolQuery,
+    scope ? entryQuery.in("tournament_id", scope) : entryQuery,
+    fetchEnteredIds(supabase),
+  ]);
+
+  const pools = new Map<string, number>();
+  for (const row of (poolResult.data ?? []) as { tournament_id: string; funded_amount_minor: unknown }[]) {
+    // `funded_amount_minor` is a bigint, which PostgREST sends as a string once it exceeds
+    // a safe integer. Adding those as strings would concatenate them into a nonsense pot.
+    const amount = Number(row.funded_amount_minor ?? 0);
+    if (!Number.isFinite(amount)) continue;
+    pools.set(row.tournament_id, (pools.get(row.tournament_id) ?? 0) + amount);
+  }
+
+  const entrantCounts = new Map<string, number>();
+  for (const row of (entryResult.data ?? []) as { tournament_id: string }[]) {
+    entrantCounts.set(row.tournament_id, (entrantCounts.get(row.tournament_id) ?? 0) + 1);
+  }
+
+  return { pools, entrantCounts, enteredIds };
+}
+
+/**
+ * Which tournaments the signed-in angler is in.
+ *
+ * Two hops, because an entry's identity rows are what name a person and they do not carry
+ * the tournament: identities claimed by this angler → their entry ids → those entries'
+ * tournaments. Signed out, the answer is "none", which is correct rather than an error —
+ * the whole app is usable signed out.
+ *
+ * This is what "My tournaments" counts. Before it existed the events loader hardcoded
+ * `entered: false` for every real row, so a signed-in angler with ten entries would have
+ * seen an empty My Tournaments and no error explaining why.
+ */
+async function fetchEnteredIds(supabase: SupabaseClient): Promise<ReadonlySet<string>> {
+  const { data: authData } = await supabase.auth.getUser();
+  const userId = authData.user?.id;
+  if (!userId) return new Set();
+
+  const { data: identities, error: identityError } = await supabase
+    .from("tournament_entry_identity")
+    .select("tournament_entry_id")
+    .eq("claimed_angler_id", userId);
+  if (identityError || !identities || identities.length === 0) return new Set();
+
+  const entryIds = (identities as { tournament_entry_id: string }[])
+    .map((row) => row.tournament_entry_id)
+    .filter((id): id is string => typeof id === "string");
+  if (entryIds.length === 0) return new Set();
+
+  const { data: entries, error: entryError } = await supabase
+    .from("tournament_entry")
+    .select("tournament_id")
+    .in("id", entryIds)
+    .is("deleted_at", null);
+  if (entryError || !entries) return new Set();
+
+  return new Set(
+    (entries as { tournament_id: string }[])
+      .map((row) => row.tournament_id)
+      .filter((id): id is string => typeof id === "string"),
+  );
+}

--- a/src/features/tournaments/queries/use-divisions.ts
+++ b/src/features/tournaments/queries/use-divisions.ts
@@ -1,0 +1,155 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { createClient } from "@/lib/supabase/client";
+import type { DivisionOption } from "@/core/tournaments/registration";
+
+import { getDemoDivisions, hasSupabaseBrowserConfig } from "../demo-store";
+
+/**
+ * The jackpots and side pots an event offers, for the registration form.
+ *
+ * This existed only as a seeded demo list read straight from the component, which meant
+ * that against a real database the founder's headline feature — "register for the biggest
+ * tuna jackpot, register for the largest marlin" — would have silently rendered nothing.
+ * Not an error, not an empty state: no jackpot section at all, on every event, with no
+ * indication that anything was missing. Silent absence is the worst failure a feature can
+ * have, because nobody reports it.
+ *
+ * Two hops, because the price and the pot live in different places by design:
+ * `tournament_division` holds what a buy-in costs, and `prize_pool` holds what has actually
+ * been collected. Joining them is what produces "Biggest Tuna · $100 · $4,200 in the pot".
+ */
+
+export type DivisionsLoad =
+  | { readonly state: "loading" }
+  | { readonly state: "ready"; readonly byTournament: ReadonlyMap<string, readonly DivisionOption[]> };
+
+const DIVISION_COLUMNS = "id,tournament_id,name,description,kind,entry_fee_minor,prize_pool_id";
+
+interface DivisionRow {
+  id: string;
+  tournament_id: string;
+  name: string;
+  description: string | null;
+  kind: string;
+  entry_fee_minor: number | string | null;
+  prize_pool_id: string | null;
+}
+
+function kindOf(raw: string): DivisionOption["kind"] {
+  return raw === "JACKPOT" || raw === "SIDE_POT" ? raw : "DIVISION";
+}
+
+function minorOrNull(value: number | string | null): number | null {
+  if (value === null) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function useDivisions(tournamentIds: readonly string[]): DivisionsLoad {
+  const [load, setLoad] = useState<DivisionsLoad>({ state: "loading" });
+  // Stable key, so the effect re-runs when the SET of events changes rather than on every
+  // render that happens to build a new array with the same ids in it.
+  const key = [...tournamentIds].sort().join(",");
+
+  const read = useCallback(async (ids: readonly string[]): Promise<ReadonlyMap<string, readonly DivisionOption[]>> => {
+    const byTournament = new Map<string, DivisionOption[]>();
+    if (ids.length === 0) return byTournament;
+
+    if (!hasSupabaseBrowserConfig()) {
+      for (const id of ids) {
+        byTournament.set(
+          id,
+          getDemoDivisions(id).map((division) => ({
+            id: division.id,
+            name: division.name,
+            description: division.description,
+            kind: division.kind,
+            entryFeeMinor: division.entry_fee_minor,
+            poolMinor: division.pool_minor,
+            participantCount: division.participant_count,
+          })),
+        );
+      }
+      return byTournament;
+    }
+
+    const supabase = createClient();
+    const { data, error } = await supabase
+      .from("tournament_division")
+      .select(DIVISION_COLUMNS)
+      .in("tournament_id", ids)
+      .is("deleted_at", null)
+      .order("sort_order", { ascending: true });
+
+    // A division list that fails to load is an empty one, not a broken page: an angler can
+    // still enter the event itself, which is the thing they came to do.
+    if (error || !data) return byTournament;
+
+    const rows = data as unknown as DivisionRow[];
+    const poolIds = rows.map((row) => row.prize_pool_id).filter((id): id is string => Boolean(id));
+
+    const pools = new Map<string, { funded: number; entries: number }>();
+    if (poolIds.length > 0) {
+      const [poolResult, entryResult] = await Promise.all([
+        supabase.from("prize_pool").select("id,funded_amount_minor").in("id", poolIds),
+        supabase
+          .from("prize_pool_entry")
+          .select("prize_pool_id")
+          .in("prize_pool_id", poolIds)
+          .eq("participation_status", "ACTIVE"),
+      ]);
+      for (const pool of (poolResult.data ?? []) as { id: string; funded_amount_minor: unknown }[]) {
+        const funded = Number(pool.funded_amount_minor ?? 0);
+        pools.set(pool.id, { funded: Number.isFinite(funded) ? funded : 0, entries: 0 });
+      }
+      for (const row of (entryResult.data ?? []) as { prize_pool_id: string }[]) {
+        const pool = pools.get(row.prize_pool_id);
+        if (pool) pool.entries += 1;
+      }
+    }
+
+    for (const row of rows) {
+      const pool = row.prize_pool_id ? pools.get(row.prize_pool_id) : undefined;
+      const option: DivisionOption = {
+        id: row.id,
+        name: row.name,
+        description: row.description,
+        kind: kindOf(row.kind),
+        entryFeeMinor: minorOrNull(row.entry_fee_minor),
+        // No pool row means the pot is not readable or not created — "New pot", never "$0".
+        poolMinor: pool ? pool.funded : null,
+        participantCount: pool ? pool.entries : null,
+      };
+      const bucket = byTournament.get(row.tournament_id);
+      if (bucket) bucket.push(option);
+      else byTournament.set(row.tournament_id, [option]);
+    }
+    return byTournament;
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const ids = key === "" ? [] : key.split(",");
+
+    void (async () => {
+      await Promise.resolve();
+      if (cancelled) return;
+      try {
+        const byTournament = await read(ids);
+        if (!cancelled) setLoad({ state: "ready", byTournament });
+      } catch {
+        // Same reasoning as the query error above: no jackpots beats no registration form.
+        if (!cancelled) setLoad({ state: "ready", byTournament: new Map() });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [key, read]);
+
+  return load;
+}

--- a/src/features/tournaments/queries/use-events.ts
+++ b/src/features/tournaments/queries/use-events.ts
@@ -8,9 +8,15 @@ import {
   getDemoEntries,
   getDemoTournaments,
   hasSupabaseBrowserConfig,
-  type DemoTournament,
 } from "../demo-store";
 import type { TournamentEvent } from "../event-card";
+import {
+  PUBLIC_TOURNAMENT_COLUMNS,
+  TOURNAMENT_COLUMNS,
+  toTournamentRecord,
+  type TournamentRecord,
+} from "../types";
+import { fetchTournamentFacts } from "./tournament-facts";
 
 /**
  * One load of "every event I can see", for every screen that shows events.
@@ -31,15 +37,7 @@ export type EventsLoad =
   | { readonly state: "error"; readonly message: string }
   | { readonly state: "ready"; readonly events: readonly TournamentEvent[]; readonly demo: boolean };
 
-/*
-  One literal, deliberately not assembled from pieces: supabase-js parses this string at
-  the type level to shape the row it returns, and a concatenated expression is just
-  `string` to it, which collapses the result type into an error type.
-*/
-const LIST_COLUMNS =
-  "id,name,status,visibility,starts_at,ends_at,location_name,registration_closes_at,entry_fee_minor,currency,created_at";
-
-function fromDemo(row: DemoTournament, enteredIds: ReadonlySet<string>): TournamentEvent {
+function fromDemo(row: TournamentRecord, enteredIds: ReadonlySet<string>): TournamentEvent {
   return {
     id: row.id,
     name: row.name,
@@ -52,24 +50,11 @@ function fromDemo(row: DemoTournament, enteredIds: ReadonlySet<string>): Tournam
     entry_fee_minor: row.entry_fee_minor,
     prize_pool_minor: row.prize_pool_minor,
     currency: row.currency,
+    refund_policy: row.refund_policy,
     entrant_count: row.entrant_count,
     entered: enteredIds.has(row.id),
     hosting: row.hosting,
   };
-}
-
-/** A Supabase row plus the two joins the card needs, flattened. */
-interface RemoteRow {
-  id: string;
-  name: string;
-  status: string;
-  visibility: string;
-  starts_at: string | null;
-  ends_at: string | null;
-  location_name: string | null;
-  registration_closes_at: string | null;
-  entry_fee_minor: number | null;
-  currency: string | null;
 }
 
 export function useEvents(): { readonly load: EventsLoad; readonly retry: () => void } {
@@ -99,18 +84,14 @@ export function useEvents(): { readonly load: EventsLoad; readonly retry: () => 
 
       try {
         const supabase = createClient();
-        const [ownedResult, publicResult, poolResult, entryResult] = await Promise.all([
-          supabase.from("tournament").select(LIST_COLUMNS).is("deleted_at", null),
+        const [ownedResult, publicResult] = await Promise.all([
+          supabase.from("tournament").select(TOURNAMENT_COLUMNS).is("deleted_at", null),
           supabase
             .from("public_tournament")
-            .select(LIST_COLUMNS)
+            .select(PUBLIC_TOURNAMENT_COLUMNS)
             .eq("visibility", "PUBLIC")
             .order("starts_at", { ascending: true })
             .limit(200),
-          // The pot, summed per event. `funded_amount_minor` counts money actually taken,
-          // which is the only number honest enough to print beside the word "prize pool".
-          supabase.from("prize_pool").select("tournament_id,funded_amount_minor"),
-          supabase.from("tournament_entry").select("tournament_id").is("deleted_at", null),
         ]);
 
         if (cancelled) return;
@@ -120,23 +101,27 @@ export function useEvents(): { readonly load: EventsLoad; readonly retry: () => 
           return;
         }
 
-        const owned = (ownedResult.data ?? []) as RemoteRow[];
+        /*
+          Rows you can read from `tournament` itself are your organisation's, which is what
+          hosting means here; `public_tournament` is everything else on offer. An event in
+          both is yours, so the public copy is dropped rather than listed twice.
+        */
+        const owned = ((ownedResult.data ?? []) as unknown[]).map((row) =>
+          toTournamentRecord(row, { hosting: true }),
+        );
         const ownedIds = new Set(owned.map((row) => row.id));
-        const open = ((publicResult.data ?? []) as RemoteRow[]).filter((row) => !ownedIds.has(row.id));
+        const open = ((publicResult.data ?? []) as unknown[])
+          .map((row) => toTournamentRecord(row))
+          .filter((row) => !ownedIds.has(row.id));
 
-        // A pool query the viewer cannot read is a missing number, never a broken page:
-        // RLS hides other organisations' finances by design.
-        const pools = new Map<string, number>();
-        for (const row of (poolResult.data ?? []) as { tournament_id: string; funded_amount_minor: number }[]) {
-          pools.set(row.tournament_id, (pools.get(row.tournament_id) ?? 0) + Number(row.funded_amount_minor ?? 0));
-        }
+        const rows = [...owned, ...open];
+        const facts = await fetchTournamentFacts(
+          supabase,
+          rows.map((row) => row.id),
+        );
+        if (cancelled) return;
 
-        const counts = new Map<string, number>();
-        for (const row of (entryResult.data ?? []) as { tournament_id: string }[]) {
-          counts.set(row.tournament_id, (counts.get(row.tournament_id) ?? 0) + 1);
-        }
-
-        const events: TournamentEvent[] = [...owned, ...open].map((row) => ({
+        const events: TournamentEvent[] = rows.map((row) => ({
           id: row.id,
           name: row.name,
           status: row.status,
@@ -146,14 +131,13 @@ export function useEvents(): { readonly load: EventsLoad; readonly retry: () => 
           location_name: row.location_name,
           registration_closes_at: row.registration_closes_at,
           entry_fee_minor: row.entry_fee_minor,
-          prize_pool_minor: pools.get(row.id) ?? null,
-          currency: row.currency ?? "USD",
-          entrant_count: counts.get(row.id) ?? null,
-          // Entered and hosting both need the signed-in angler, which arrives with the
-          // registration work. Until then the honest answer is "not known here" rather
-          // than a guess that would put somebody else's event in your My Tournaments.
-          entered: false,
-          hosting: ownedIds.has(row.id),
+          // Absent means the pot is not readable from here — "—", never "$0".
+          prize_pool_minor: facts.pools.has(row.id) ? (facts.pools.get(row.id) ?? null) : null,
+          currency: row.currency,
+          refund_policy: row.refund_policy,
+          entrant_count: facts.entrantCounts.get(row.id) ?? 0,
+          entered: facts.enteredIds.has(row.id),
+          hosting: row.hosting,
         }));
 
         setLoad({ state: "ready", events, demo: false });

--- a/src/features/tournaments/queries/use-standings.ts
+++ b/src/features/tournaments/queries/use-standings.ts
@@ -1,0 +1,136 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { createClient } from "@/lib/supabase/client";
+
+import { getDemoStandings, hasSupabaseBrowserConfig } from "../demo-store";
+
+/**
+ * The standings, from wherever they actually live.
+ *
+ * Before this, every screen that showed standings did `demoMode ? getDemoStandings(id) : []`.
+ * Against a real database that is an empty array on every load, rendered as "Nothing has
+ * been scored yet — approved catches will appear here." Which is a sentence that is not
+ * true: nothing would ever have appeared there, because nothing was ever asked for. A
+ * plausible empty state over a missing query is worse than an error, because nobody
+ * reports it — the leaderboard just looks like a quiet tournament.
+ *
+ * The production source is `public_leaderboard`, which is the projection of `standing`
+ * rows whose score computation is COMPLETE. It carries a rank, a score and a
+ * disqualification flag but no names — those are in `public_tournament_entry` — and no
+ * species or weight, because a standing is a *total*, not a fish. The demo seed happens to
+ * know the winning fish for each row, so that stays optional and the screens print it when
+ * they have it.
+ */
+
+export interface StandingRow {
+  readonly rank: number;
+  readonly displayName: string;
+  /** The number the ranking is on — pounds in the demo, the computed score in production. */
+  readonly score: number;
+  /** Unit for `score`, when there is a meaningful one. Null prints the bare number. */
+  readonly scoreUnit: string | null;
+  /** The fish behind the row, when the source knows it. A standing usually does not. */
+  readonly detail: string | null;
+  /** False while a review behind the row is still open. */
+  readonly official: boolean;
+}
+
+export type StandingsLoad =
+  | { readonly state: "loading" }
+  | { readonly state: "ready"; readonly rows: readonly StandingRow[] }
+  /** The tournament server answered, and it said no. Distinct from "nobody has scored". */
+  | { readonly state: "error"; readonly message: string };
+
+export function useStandings(tournamentId: string): StandingsLoad {
+  const [load, setLoad] = useState<StandingsLoad>({ state: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      await Promise.resolve();
+      if (cancelled) return;
+
+      if (!hasSupabaseBrowserConfig()) {
+        setLoad({
+          state: "ready",
+          rows: getDemoStandings(tournamentId).map((row) => ({
+            rank: row.rank,
+            displayName: row.display_name,
+            score: row.weight_lb,
+            scoreUnit: "lb",
+            detail: row.species,
+            official: row.official,
+          })),
+        });
+        return;
+      }
+
+      try {
+        const supabase = createClient();
+        const [boardResult, entryResult] = await Promise.all([
+          supabase
+            .from("public_leaderboard")
+            .select("tournament_entry_id,rank,score_numeric,is_disqualified,division_id")
+            .eq("tournament_id", tournamentId)
+            .order("rank", { ascending: true }),
+          supabase
+            .from("public_tournament_entry")
+            .select("id,display_name")
+            .eq("tournament_id", tournamentId),
+        ]);
+
+        if (cancelled) return;
+        if (boardResult.error) {
+          setLoad({ state: "error", message: boardResult.error.message });
+          return;
+        }
+
+        const names = new Map<string, string>();
+        for (const row of (entryResult.data ?? []) as { id: string; display_name: string }[]) {
+          if (typeof row.display_name === "string") names.set(row.id, row.display_name);
+        }
+
+        const rows = ((boardResult.data ?? []) as {
+          tournament_entry_id: string;
+          rank: number;
+          score_numeric: unknown;
+          is_disqualified: boolean;
+          division_id: string | null;
+        }[])
+          // Overall standings only. Division boards are their own screen; mixing them into
+          // one list would show the same angler three times with three different ranks.
+          .filter((row) => row.division_id === null)
+          .map((row) => {
+            const score = Number(row.score_numeric);
+            return {
+              rank: row.rank,
+              // An entry whose identity is not public still has a rank, and dropping the
+              // row would renumber the board. "Entry 4" is honest; a blank name is not.
+              displayName: names.get(row.tournament_entry_id) ?? `Entry ${row.rank}`,
+              score: Number.isFinite(score) ? score : 0,
+              scoreUnit: null,
+              detail: null,
+              official: !row.is_disqualified,
+            };
+          });
+
+        setLoad({ state: "ready", rows });
+      } catch (cause) {
+        if (cancelled) return;
+        setLoad({
+          state: "error",
+          message: cause instanceof Error ? cause.message : "The standings could not be loaded.",
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [tournamentId]);
+
+  return load;
+}

--- a/src/features/tournaments/types.test.ts
+++ b/src/features/tournaments/types.test.ts
@@ -1,0 +1,153 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { PUBLIC_TOURNAMENT_COLUMNS, TOURNAMENT_COLUMNS, toTournamentRecord } from "./types";
+
+/**
+ * Narrowing a row from PostgREST, which is network input rather than something we wrote.
+ *
+ * Every screen used to do `data as TournamentRecord`. A cast is not a check — it is a
+ * promise to the compiler that nobody verified — and the failures it hides are quiet ones:
+ * a column renamed in a migration, a view that does not carry a field, or an RLS policy
+ * that hides one all satisfy the cast and then surface three screens later as an empty card
+ * or "NaN", with nothing in the logs.
+ */
+describe("toTournamentRecord", () => {
+  it("keeps what the row has", () => {
+    const record = toTournamentRecord({
+      id: "t1",
+      name: "Harbor Bay Shootout",
+      status: "LIVE",
+      visibility: "PUBLIC",
+      starts_at: "2026-09-07T15:00:00Z",
+      ends_at: null,
+      location_name: "Dana Point Harbor",
+      registration_closes_at: "2026-09-06T18:00:00Z",
+      entry_fee_minor: 15000,
+      currency: "USD",
+      organization_id: "org1",
+    });
+    expect(record.name).toBe("Harbor Bay Shootout");
+    expect(record.entry_fee_minor).toBe(15000);
+    expect(record.location_name).toBe("Dana Point Harbor");
+  });
+
+  it("gives a missing price null, never zero — the difference is money", () => {
+    // A view that does not carry `entry_fee_minor` must not turn every event free.
+    const record = toTournamentRecord({ id: "t1", name: "X" });
+    expect(record.entry_fee_minor).toBeNull();
+    expect(record.prize_pool_minor).toBeNull();
+  });
+
+  it("keeps a real zero as zero, because free is a price", () => {
+    expect(toTournamentRecord({ entry_fee_minor: 0 }).entry_fee_minor).toBe(0);
+  });
+
+  it("reads a bigint that arrived as a string", () => {
+    // PostgREST sends bigint as a string once it exceeds a safe integer; `Number(...)` on
+    // the whole row would otherwise leave a price that renders as text.
+    expect(toTournamentRecord({ entry_fee_minor: "25000" }).entry_fee_minor).toBe(25000);
+  });
+
+  it("never produces undefined for a field a screen will render", () => {
+    const record = toTournamentRecord(null);
+    expect(record.name).toBe("");
+    expect(record.currency).toBe("USD");
+    expect(record.entrant_count).toBe(0);
+    expect(record.hosting).toBe(false);
+    for (const value of Object.values(record)) {
+      expect(value).not.toBeUndefined();
+    }
+  });
+
+  it("does not invent a status or a visibility that would widen access", () => {
+    // A row with no visibility must read as the most private option, not the most public.
+    const record = toTournamentRecord({});
+    expect(record.status).toBe("DRAFT");
+    expect(record.visibility).toBe("PRIVATE");
+  });
+
+  it("lets the caller override what the row cannot know", () => {
+    const record = toTournamentRecord({ id: "t1" }, { hosting: true, entrant_count: 31 });
+    expect(record.hosting).toBe(true);
+    expect(record.entrant_count).toBe(31);
+  });
+
+  it("rejects a non-finite number rather than storing NaN as a fee", () => {
+    expect(toTournamentRecord({ entry_fee_minor: Number.NaN }).entry_fee_minor).toBeNull();
+    expect(toTournamentRecord({ entry_fee_minor: "not a number" }).entry_fee_minor).toBeNull();
+  });
+});
+
+describe("column lists", () => {
+  /**
+   * The public projection genuinely has fewer columns than the table, and asking it for one
+   * it does not have is not a soft failure — PostgREST rejects the request and the whole
+   * events list goes with it. That bug shipped once already.
+   */
+  it("never asks the public view for a column it does not carry", () => {
+    const internalOnly = ["active_rule_set_version_id", "active_scoring_version_id", "active_verification_policy_version_id", "active_boundary_version_id"];
+    const publicColumns = PUBLIC_TOURNAMENT_COLUMNS.split(",");
+    for (const column of internalOnly) {
+      expect(TOURNAMENT_COLUMNS.split(",")).toContain(column);
+      expect(publicColumns).not.toContain(column);
+    }
+  });
+
+  it("still asks the public view for the three facts an event card shows", () => {
+    for (const column of ["location_name", "entry_fee_minor", "registration_closes_at"]) {
+      expect(PUBLIC_TOURNAMENT_COLUMNS.split(",")).toContain(column);
+    }
+  });
+
+  it("has no spaces, which PostgREST would send as part of a column name", () => {
+    expect(TOURNAMENT_COLUMNS).not.toMatch(/\s/);
+    expect(PUBLIC_TOURNAMENT_COLUMNS).not.toMatch(/\s/);
+  });
+});
+
+describe("the public view actually carries what the code asks it for", () => {
+  /**
+   * The bug this exists for shipped in the same change that added the column list: the code
+   * asked `public_tournament` for `location_name`, `entry_fee_minor` and `currency`, and the
+   * view selected none of them. PostgREST does not degrade on an unknown column — it rejects
+   * the request — so the entire events list would have failed for every signed-in angler,
+   * and nothing in the type system or the test suite would have said a word.
+   *
+   * Reads the migrations rather than a database, because there is no database in CI and the
+   * mismatch is decidable from the SQL alone.
+   */
+  const viewColumns = (() => {
+    const dir = fileURLToPath(new URL("../../../supabase/migrations/", import.meta.url));
+    const files = readdirSync(dir).filter((name) => name.endsWith(".sql")).sort();
+    let latest: string | null = null;
+    for (const file of files) {
+      const sql = readFileSync(`${dir}${file}`, "utf8");
+      const match = /create or replace view public\.public_tournament as([\s\S]*?);/i.exec(sql);
+      // Later migrations replace earlier ones, so the last definition wins — same as the
+      // database would resolve it.
+      if (match) latest = match[1];
+    }
+    if (latest === null) return null;
+    return [...latest.matchAll(/\bt\.([a-z_][a-z0-9_]*)/gi)].map((m) => m[1].toLowerCase());
+  })();
+
+  it("finds the view definition, so a moved directory cannot make this vacuous", () => {
+    expect(viewColumns).not.toBeNull();
+    expect(viewColumns).toContain("name");
+  });
+
+  it("selects every column PUBLIC_TOURNAMENT_COLUMNS asks for", () => {
+    const missing = PUBLIC_TOURNAMENT_COLUMNS.split(",").filter(
+      (column) => !(viewColumns ?? []).includes(column),
+    );
+    expect(
+      missing,
+      `public_tournament does not select these, and PostgREST rejects a request for a ` +
+        `column a view does not have — which fails the whole events list rather than ` +
+        `hiding one field: ${missing.join(", ")}`,
+    ).toEqual([]);
+  });
+});

--- a/src/features/tournaments/types.ts
+++ b/src/features/tournaments/types.ts
@@ -1,0 +1,119 @@
+/**
+ * One tournament, as every screen in this section reads it.
+ *
+ * This shape used to be called `TournamentRecord` and live in `demo-store.ts`, which was
+ * honest while the only tournaments were seeded ones on a phone. It stopped being honest
+ * the moment `use-tournament.ts` and `queries/use-events.ts` started casting real Supabase
+ * rows to it: the production data path was being typed as demo data, and a reader checking
+ * whether a field was safe to use had to work out that "Demo" no longer meant demo.
+ *
+ * The name is the fix. The demo store produces `TournamentRecord`s; so does Supabase; the
+ * screens do not know or care which they were handed.
+ */
+export interface TournamentRecord {
+  readonly id: string;
+  readonly name: string;
+  readonly status: string;
+  readonly visibility: string;
+  readonly starts_at: string | null;
+  readonly ends_at: string | null;
+
+  /*
+    The event's public face — added with the event calendar. Every one of these is nullable
+    because a host creates a draft long before they know all of it, and a screen that
+    demanded them would make an event impossible to start.
+  */
+  readonly location_name: string | null;
+  readonly registration_closes_at: string | null;
+  /** Base entry cost in minor units. Null means the host has not priced it — not free. */
+  readonly entry_fee_minor: number | null;
+  /** What the pot holds right now, in minor units. Null means not known here. */
+  readonly prize_pool_minor: number | null;
+  /** The host's own words on withdrawals and cancellations. Null means none published. */
+  readonly refund_policy: string | null;
+  readonly currency: string;
+  readonly entrant_count: number;
+  /** Whether the viewer runs this one. */
+  readonly hosting: boolean;
+
+  readonly organization_id: string;
+  readonly active_rule_set_version_id: string | null;
+  readonly active_scoring_version_id: string | null;
+  readonly active_verification_policy_version_id: string | null;
+  readonly active_boundary_version_id: string | null;
+}
+
+/*
+  Two column lists, because there are two tables to read a tournament from and they do not
+  hold the same columns.
+
+  `tournament` is the real row, readable by members of the owning organisation.
+  `public_tournament` is the projection everyone else reads: it carries the flyer — where,
+  when, what it costs — and none of the internal version pointers. Asking the view for a
+  column it does not have is not a soft failure; PostgREST rejects the request and the whole
+  events list goes with it.
+
+  Each is a single literal on purpose: supabase-js parses the string at the type level to
+  shape the row it returns, and a concatenated expression is just `string` to it, which
+  collapses the result type into an error type.
+*/
+export const TOURNAMENT_COLUMNS =
+  "id,name,status,visibility,starts_at,ends_at,location_name,registration_closes_at,entry_fee_minor,currency,refund_policy,organization_id,active_rule_set_version_id,active_scoring_version_id,active_verification_policy_version_id,active_boundary_version_id";
+
+export const PUBLIC_TOURNAMENT_COLUMNS =
+  "id,name,status,visibility,starts_at,ends_at,location_name,registration_closes_at,entry_fee_minor,currency,refund_policy,organization_id";
+
+/**
+ * Narrow an unknown row into a `TournamentRecord`, filling what the row does not carry.
+ *
+ * Every screen used to do `data as TournamentRecord`, which is not a check — it is a
+ * promise to the compiler that nobody verified. A row from PostgREST is network input: a
+ * column renamed in a migration, a view that drops a field, or an RLS policy that hides one
+ * all produce a row that satisfies the cast and then reads `undefined` three screens later,
+ * where it renders as "NaN" or an empty card rather than as an error anybody can act on.
+ *
+ * The defaults are deliberate and each one is the safe direction:
+ * - a missing name is an empty string, never "undefined";
+ * - a missing fee or pot is `null` ("not known"), never `0` ("free"), because the
+ *   difference is money;
+ * - a missing currency is USD, matching the column's own default.
+ */
+export function toTournamentRecord(row: unknown, overrides: Partial<TournamentRecord> = {}): TournamentRecord {
+  const source = (row ?? {}) as Record<string, unknown>;
+  const text = (key: string): string | null => {
+    const value = source[key];
+    return typeof value === "string" && value.length > 0 ? value : null;
+  };
+  const wholeNumber = (key: string): number | null => {
+    const value = source[key];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    // PostgREST returns bigint columns as strings once they exceed a safe integer.
+    if (typeof value === "string" && value.trim() !== "" && Number.isFinite(Number(value))) {
+      return Number(value);
+    }
+    return null;
+  };
+
+  return {
+    id: text("id") ?? "",
+    name: text("name") ?? "",
+    status: text("status") ?? "DRAFT",
+    visibility: text("visibility") ?? "PRIVATE",
+    starts_at: text("starts_at"),
+    ends_at: text("ends_at"),
+    location_name: text("location_name"),
+    registration_closes_at: text("registration_closes_at"),
+    entry_fee_minor: wholeNumber("entry_fee_minor"),
+    prize_pool_minor: wholeNumber("prize_pool_minor"),
+    refund_policy: text("refund_policy"),
+    currency: text("currency") ?? "USD",
+    entrant_count: wholeNumber("entrant_count") ?? 0,
+    hosting: source.hosting === true,
+    organization_id: text("organization_id") ?? "",
+    active_rule_set_version_id: text("active_rule_set_version_id"),
+    active_scoring_version_id: text("active_scoring_version_id"),
+    active_verification_policy_version_id: text("active_verification_policy_version_id"),
+    active_boundary_version_id: text("active_boundary_version_id"),
+    ...overrides,
+  };
+}

--- a/src/features/tournaments/ui-classes.ts
+++ b/src/features/tournaments/ui-classes.ts
@@ -65,8 +65,11 @@ export const CHIP = `inline-flex min-h-touch-floor items-center justify-center r
 export const CHIP_ON = "border-signal-orange bg-signal-orange text-ink-on-orange";
 export const CHIP_OFF = "border-border-interactive bg-surface text-text-link hover:border-text-link";
 
-/** The "← Tournaments" line at the top of a detail screen. 48px of tap area, not 20. */
-export const BACK_LINK = `inline-flex min-h-touch-floor items-center gap-space-2 self-start rounded-md text-caption text-text-link transition-colors hover:text-text-primary ${FOCUS_RING}`;
+/*
+  The back link's own classes used to live here, beside a second `BackLink` component in
+  `tournament-chrome.tsx`. Both are gone: going back is `@/components/back-link`, once, for
+  the whole app.
+*/
 
 /** Numbers that line up in a column: weights, ranks, counts, clocks. */
 export const TABULAR = "font-mono tabular-nums";

--- a/src/features/tournaments/use-tournament.ts
+++ b/src/features/tournaments/use-tournament.ts
@@ -3,7 +3,14 @@
 import { useEffect, useState } from "react";
 
 import { createClient } from "@/lib/supabase/client";
-import { getDemoTournament, hasSupabaseBrowserConfig, type DemoTournament } from "./demo-store";
+import { getDemoTournament, hasSupabaseBrowserConfig } from "./demo-store";
+import { fetchTournamentFacts } from "./queries/tournament-facts";
+import {
+  PUBLIC_TOURNAMENT_COLUMNS,
+  TOURNAMENT_COLUMNS,
+  toTournamentRecord,
+  type TournamentRecord,
+} from "./types";
 
 /**
  * One loader for every tournament detail screen.
@@ -22,10 +29,7 @@ import { getDemoTournament, hasSupabaseBrowserConfig, type DemoTournament } from
 export type TournamentLoad =
   | { readonly state: "loading" }
   | { readonly state: "error"; readonly message: string }
-  | { readonly state: "ready"; readonly tournament: DemoTournament };
-
-const SELECT_COLUMNS =
-  "id,name,status,visibility,starts_at,ends_at,organization_id,active_rule_set_version_id,active_scoring_version_id,active_verification_policy_version_id,active_boundary_version_id";
+  | { readonly state: "ready"; readonly tournament: TournamentRecord };
 
 export function useTournament(tournamentId: string): TournamentLoad {
   const [load, setLoad] = useState<TournamentLoad>({ state: "loading" });
@@ -59,17 +63,81 @@ export function useTournament(tournamentId: string): TournamentLoad {
 
       try {
         const supabase = createClient();
-        const { data, error } = await supabase
+
+        /*
+          Two places a tournament can be read from, and both are needed.
+
+          `tournament` is the real row and row-level security limits it to members of the
+          owning organisation. `public_tournament` is the projection everyone else reads.
+          Querying only the first — which this loader did — meant that tapping a public
+          event from the event calendar, as somebody who does not belong to the host's
+          organisation, produced "That tournament is not there, or it is not shared with
+          you." The event was public. It was on the calendar. It just was not theirs.
+
+          Reading from `tournament` at all is what "you host this" means here, so the
+          fallback also settles the badge.
+        */
+        const ownRow = await supabase
           .from("tournament")
-          .select(SELECT_COLUMNS)
+          .select(TOURNAMENT_COLUMNS)
           .eq("id", tournamentId)
           .is("deleted_at", null)
           .maybeSingle();
 
         if (cancelled) return;
-        if (error) setLoad({ state: "error", message: error.message });
-        else if (!data) setLoad({ state: "error", message: "That tournament is not there, or it is not shared with you." });
-        else setLoad({ state: "ready", tournament: data as DemoTournament });
+
+        let row: unknown = ownRow.data ?? null;
+        let hosting = row !== null;
+
+        if (row === null) {
+          const publicRow = await supabase
+            .from("public_tournament")
+            .select(PUBLIC_TOURNAMENT_COLUMNS)
+            .eq("id", tournamentId)
+            .maybeSingle();
+          if (cancelled) return;
+          row = publicRow.data ?? null;
+          hosting = false;
+
+          if (row === null) {
+            // Report the members-only error only if there was one; otherwise the honest
+            // answer is that no event with this id is visible to this viewer.
+            setLoad({
+              state: "error",
+              message:
+                ownRow.error?.message ??
+                publicRow.error?.message ??
+                "That tournament is not there, or it is not shared with you.",
+            });
+            return;
+          }
+        }
+
+        /*
+          The pot and the field size are not columns on the row, and the detail screen has
+          to show them: a card in the list that carries the prize pool, linking to a page
+          that does not, reads as the page having lost the number.
+
+          Fetched after the row rather than beside it so a viewer who cannot read the
+          finances still gets the tournament. Facts degrade to "not known"; the tournament
+          does not.
+        */
+        const facts = await fetchTournamentFacts(supabase, [tournamentId]);
+        if (cancelled) return;
+
+        setLoad({
+          state: "ready",
+          // Narrowed, not cast. A column renamed in a migration or hidden by a policy used
+          // to satisfy `as TournamentRecord` and surface three screens later as an empty
+          // card; `toTournamentRecord` gives every missing field a defined, safe value.
+          tournament: toTournamentRecord(row, {
+            prize_pool_minor: facts.pools.has(tournamentId)
+              ? (facts.pools.get(tournamentId) ?? null)
+              : null,
+            entrant_count: facts.entrantCounts.get(tournamentId) ?? 0,
+            hosting,
+          }),
+        });
       } catch (cause) {
         if (cancelled) return;
         setLoad({

--- a/supabase/migrations/20260907140000_public_tournament_event_face.sql
+++ b/supabase/migrations/20260907140000_public_tournament_event_face.sql
@@ -1,0 +1,43 @@
+/*
+  The public projection of a tournament has to carry the things a public event card shows.
+
+  `public_tournament` is what an angler who is not in your organisation reads, and it did
+  not select `location_name`, `entry_fee_minor` or `currency` — the three facts the event
+  calendar exists to answer. Two consequences, both bugs:
+
+  1. Every public event on the calendar would render "Not announced" for where it is and
+     nothing for what it costs, no matter what the host had filled in.
+  2. Any query asking the view for those columns fails outright, taking the whole events
+     list down rather than degrading.
+
+  Safe to expose: these are the contents of the flyer. Money that is nobody else's business
+  — what has been collected, who paid, platform fees — stays out of this view, as it always
+  has; the pot is read from `prize_pool` under its own policies.
+
+  A replacement view rather than an edit to 20260905195500: that migration is now
+  applicable, so its history is real and `create or replace view` is the ordinary way to
+  evolve one.
+*/
+create or replace view public.public_tournament as
+select
+  t.id,
+  t.slug,
+  t.name,
+  t.description,
+  t.visibility,
+  t.status,
+  t.starts_at,
+  t.ends_at,
+  t.registration_opens_at,
+  t.registration_closes_at,
+  t.location_name,
+  t.entry_fee_minor,
+  t.currency,
+  t.organization_id,
+  t.created_at
+from public.tournament t
+where t.deleted_at is null
+  and t.visibility in ('PUBLIC','UNLISTED');
+
+comment on view public.public_tournament is
+  'What an angler outside the organisation may read about an event: the flyer, not the books.';

--- a/supabase/migrations/20260907150000_tournament_refund_policy.sql
+++ b/supabase/migrations/20260907150000_tournament_refund_policy.sql
@@ -1,0 +1,47 @@
+/*
+  The host's refund policy, on the tournament.
+
+  ADR 010 §4 requires it on the checkout screen above the pay button, in the host's own
+  words, because weather cancellation is routine in this sport and "what happens to my
+  $400" is the first question a person asks. Until now there was nowhere to put one, so the
+  checkout could only ever say "this host has not published a refund policy" — for every
+  event, forever.
+
+  Deliberately free text and deliberately nullable. It is a promise between a host and an
+  angler about their money; a set of structured options would either be wrong for most
+  events or would read as the app underwriting the terms. Null is honest and the screen
+  says so.
+
+  Public, because it is part of the offer: it goes in the projection an angler reads before
+  they have entered, alongside the price it qualifies.
+*/
+alter table public.tournament
+  add column if not exists refund_policy text;
+
+comment on column public.tournament.refund_policy is
+  'The host''s own words on withdrawals and cancellations. Shown above the pay button. Null means none published, which the checkout states rather than inventing terms.';
+
+create or replace view public.public_tournament as
+select
+  t.id,
+  t.slug,
+  t.name,
+  t.description,
+  t.visibility,
+  t.status,
+  t.starts_at,
+  t.ends_at,
+  t.registration_opens_at,
+  t.registration_closes_at,
+  t.location_name,
+  t.entry_fee_minor,
+  t.currency,
+  t.refund_policy,
+  t.organization_id,
+  t.created_at
+from public.tournament t
+where t.deleted_at is null
+  and t.visibility in ('PUBLIC','UNLISTED');
+
+comment on view public.public_tournament is
+  'What an angler outside the organisation may read about an event: the flyer, not the books.';


### PR DESCRIPTION
No new screens. This is the tidy-and-harden pass ahead of production: the section made honest about its real data path, and the create-to-calendar loop joined up.

## The flow had a hole in the middle

The create form collected a name, a visibility and two dates. The event calendar answers three questions — **where it is, what the pot is at, how long you have to enter** — and the form collected none of them. So every event a host actually made appeared on the calendar as "Not announced", unpriced, with no deadline. A create form that cannot fill in the screen it feeds is the flow broken in the middle.

There is now a step for **where it is, what it costs, when entries close, and the refund policy** the checkout is already required to display, and the review screen shows the event card as an angler will read it.

## Three things would have failed silently against a real database

All three found by reading, not by a failing test.

**The public projection was missing three columns.** `public_tournament` did not carry `location_name`, `entry_fee_minor` or `currency`. PostgREST does not degrade on an unknown column — it rejects the request — so this would have failed **the entire events list** for every signed-in angler, not hidden a field. The view carries them now, and there is a test that reads the migrations and fails if the code asks the view for a column it does not select. I broke the view deliberately to confirm it catches it:

```
AssertionError: public_tournament does not select these, and PostgREST rejects a request
for a column a view does not have — which fails the whole events list rather than hiding
one field: location_name
```

**Jackpots were demo-only.** Read straight from the seeded list with no database path, so the headline feature — "register for the biggest tuna jackpot" — would have rendered nothing at all. No error, no empty state, just no jackpot section on any event. There is a loader now joining each division to the prize pool funding it, which is what produces "Biggest Tuna · $100 · $4,200 in the pot".

**Standings were the worst version of this.** Three screens did `demoMode ? getDemoStandings(id) : []`, so against a real database the leaderboard always rendered *"Nothing has been scored yet — approved catches will appear here."* That sentence is not true: nothing would ever have appeared, because nothing was ever asked for. A reassuring empty state over a missing query is worse than an error — nobody reports it, because it looks like a quiet tournament. There's a loader now reading `public_leaderboard` joined to `public_tournament_entry`, and the screens tell **still loading**, **the standings did not load** and **nobody has scored** apart. The overview's top three and the leaderboard read from the same loader, so they cannot disagree.

The row shape follows what the data can actually say: a standing is a *total*, not a fish, so species and weight are optional and the score's unit is too — an unlabelled number beats a wrong one.

## Other things that were quietly wrong

- **Opening a public event you did not host said "not shared with you".** The loader only read the members-only `tournament` table; it now falls back to the public projection. The event was public, it was on the calendar, it just wasn't yours.
- **`entered` was hardcoded `false`** on the real path, so My Tournaments would have been empty for every signed-in angler with no error explaining why.
- **Every screen cast network rows with `as TournamentRecord`.** A cast is not a check — it's a promise to the compiler nobody verified. Rows are narrowed now, and a missing price reads as "not known", never as free. The difference is money.
- **The type was still called `DemoTournament`** while the production path cast real Supabase rows to it. Renamed to `TournamentRecord`.
- **Entry fees went through `Number(x) * 100`.** Binary floating point can't hold most decimal fractions: `1.005 * 100` is `100.49999999999999`, which rounds to 100 cents instead of 101. Prices are parsed as text now, exactly.
- **A second `BackLink` had grown inside the section**, with a different type scale, so half of it went back in `text-caption` and half in `text-label` — the exact inconsistency the shell round removed from the rest of the app. One now, with a test that fails if a third appears. (That test failed on itself the moment it was committed, because its own assertion contains the pattern it searches for. Test files are excluded now, which is at least proof the search works.)

## How it was checked

- `npm run verify` clean — **955 tests across 92 files**. 8 lint warnings, all pre-existing in files this branch does not touch. `npm run build` clean.
- 24 new tests, including the two structural guards above and the money parser's rounding cases.
- Walked in a browser at 390px against the production build: hosted an event with a location, a **$175.50** fee (cents preserved exactly), a deadline and a refund policy; watched it appear on the calendar carrying all of it with a "You host this" badge; registered for a seeded event and confirmed the jackpots and the host's own refund policy both show; and checked the leaderboard, overview and operations screens against live, final and not-yet-scored events. No console errors.

## Still open, so it isn't lost

- **Host admin (part 3) is not built.** `/tournaments/[id]/operations` exists and is where it goes.
- Live catches and entry writes are still device-local on the real path.
- No payment gateway is configured, and none of this has been on a real phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NvrbeVyuL4CQXbpPMijvnv