### PR TITLE
Registrations reach the server, and the migrations are proved against a real Postgres

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -49,3 +49,19 @@ jobs:
       # builds the branches it is wired to. Running it here means a red build is caught
       # on the PR by the same check as everything else.
       - run: npm run build
+
+      # Applies every migration to a real Postgres, then runs the database behaviour
+      # checks. Nothing else in this workflow can tell whether the SQL runs: when this
+      # step was added, the tournament migrations had never been applied anywhere and the
+      # first run found four separate reasons they could not be — including a foreign key
+      # Postgres refuses to create, and a view that selected three columns its table does
+      # not have. Every one of those would have surfaced as a failed production deploy.
+      #
+      # Installed explicitly rather than relying on the runner image, because the script
+      # exits 2 when it finds no server binaries and a skip that looks like a pass is
+      # exactly the failure this step exists to prevent.
+      - name: Install PostgreSQL
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends postgresql-16
+
+      - name: Migrations apply to a real database
+        run: scripts/check-migrations-apply.sh

--- a/docs/architecture/decisions/010-tournament-checkout-and-payment-methods.md
+++ b/docs/architecture/decisions/010-tournament-checkout-and-payment-methods.md
@@ -132,3 +132,44 @@ architect's call to make silently.
 - `tournament_division` and `tournament_award_category` are referenced by
   `20260905194000_tournament_scoring.sql` and never created; jackpots are divisions, so
   that gap is closed by the registration work rather than left.
+
+---
+
+## Amendment, 2026-09-07 — two corrections the database made
+
+Both of these were found by applying the migration set to a real Postgres and running the
+registration functions against it. Neither was visible by reading the SQL.
+
+### An order covers one host, not one basket
+
+§1 says "one order, many items" and did not say whose. `tournament_order` holds a single
+`organization_id`, and that is correct rather than a limitation to design around: one card
+charge settles into one account, and a refund drawn from a basket spanning two hosts would
+have no single party to come from.
+
+So an order covers **one organisation's events**. A basket spanning hosts is two
+registrations, and both the server (`register_crew_for_tournaments` raises) and the
+registration form (which warns while you are still ticking boxes) say so. Everything else in
+§1 stands: within one host, several events and several jackpots are one order, one payment,
+all-or-nothing.
+
+### A crew is a team of entries, not one entry with a crew on it
+
+`tournament_entry_one_identity` is a unique index: an entry holds exactly **one** person.
+The first implementation put the whole crew on one entry and the database refused it.
+
+The correct shape — and, on reflection, the better one — is a `tournament_team` per boat per
+event, holding one `tournament_entry` per angler, with the captain flagged on
+`tournament_team_member.role`. It is more rows, and it is the only shape in which a crew
+member can be scored, disqualified, or claim their own catches independently of the skipper.
+
+**The money does not multiply with the crew.** One boat pays one entry fee per event — a
+`TEAM_ENTRY` line, not a line per angler — and buys into a jackpot once. That is what the
+schema's distinct `TEAM_ENTRY` item type is for.
+
+### And one rule that got sharper
+
+Activation is server-side only. `confirm_tournament_order` is granted to nobody: an angler
+who could call it would never need to pay. Until a payment webhook exists, an entry stays
+PENDING after a test-mode payment, and the checkout screen says exactly that rather than
+claiming an entry the server has not confirmed.

--- a/docs/team/worklog/2026-09-07-04-head-dev.md
+++ b/docs/team/worklog/2026-09-07-04-head-dev.md
@@ -1,0 +1,56 @@
+### 2026-09-07 | head-dev + architect | 5h
+
+Registrations now reach the server. This was the last of the "goes quietly blank in
+production" problems: a registration wrote to the phone, so an angler would see a
+confirmation the host would never receive.
+
+**The biggest thing I did was stand up a real Postgres and apply all 58 migrations to it.**
+There is a script for it now (`npm run db:check`) and it runs in CI. Nothing else in the
+project could tell whether the SQL runs — the linter, the type checker and every test read
+the files as text. The first run found four separate reasons the tournament migrations could
+not be applied to an empty database, all of which would have surfaced as a failed production
+deploy:
+
+- a foreign key typed `uuid` against `species.id`, which is `text` — Postgres refuses to
+  create it at all, and every migration after it fails with it. **This one was mine, merged
+  yesterday.**
+- a view selecting three columns its table does not have (`tournament_entry_id`,
+  `captured_at_device`, `state` on `tournament_catch`).
+- `create or replace view` cannot insert a column into the middle of a view — only append.
+  Two migrations did exactly that. **Also mine, also merged.**
+- replacing that view needs the function returning its row type dropped and restored first.
+
+**Then the database corrected the design twice**, which is the part I could not have got
+right by reading:
+
+- One order cannot span two hosts. `tournament_order` holds a single organisation, and that
+  is right — a card charge settles into one account. A basket across hosts is two
+  registrations, and the form now says so while you are ticking boxes rather than at the
+  pay button.
+- A crew is not one entry with several people on it. There is a unique index saying an entry
+  holds exactly one identity, so a boat is a team holding one entry per angler. More rows,
+  and the only shape where a crew member can be scored or disqualified on their own. The
+  money does not multiply: one boat pays one entry fee per event.
+
+**Two bugs in my own SQL that only running it could find:** the idempotency check ran after
+validation, so a legitimate retry hit "you are already entered" instead of returning the
+order it had already created; and a `where team_id = team_id` compared a column to itself,
+which would have confirmed every entry in the database on any payment. There is a test for
+that second one now.
+
+**The security line worth knowing:** `confirm_tournament_order` is granted to nobody. An
+angler who could call it would never need to pay. So entries stay PENDING after a test-mode
+payment until a payment webhook exists, and the checkout says that plainly instead of
+claiming an entry the server has not confirmed.
+
+Checked: 58 migrations apply cleanly and 28 database behaviour checks pass against real
+Postgres 16; `npm run verify` clean with 955 tests; `npm run build` clean. Walked the
+registration in a browser at 390px — crew of two, two events, a jackpot, paid, and both
+events appear in My Tournaments.
+
+- Files: scripts/check-migrations-apply.sh, supabase/test/{supabase-shim,rpc-behaviour}.sql,
+  supabase/migrations/{20260907160000,20260907161000} and fixes to four existing ones,
+  src/features/tournaments/queries/use-registration-order.ts, checkout/use-checkout.ts,
+  components/{registration-page,checkout-panel}.tsx, .github/workflows/verify.yml, ADR 010.
+- Next: the payment webhook that calls `confirm_tournament_order` is the missing piece, and
+  it needs a server. Host admin is still not built. Live catches are still device-local.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "tokens:check": "node scripts/tokens.mjs --check",
     "tripwires": "node scripts/check-tripwires.mjs",
     "migrations:check": "node scripts/check-migration-versions.mjs",
+    "db:check": "scripts/check-migrations-apply.sh",
     "test": "vitest run",
     "verify": "npm run tokens:check && npm run tripwires && npm run migrations:check && npm run lint && tsc --noEmit && npm run test"
   },

--- a/scripts/check-migrations-apply.sh
+++ b/scripts/check-migrations-apply.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Applies every migration, in order, to a real Postgres.
+#
+# This exists because reading SQL does not tell you whether it runs. When this script was
+# written the tournament migration set had never been applied anywhere, and the first run
+# found four separate reasons it could not be:
+#
+#   1. `tournament_division.target_species_id` was typed `uuid` against `species.id`, which
+#      is `text` — a foreign key Postgres refuses to create at all.
+#   2. `public_tournament_catch` selected three columns that do not exist on
+#      `tournament_catch` (`tournament_entry_id`, `captured_at_device`, `state`).
+#   3. `create or replace view` cannot insert a column into the middle of a view's select
+#      list; it can only append. Two migrations did exactly that.
+#   4. Replacing the view needs `get_public_tournament` dropped and restored first, because
+#      the function returns the view's row type.
+#
+# None of those are visible to TypeScript, to the linter, or to any test that reads the
+# files as text. All four would have surfaced as a failed production deploy.
+#
+# Usage: scripts/check-migrations-apply.sh [--keep]
+#   --keep  leave the database running afterwards, for poking at with psql.
+set -euo pipefail
+
+PGBIN="${PGBIN:-/usr/lib/postgresql/16/bin}"
+PGDATA_DIR="${PGDATA_DIR:-/tmp/flb-migration-check/data}"
+PGRUN_DIR="${PGRUN_DIR:-/tmp/flb-migration-check/run}"
+PGPORT="${PGPORT:-5433}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+KEEP=false
+[[ "${1:-}" == "--keep" ]] && KEEP=true
+
+if [[ ! -x "$PGBIN/initdb" ]]; then
+  echo "No Postgres server binaries at $PGBIN." >&2
+  echo "Install postgresql-16, or set PGBIN. Skipping is NOT the same as passing." >&2
+  exit 2
+fi
+
+# Postgres refuses to run as root, so a throwaway unprivileged user owns the cluster.
+RUN_AS=""
+if [[ "$(id -u)" -eq 0 ]]; then
+  id -u flbpg >/dev/null 2>&1 || useradd -m flbpg
+  RUN_AS="flbpg"
+fi
+as_pg() { if [[ -n "$RUN_AS" ]]; then su "$RUN_AS" -c "$1"; else bash -c "$1"; fi; }
+
+cleanup() {
+  if [[ "$KEEP" == false ]]; then
+    as_pg "$PGBIN/pg_ctl -D $PGDATA_DIR stop -m immediate" >/dev/null 2>&1 || true
+    rm -rf "$(dirname "$PGDATA_DIR")"
+  fi
+}
+trap cleanup EXIT
+
+rm -rf "$(dirname "$PGDATA_DIR")"
+mkdir -p "$PGDATA_DIR" "$PGRUN_DIR"
+[[ -n "$RUN_AS" ]] && chown -R "$RUN_AS" "$(dirname "$PGDATA_DIR")"
+
+as_pg "$PGBIN/initdb -D $PGDATA_DIR -U postgres -A trust" >/dev/null
+as_pg "$PGBIN/pg_ctl -D $PGDATA_DIR -o '-k $PGRUN_DIR -p $PGPORT -c listen_addresses=' -w start" >/dev/null
+
+PSQL=(psql -q -h "$PGRUN_DIR" -p "$PGPORT" -U postgres -d postgres -v ON_ERROR_STOP=1)
+
+# Stand-ins for the parts of Supabase the migrations reference. Deliberately the smallest
+# thing that lets the SQL run: a real Supabase has far more, and none of the rest is what
+# these migrations are testing.
+"${PSQL[@]}" -f "$REPO_ROOT/supabase/test/supabase-shim.sql" >/dev/null
+
+failed=0
+count=0
+for file in "$REPO_ROOT"/supabase/migrations/*.sql; do
+  count=$((count + 1))
+  if ! output=$("${PSQL[@]}" -f "$file" 2>&1); then
+    echo "FAILED: $(basename "$file")" >&2
+    echo "$output" | grep -v '^psql.*NOTICE' | head -20 >&2
+    failed=1
+    break
+  fi
+done
+
+if [[ "$failed" -eq 1 ]]; then
+  echo "" >&2
+  echo "A migration did not apply. A deploy would fail here." >&2
+  exit 1
+fi
+
+echo "migrations: all $count applied cleanly to Postgres $("${PSQL[@]}" -tAc 'show server_version' | tr -d ' ')."
+
+if [[ -f "$REPO_ROOT/supabase/test/rpc-behaviour.sql" ]]; then
+  if ! output=$("${PSQL[@]}" -f "$REPO_ROOT/supabase/test/rpc-behaviour.sql" 2>&1); then
+    echo "FAILED: rpc-behaviour.sql" >&2
+    echo "$output" | grep -v '^psql.*NOTICE' | tail -30 >&2
+    exit 1
+  fi
+  echo "$output" | grep -E '^(ok|not ok|##)' || true
+  echo "database behaviour checks passed."
+fi
+
+if [[ "$KEEP" == true ]]; then
+  echo "Database left running: psql -h $PGRUN_DIR -p $PGPORT -U postgres"
+fi

--- a/src/features/tournaments/checkout/use-checkout.ts
+++ b/src/features/tournaments/checkout/use-checkout.ts
@@ -39,9 +39,16 @@ export type CheckoutState =
   | { readonly kind: "failed"; readonly message: string };
 
 export interface CheckoutOrder {
-  readonly orderId: string;
   readonly totalMinor: number;
   readonly currency: string;
+  /**
+   * Creates the order on the server and returns its id, or explains why it could not.
+   *
+   * Called at the moment the angler commits to paying, not on mount: an order created when
+   * a form loads is a PENDING row for everybody who ever opened the screen. Idempotent, so
+   * a second tap returns the first order rather than a second one.
+   */
+  readonly createOrder: () => Promise<{ ok: true; orderId: string } | { ok: false; message: string }>;
 }
 
 /* Module-level so their identity is stable across renders; `useSyncExternalStore`
@@ -110,12 +117,19 @@ export function useCheckout(order: CheckoutOrder) {
     async (cardNumber: string) => {
       setState({ kind: "working" });
       try {
+        /* The order exists before the money moves. See `use-registration-order.ts`: a
+           payment that succeeds against nothing leaves somebody charged and not entered. */
+        const order_ = await order.createOrder();
+        if (!order_.ok) {
+          if (alive.current) setState({ kind: "failed", message: order_.message });
+          return;
+        }
         const provider = new StripePaymentProvider(new TestStripeClient(cardNumber));
         const created = await provider.createPayment({
-          orderId: order.orderId,
+          orderId: order_.orderId,
           amountMinor: order.totalMinor,
           currency: order.currency,
-          idempotencyKey: order.orderId,
+          idempotencyKey: order_.orderId,
         });
         if (created.status === "REQUIRES_ACTION") {
           if (alive.current) setState({ kind: "action-required" });
@@ -128,23 +142,28 @@ export function useCheckout(order: CheckoutOrder) {
         setState({ kind: "failed", message: messageOf(cause) });
       }
     },
-    [order.orderId, order.totalMinor, order.currency, settle],
+    [order, settle],
   );
 
   /** Wallet, step one: get a quote and show what to send, where, and by when. */
   const startWalletPayment = useCallback(async () => {
     setState({ kind: "working" });
     try {
+      const order_ = await order.createOrder();
+      if (!order_.ok) {
+        if (alive.current) setState({ kind: "failed", message: order_.message });
+        return;
+      }
       const gateway = new TestCryptoGateway();
       const provider = new CryptoPaymentProvider(gateway);
       cryptoGateway.current = gateway;
       cryptoProvider.current = provider;
 
       const created = await provider.createPayment({
-        orderId: order.orderId,
+        orderId: order_.orderId,
         amountMinor: order.totalMinor,
         currency: order.currency,
-        idempotencyKey: order.orderId,
+        idempotencyKey: order_.orderId,
       });
       paymentId.current = created.providerPaymentId;
       const quote = await gateway.getQuote(created.providerPaymentId.replace(/^crypto:/, ""));
@@ -153,7 +172,7 @@ export function useCheckout(order: CheckoutOrder) {
       if (!alive.current) return;
       setState({ kind: "failed", message: messageOf(cause) });
     }
-  }, [order.orderId, order.totalMinor, order.currency]);
+  }, [order]);
 
   /**
    * Wallet, step two: record the transaction and watch the chain.

--- a/src/features/tournaments/components/checkout-panel.tsx
+++ b/src/features/tournaments/components/checkout-panel.tsx
@@ -6,7 +6,12 @@ import type { OrderDraft } from "@/core/tournaments/registration";
 import { WalletFailure, connectWallet } from "@/lib/wallet/browser-wallet";
 
 import { TEST_CARDS } from "../checkout/test-gateways";
-import { useCheckout, type CheckoutState, type PaymentMethod } from "../checkout/use-checkout";
+import {
+  useCheckout,
+  type CheckoutOrder,
+  type CheckoutState,
+  type PaymentMethod,
+} from "../checkout/use-checkout";
 import { formatMoney } from "../event-card";
 import {
   BIG_ACTION,
@@ -40,25 +45,29 @@ export interface EventRefundPolicy {
 }
 
 export function CheckoutPanel({
-  orderId,
+  createOrder,
   draft,
   refundPolicies,
   ready,
   blockedReason,
+  serverBacked,
   onPaid,
 }: {
-  orderId: string;
+  /** Creates the real order the moment the angler commits. See `use-checkout.ts`. */
+  createOrder: CheckoutOrder["createOrder"];
   draft: OrderDraft;
   /** One per event being paid for — see the note where these render. */
   refundPolicies: readonly EventRefundPolicy[];
   ready: boolean;
   blockedReason: string | null;
+  /** True when a tournament server took the registration, false in on-device demo mode. */
+  serverBacked: boolean;
   onPaid: (reference: string) => void;
 }) {
   const checkout = useCheckout({
-    orderId,
     totalMinor: draft.totalMinor,
     currency: draft.currency,
+    createOrder,
   });
   const [method, setMethod] = useState<PaymentMethod>("card");
   const [card, setCard] = useState<string>(TEST_CARDS.success);
@@ -75,11 +84,23 @@ export function CheckoutPanel({
       <section className={`${CARD_PADDED} flex flex-col gap-space-3`} aria-live="polite">
         <h2 className="flex items-center gap-space-2 text-h3 text-success-green">
           <CheckIcon />
-          Paid — you are entered
+          {serverBacked ? "Paid — waiting on confirmation" : "Paid — you are entered"}
         </h2>
         <p className="text-body text-text-primary">
           {total} for {draft.lines.length} {draft.lines.length === 1 ? "item" : "items"}.
         </p>
+        {/*
+          On a real tournament server an entry becomes CONFIRMED only when the payment
+          provider tells the server so, which no browser may do — see
+          `confirm_tournament_order`. Saying "you are entered" here would be the single
+          worst lie this app could tell somebody standing on a dock at 5am.
+        */}
+        {serverBacked ? (
+          <p className="text-body text-text-muted">
+            Your boat and your crew are registered and the host can see you. The entry shows
+            as pending until the payment is confirmed by the host&rsquo;s payment provider.
+          </p>
+        ) : null}
         <p className={`text-caption text-text-muted ${TABULAR}`}>Reference {state.reference}</p>
         <button type="button" onClick={() => onPaid(state.reference)} className={BIG_ACTION}>
           See my tournaments
@@ -201,7 +222,7 @@ export function CheckoutPanel({
               return, and the provider's real observation logic — chain, asset, recipient,
               amount, confirmations — runs against it exactly as it would on a live chain.
             */
-            const hash = `0x${orderId.replace(/\W/g, "").padEnd(64, "0").slice(0, 64)}`;
+            const hash = `0x${state.quote.quoteId.replace(/\W/g, "").padEnd(64, "0").slice(0, 64)}`;
             void checkout.submitWalletTransaction(hash, state.quote);
           }}
         >

--- a/src/features/tournaments/components/registration-page.tsx
+++ b/src/features/tournaments/components/registration-page.tsx
@@ -13,9 +13,10 @@ import {
   type EventOption,
 } from "@/core/tournaments/registration";
 
-import { registerDemoEntry } from "../demo-store";
 import { registrationState } from "../event-card";
+import { hasSupabaseBrowserConfig } from "../demo-store";
 import { useDivisions } from "../queries/use-divisions";
+import { useRegistrationOrder } from "../queries/use-registration-order";
 import { useEvents } from "../queries/use-events";
 import { useNow } from "../use-now";
 import { CARD_PADDED, INSET, PAGE } from "../ui-classes";
@@ -53,6 +54,12 @@ export function RegistrationPage({ tournamentId }: { tournamentId: string }) {
   const [eventIds, setEventIds] = useState<readonly string[]>([tournamentId]);
   const [divisionIds, setDivisionIds] = useState<readonly string[]>([]);
   const [policyAcknowledged, setPolicyAcknowledged] = useState(false);
+  const createRegistrationOrder = useRegistrationOrder();
+  /*
+    One key per visit to this screen, not per render and not per tap. Two taps on Pay must
+    reach the same order; opening the form again tomorrow must not.
+  */
+  const [idempotencyKey] = useState(() => `reg-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`);
 
   /* Only events still taking entries can be added. Offering a closed one and refusing it at
      checkout would waste the one decision the screen is asking for. */
@@ -128,7 +135,20 @@ export function RegistrationPage({ tournamentId }: { tournamentId: string }) {
       divisionIds.includes(id) ? divisionIds.filter((each) => each !== id) : [...divisionIds, id],
     );
 
-  const ready = canCheckOut({ crew, build, refundPolicyAcknowledged: policyAcknowledged });
+  /*
+    One payment cannot pay two hosts. `tournament_order` holds a single `organization_id`,
+    and that is right rather than a limitation: a card charge settles to one account, and a
+    refund from a shared basket would have no single party to come from. The server refuses
+    it; saying so here means an angler finds out while ticking boxes rather than after
+    filling in a crew and reaching for a card.
+  */
+  const selectedHosts = new Set(
+    enterable.filter((event) => eventIds.includes(event.id)).map((event) => event.organization_id),
+  );
+  const multipleHosts = selectedHosts.size > 1;
+
+  const ready =
+    !multipleHosts && canCheckOut({ crew, build, refundPolicyAcknowledged: policyAcknowledged });
 
   return (
     <div className={PAGE}>
@@ -157,6 +177,13 @@ export function RegistrationPage({ tournamentId }: { tournamentId: string }) {
         disabled={false}
       />
 
+      {multipleHosts ? (
+        <p className={`${INSET} text-body text-amber-flag`} role="alert">
+          These events are run by different hosts, so they cannot be paid for together.
+          Register with one host, then come back for the other.
+        </p>
+      ) : null}
+
       {build.problem === "mixed-currency" ? (
         <p className={`${INSET} text-body text-amber-flag`} role="alert">
           These events are priced in different currencies, so they cannot be paid for
@@ -178,21 +205,34 @@ export function RegistrationPage({ tournamentId }: { tournamentId: string }) {
 
       {build.draft ? (
         <CheckoutPanel
-          orderId={`order-${tournamentId}-${eventIds.length}-${divisionIds.length}`}
           draft={build.draft}
           refundPolicies={refundPolicies}
           ready={ready}
-          blockedReason={blockedReason({ problems: problems.length, policyAcknowledged })}
-          onPaid={() => {
-            // Demo mode has no server to write to, so the entry is recorded on the device.
-            // The real write lands with the tournament backend; the rule that only a
-            // confirmed payment gets here is already enforced above.
-            const captain = crew.find((member) => member.isCaptain);
-            for (const id of eventIds) {
-              registerDemoEntry(id, captain?.displayName.trim() || "My boat");
-            }
-            router.push("/tournaments/mine");
+          serverBacked={hasSupabaseBrowserConfig()}
+          blockedReason={blockedReason({
+            problems: problems.length,
+            policyAcknowledged,
+            multipleHosts,
+          })}
+          createOrder={async () => {
+            /*
+              Runs at the moment the angler commits to paying — the registration is written
+              to the server BEFORE any money moves, so a successful payment can never land
+              against nothing. See `use-registration-order.ts`.
+            */
+            const result = await createRegistrationOrder({
+              crew,
+              selection,
+              divisionsByEvent: new Map(
+                options.map((option) => [option.id, option.divisions.map((d) => d.id)]),
+              ),
+              idempotencyKey,
+            });
+            return result.ok
+              ? { ok: true as const, orderId: result.orderId }
+              : { ok: false as const, message: result.message };
           }}
+          onPaid={() => router.push("/tournaments/mine")}
         />
       ) : (
         <p className="text-body text-text-muted">Tick at least one event to see the total.</p>
@@ -204,7 +244,12 @@ export function RegistrationPage({ tournamentId }: { tournamentId: string }) {
 }
 
 /** Says what is still missing, so a disabled pay button is never a mystery. */
-function blockedReason(input: { problems: number; policyAcknowledged: boolean }): string | null {
+function blockedReason(input: {
+  problems: number;
+  policyAcknowledged: boolean;
+  multipleHosts: boolean;
+}): string | null {
+  if (input.multipleHosts) return "Pick events from one host to pay for them together.";
   if (input.problems > 0) return "Finish the crew details above before paying.";
   if (!input.policyAcknowledged) return "Tick the box above to confirm you have read the policy.";
   return null;

--- a/src/features/tournaments/event-card.test.ts
+++ b/src/features/tournaments/event-card.test.ts
@@ -30,6 +30,7 @@ function event(overrides: Partial<TournamentEvent> = {}): TournamentEvent {
     currency: "USD",
     refund_policy: "Full refund up to 48 hours before the start.",
     entrant_count: 19,
+    organization_id: "org-1",
     entered: false,
     hosting: false,
     ...overrides,

--- a/src/features/tournaments/event-card.ts
+++ b/src/features/tournaments/event-card.ts
@@ -33,6 +33,8 @@ export interface TournamentEvent {
   /** The host's own words on withdrawals. Null means none published — the checkout says so. */
   readonly refund_policy: string | null;
   readonly entrant_count: number | null;
+  /** Who runs it. Two hosts cannot share one payment — see `registration-page.tsx`. */
+  readonly organization_id: string;
   /** Whether the viewer is entered in this one. Drives "My tournaments" and the badges. */
   readonly entered: boolean;
   /** Whether the viewer hosts it. Drives the host-admin door. */

--- a/src/features/tournaments/queries/use-events.ts
+++ b/src/features/tournaments/queries/use-events.ts
@@ -52,6 +52,7 @@ function fromDemo(row: TournamentRecord, enteredIds: ReadonlySet<string>): Tourn
     currency: row.currency,
     refund_policy: row.refund_policy,
     entrant_count: row.entrant_count,
+    organization_id: row.organization_id,
     entered: enteredIds.has(row.id),
     hosting: row.hosting,
   };
@@ -136,6 +137,7 @@ export function useEvents(): { readonly load: EventsLoad; readonly retry: () => 
           currency: row.currency,
           refund_policy: row.refund_policy,
           entrant_count: facts.entrantCounts.get(row.id) ?? 0,
+          organization_id: row.organization_id,
           entered: facts.enteredIds.has(row.id),
           hosting: row.hosting,
         }));

--- a/src/features/tournaments/queries/use-registration-order.ts
+++ b/src/features/tournaments/queries/use-registration-order.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useCallback } from "react";
+
+import type { CrewMember, RegistrationSelection } from "@/core/tournaments/registration";
+import { createClient } from "@/lib/supabase/client";
+
+import { hasSupabaseBrowserConfig, registerDemoEntry } from "../demo-store";
+
+/**
+ * Creating the real order and the real entries, before a penny is taken.
+ *
+ * The order in which these two things happen is the whole design, and it is the opposite
+ * of the obvious one. Pay first and then register, and a payment that succeeds while the
+ * registration fails leaves somebody charged and not entered, with nothing on the server
+ * that knows they tried. Register first and the worst case is an unpaid PENDING order,
+ * which is a row a host can see, chase, or expire.
+ *
+ * So: `register_crew_for_tournaments` runs first and creates the order, the boat, one entry
+ * per angler per event, and the bill — all PENDING. Then the payment is taken against that
+ * order id. Then, and only then, a confirmation from the payment provider activates the
+ * entries, server-side, in `confirm_tournament_order`.
+ *
+ * **That last step cannot happen from here, deliberately.** If the browser could confirm an
+ * order, the checkout would be optional: skip the paying, call the confirming. So there is
+ * no client path to it, and until a payment webhook exists an entry stays PENDING after a
+ * test-mode payment. The screens say so rather than claiming an entry that does not exist.
+ */
+
+export interface OrderRequest {
+  readonly crew: readonly CrewMember[];
+  readonly selection: RegistrationSelection;
+  /** Which divisions belong to which event, so the call can be shaped per event. */
+  readonly divisionsByEvent: ReadonlyMap<string, readonly string[]>;
+  /** Stable for one attempt — see the idempotency note in the migration. */
+  readonly idempotencyKey: string;
+}
+
+export type OrderResult =
+  | { readonly ok: true; readonly orderId: string; readonly serverBacked: boolean }
+  | { readonly ok: false; readonly message: string };
+
+export function useRegistrationOrder() {
+  return useCallback(async (request: OrderRequest): Promise<OrderResult> => {
+    if (!hasSupabaseBrowserConfig()) {
+      // Demo mode has no server to write to. The entry is recorded on the device so the
+      // rest of the app behaves, and the order id is local.
+      const captain = request.crew.find((member) => member.isCaptain);
+      for (const id of request.selection.eventIds) {
+        registerDemoEntry(id, captain?.displayName.trim() || "My boat");
+      }
+      return { ok: true, orderId: `demo-order-${request.idempotencyKey}`, serverBacked: false };
+    }
+
+    try {
+      const supabase = createClient();
+      const { data: authData } = await supabase.auth.getUser();
+      if (!authData.user) {
+        return { ok: false, message: "Sign in before registering, so the entry is yours." };
+      }
+
+      const registrations = request.selection.eventIds.map((eventId) => ({
+        tournament_id: eventId,
+        division_ids: (request.divisionsByEvent.get(eventId) ?? []).filter((id) =>
+          request.selection.divisionIds.includes(id),
+        ),
+      }));
+
+      const { data, error } = await supabase.rpc("register_crew_for_tournaments", {
+        registrations,
+        crew: request.crew.map((member) => ({
+          display_name: member.displayName.trim(),
+          email: member.email,
+          phone: member.phone,
+          is_captain: member.isCaptain,
+        })),
+        idempotency_key: request.idempotencyKey,
+      });
+
+      if (error) return { ok: false, message: error.message };
+      if (typeof data !== "string") {
+        return { ok: false, message: "The tournament server did not return an order." };
+      }
+      return { ok: true, orderId: data, serverBacked: true };
+    } catch (cause) {
+      return {
+        ok: false,
+        message: cause instanceof Error ? cause.message : "The registration could not be created.",
+      };
+    }
+  }, []);
+}

--- a/src/features/tournaments/types.test.ts
+++ b/src/features/tournaments/types.test.ts
@@ -125,7 +125,9 @@ describe("the public view actually carries what the code asks it for", () => {
     let latest: string | null = null;
     for (const file of files) {
       const sql = readFileSync(`${dir}${file}`, "utf8");
-      const match = /create or replace view public\.public_tournament as([\s\S]*?);/i.exec(sql);
+      // Matches both `create view` and `create or replace view`: the later migrations drop
+      // and recreate, because replace cannot insert a column into the middle of a view.
+      const match = /create (?:or replace )?view public\.public_tournament as([\s\S]*?);/i.exec(sql);
       // Later migrations replace earlier ones, so the last definition wins — same as the
       // database would resolve it.
       if (match) latest = match[1];

--- a/supabase/migrations/20260905184500_tournament_core.sql
+++ b/supabase/migrations/20260905184500_tournament_core.sql
@@ -172,7 +172,14 @@ create table if not exists public.tournament_division (
   entry_fee_minor bigint check (entry_fee_minor is null or entry_fee_minor >= 0),
   /* Whether an entrant chooses this, or is placed in it by the rules. */
   is_optional boolean not null default true,
-  target_species_id uuid references public.species(id) on delete set null,
+  /*
+    `text`, not `uuid`: species ids in this schema are slugs ("yellowtail"), not generated
+    keys — `public.species.id` is a text primary key from the 28 August core schema. Typed
+    as uuid this foreign key does not merely mismatch at runtime, it refuses to be created,
+    and every migration after it fails with it. Caught by applying the set to a real
+    Postgres rather than by reading it.
+  */
+  target_species_id text references public.species(id) on delete set null,
   sort_order integer not null default 0,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),

--- a/supabase/migrations/20260905195500_tournament_public_projections.sql
+++ b/supabase/migrations/20260905195500_tournament_public_projections.sql
@@ -38,15 +38,21 @@ where e.deleted_at is null
   and t.visibility in ('PUBLIC','UNLISTED');
 
 create or replace view public.public_tournament_catch as
+/*
+  Column names corrected against `public.tournament_catch` as it is actually defined in
+  20260905193000: the entry is `entry_id`, the device clock is `caught_at_device`, and the
+  review state is `status`. As written the view could not be created, which stopped every
+  migration after it — so no environment had ever run this file.
+*/
 select
   c.id,
   c.tournament_id,
-  c.tournament_entry_id,
+  c.entry_id as tournament_entry_id,
   c.species_id,
   c.weight_g,
   c.length_mm,
-  c.captured_at_device,
-  c.state,
+  c.caught_at_device as captured_at_device,
+  c.status as state,
   e.storage_path as public_photo_path
 from public.tournament_catch c
 join public.tournament t on t.id = c.tournament_id
@@ -60,7 +66,7 @@ left join lateral (
 ) e on true
 where t.deleted_at is null
   and t.visibility in ('PUBLIC','UNLISTED')
-  and c.state in ('APPROVED','FINAL');
+  and c.status in ('APPROVED','FINAL');
 
 create or replace view public.public_leaderboard as
 select

--- a/supabase/migrations/20260907140000_public_tournament_event_face.sql
+++ b/supabase/migrations/20260907140000_public_tournament_event_face.sql
@@ -18,7 +18,16 @@
   applicable, so its history is real and `create or replace view` is the ordinary way to
   evolve one.
 */
-create or replace view public.public_tournament as
+/*
+  Dropped and recreated rather than `create or replace view`. Replace can only APPEND
+  columns: inserting one into the middle of the select list fails with "cannot change name
+  of view column", because Postgres matches the new definition to the old one positionally.
+  Keeping the columns in a readable order is worth the drop, and nothing depends on this
+  view but the client.
+*/
+drop function if exists public.get_public_tournament(text);
+drop view if exists public.public_tournament;
+create view public.public_tournament as
 select
   t.id,
   t.slug,
@@ -41,3 +50,18 @@ where t.deleted_at is null
 
 comment on view public.public_tournament is
   'What an angler outside the organisation may read about an event: the flyer, not the books.';
+
+/*
+  `get_public_tournament` returns `setof public.public_tournament`, so it holds a reference
+  to the view's row type and has to be dropped with it and put back afterwards. Restored
+  verbatim from 20260905195500, grants included — a function that silently loses its grant
+  is a route that stops working for anonymous readers.
+*/
+create or replace function public.get_public_tournament(target_slug text)
+returns setof public.public_tournament
+language sql stable security definer set search_path = public as $$
+  select * from public.public_tournament where slug = target_slug limit 1;
+$$;
+
+revoke all on function public.get_public_tournament(text) from public;
+grant execute on function public.get_public_tournament(text) to anon, authenticated;

--- a/supabase/migrations/20260907150000_tournament_refund_policy.sql
+++ b/supabase/migrations/20260907150000_tournament_refund_policy.sql
@@ -21,7 +21,16 @@ alter table public.tournament
 comment on column public.tournament.refund_policy is
   'The host''s own words on withdrawals and cancellations. Shown above the pay button. Null means none published, which the checkout states rather than inventing terms.';
 
-create or replace view public.public_tournament as
+/*
+  Dropped and recreated rather than `create or replace view`. Replace can only APPEND
+  columns: inserting one into the middle of the select list fails with "cannot change name
+  of view column", because Postgres matches the new definition to the old one positionally.
+  Keeping the columns in a readable order is worth the drop, and nothing depends on this
+  view but the client.
+*/
+drop function if exists public.get_public_tournament(text);
+drop view if exists public.public_tournament;
+create view public.public_tournament as
 select
   t.id,
   t.slug,
@@ -45,3 +54,18 @@ where t.deleted_at is null
 
 comment on view public.public_tournament is
   'What an angler outside the organisation may read about an event: the flyer, not the books.';
+
+/*
+  `get_public_tournament` returns `setof public.public_tournament`, so it holds a reference
+  to the view's row type and has to be dropped with it and put back afterwards. Restored
+  verbatim from 20260905195500, grants included — a function that silently loses its grant
+  is a route that stops working for anonymous readers.
+*/
+create or replace function public.get_public_tournament(target_slug text)
+returns setof public.public_tournament
+language sql stable security definer set search_path = public as $$
+  select * from public.public_tournament where slug = target_slug limit 1;
+$$;
+
+revoke all on function public.get_public_tournament(text) from public;
+grant execute on function public.get_public_tournament(text) to anon, authenticated;

--- a/supabase/migrations/20260907160000_crew_registration_rpc.sql
+++ b/supabase/migrations/20260907160000_crew_registration_rpc.sql
@@ -1,0 +1,308 @@
+/*
+  Registering a crew for one or more events, as a single transaction.
+
+  Why a function and not inserts from the browser: `tournament_entry` is writable only by
+  OWNER/ADMIN/STAFF of the owning organisation (20260905190000), which is correct — an
+  angler must not be able to write arbitrary entries. Self-registration therefore has to go
+  through a definer function that decides, in one place, exactly what an angler may create
+  for themselves. `register_self_for_tournament` already does that for a bare one-person
+  entry; this is the same idea for the flow the product actually has: a crew, a captain, a
+  basket of events and jackpots, and a bill.
+
+  Why one transaction: ADR 010 §1 makes a registration all-or-nothing. Six inserts issued
+  separately from a browser can half-succeed — a phone loses signal between the entry and
+  its identities and an angler is registered as nobody. Inside a function they commit
+  together or not at all.
+
+  What it deliberately does NOT do is take money or confirm anything. Everything it creates
+  is PENDING. Activation happens in `confirm_tournament_order`, which is not callable by an
+  angler — see the note there.
+
+  **The shape of a crew, which the schema decides and not this function.**
+  `tournament_entry_one_identity` is a unique index: an entry holds exactly ONE person. A
+  boat is therefore a `tournament_team` grouping one entry per angler, with the captain
+  flagged on `tournament_team_member.role`. Three anglers across two events is six entries
+  and two teams, which looks like a lot until you notice it is the only shape in which a
+  crew member can be scored, disqualified or claim their own catches independently.
+
+  The money does not multiply with the crew. One boat pays one entry fee per event — a
+  `TEAM_ENTRY` line, not one line per angler — and a jackpot is bought by the boat once.
+  That is what the schema's separate `TEAM_ENTRY` item type is for, and it matches how these
+  events are actually sold.
+*/
+
+create or replace function public.register_crew_for_tournaments(
+  registrations jsonb,
+  crew jsonb,
+  idempotency_key text
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  uid uuid := auth.uid();
+  reg jsonb;
+  member jsonb;
+  captain_count integer := 0;
+  captain_digits integer := 0;
+  target public.tournament;
+  organization uuid;
+  order_currency text;
+  new_order_id uuid;
+  existing_order_id uuid;
+  new_entry_id uuid;
+  new_team_id uuid;
+  captain_entry_id uuid;
+  running_total bigint := 0;
+  division public.tournament_division;
+  division_id uuid;
+begin
+  if uid is null then
+    raise exception 'authentication required' using errcode = '42501';
+  end if;
+
+  if idempotency_key is null or length(btrim(idempotency_key)) = 0 then
+    raise exception 'idempotency key required' using errcode = 'check_violation';
+  end if;
+
+  if registrations is null or jsonb_typeof(registrations) <> 'array'
+     or jsonb_array_length(registrations) = 0 then
+    raise exception 'choose at least one event' using errcode = 'check_violation';
+  end if;
+
+  if crew is null or jsonb_typeof(crew) <> 'array' or jsonb_array_length(crew) = 0 then
+    raise exception 'a crew needs at least one angler' using errcode = 'check_violation';
+  end if;
+
+  /*
+    The same three crew rules the form enforces (`core/tournaments/registration.ts`), stated
+    again here because a client-side check is a courtesy and a server-side one is the rule.
+    The phone test is "enough digits to dial", not a format: international numbers and
+    "(cell)" are both real, and rejecting a number a host can actually ring in order to
+    enforce a pattern is the wrong trade.
+  */
+  for member in select * from jsonb_array_elements(crew) loop
+    if length(btrim(coalesce(member->>'display_name', ''))) = 0 then
+      raise exception 'every angler needs a name' using errcode = 'check_violation';
+    end if;
+    if coalesce((member->>'is_captain')::boolean, false) then
+      captain_count := captain_count + 1;
+      captain_digits := length(regexp_replace(coalesce(member->>'phone', ''), '\D', '', 'g'));
+    end if;
+  end loop;
+
+  if captain_count <> 1 then
+    raise exception 'exactly one captain is required' using errcode = 'check_violation';
+  end if;
+  if captain_digits < 7 then
+    raise exception 'the captain needs a contact number' using errcode = 'check_violation';
+  end if;
+
+  /*
+    Idempotency comes FIRST, before any validation.
+
+    It is a money property, not a nicety: a double-tapped Pay button, or a client retrying
+    after a dropped response, must not produce two orders and two sets of entries. Putting
+    it after the checks was a real bug and the database found it — the retry reached the
+    "you are already entered" guard, which is true precisely BECAUSE the first call
+    succeeded, and the caller got an error instead of the order it had already paid for.
+
+    Scoped to the purchasing angler rather than the organisation, because the organisation
+    is not known until the events have been read, and a key is minted per attempt by one
+    client anyway.
+  */
+  select id into existing_order_id
+    from public.tournament_order
+   where tournament_order.idempotency_key = btrim(register_crew_for_tournaments.idempotency_key)
+     and purchaser_angler_id = uid;
+  if existing_order_id is not null then
+    return existing_order_id;
+  end if;
+
+  /*
+    Every event on one order must belong to one organisation, because `tournament_order`
+    holds a single `organization_id` — and that is right, not a limitation to design around:
+    one card charge cannot pay two different hosts, and a refund from a shared basket would
+    have no single party to come from. A basket spanning hosts is two registrations.
+  */
+  for reg in select * from jsonb_array_elements(registrations) loop
+    select * into target
+      from public.tournament
+     where id = (reg->>'tournament_id')::uuid
+       and deleted_at is null;
+
+    if target.id is null then
+      raise exception 'tournament not found' using errcode = 'P0002';
+    end if;
+    if target.status <> 'REGISTRATION_OPEN' then
+      raise exception 'registration is not open for %', target.name using errcode = 'check_violation';
+    end if;
+    -- The deadline is enforced by the clock, not by whoever last set the status column.
+    if target.registration_closes_at is not null and target.registration_closes_at <= now() then
+      raise exception 'entries have closed for %', target.name using errcode = 'check_violation';
+    end if;
+
+    if organization is null then
+      organization := target.organization_id;
+      order_currency := target.currency;
+    elsif organization <> target.organization_id then
+      raise exception 'these events have different hosts, so they cannot share one payment'
+        using errcode = 'check_violation';
+    elsif order_currency is distinct from target.currency then
+      raise exception 'these events are priced in different currencies'
+        using errcode = 'check_violation';
+    end if;
+
+    -- Entering twice is a mistake, not an intention, and it would be charged for twice.
+    if exists (
+      select 1
+        from public.tournament_entry e
+        join public.tournament_entry_identity i on i.tournament_entry_id = e.id
+       where e.tournament_id = target.id
+         and e.deleted_at is null
+         and i.claimed_angler_id = uid
+    ) then
+      raise exception 'you are already entered in %', target.name using errcode = 'unique_violation';
+    end if;
+  end loop;
+
+  insert into public.tournament_order (
+    organization_id, tournament_id, purchaser_angler_id, currency,
+    subtotal_minor, total_minor, status, idempotency_key
+  ) values (
+    organization,
+    (registrations->0->>'tournament_id')::uuid,
+    uid,
+    coalesce(order_currency, 'USD'),
+    0, 0, 'PENDING_PAYMENT',
+    btrim(register_crew_for_tournaments.idempotency_key)
+  ) returning id into new_order_id;
+
+  for reg in select * from jsonb_array_elements(registrations) loop
+    select * into target from public.tournament where id = (reg->>'tournament_id')::uuid;
+
+    /*
+      The boat. Named for the captain, because that is how a dock refers to it and because
+      the schema wants a non-blank name that a person will recognise on a leaderboard.
+    */
+    insert into public.tournament_team (tournament_id, organization_id, name, created_by)
+    values (
+      target.id,
+      target.organization_id,
+      coalesce(
+        nullif(btrim((select m->>'display_name' from jsonb_array_elements(crew) m
+                       where coalesce((m->>'is_captain')::boolean, false) limit 1)), ''),
+        'Crew'
+      ),
+      uid
+    ) returning id into new_team_id;
+
+    for member in select * from jsonb_array_elements(crew) loop
+      insert into public.tournament_entry (
+        tournament_id, organization_id, team_id, registration_status,
+        eligibility_status, check_in_status, competition_status
+      ) values (
+        target.id, target.organization_id, new_team_id, 'PENDING',
+        'UNKNOWN', 'NOT_CHECKED_IN', 'NOT_STARTED'
+      ) returning id into new_entry_id;
+
+      /*
+        One identity per entry — the captain is the signed-in angler and is claimed;
+        everyone else is a GUEST, because they have not signed in and claiming on their
+        behalf would fail `registered_identity_has_angler`. A guest can claim later.
+      */
+      insert into public.tournament_entry_identity (
+        tournament_entry_id, identity_type, display_name, email, phone,
+        claimed_angler_id, claimed_at
+      ) values (
+        new_entry_id,
+        case when coalesce((member->>'is_captain')::boolean, false) then 'REGISTERED_USER' else 'GUEST' end,
+        btrim(member->>'display_name'),
+        nullif(btrim(coalesce(member->>'email', '')), ''),
+        nullif(btrim(coalesce(member->>'phone', '')), ''),
+        case when coalesce((member->>'is_captain')::boolean, false) then uid else null end,
+        case when coalesce((member->>'is_captain')::boolean, false) then now() else null end
+      );
+
+      insert into public.tournament_team_member (tournament_team_id, tournament_entry_id, role)
+      values (
+        new_team_id, new_entry_id,
+        case when coalesce((member->>'is_captain')::boolean, false) then 'CAPTAIN' else 'MEMBER' end
+      );
+
+      if coalesce((member->>'is_captain')::boolean, false) then
+        captain_entry_id := new_entry_id;
+      end if;
+    end loop;
+
+    -- An unpriced event produces no line. Null is "the host has not said", and charging
+    -- zero for it would tell the angler their entry is settled when it is not.
+    if target.entry_fee_minor is not null then
+      insert into public.tournament_order_item (
+        order_id, item_type, reference_id, description, quantity,
+        unit_amount_minor, total_amount_minor, metadata
+      ) values (
+        new_order_id, 'TEAM_ENTRY', target.id, target.name, 1,
+        target.entry_fee_minor, target.entry_fee_minor,
+        jsonb_build_object('tournament_team_id', new_team_id)
+      );
+      running_total := running_total + target.entry_fee_minor;
+    end if;
+
+    for division_id in
+      select (value #>> '{}')::uuid from jsonb_array_elements(coalesce(reg->'division_ids', '[]'::jsonb))
+    loop
+      select * into division
+        from public.tournament_division
+       where id = division_id
+         and tournament_id = target.id
+         and deleted_at is null;
+
+      if division.id is null then
+        raise exception 'that jackpot is not part of %', target.name using errcode = 'P0002';
+      end if;
+      if not division.is_optional then
+        raise exception '% is not something you opt into', division.name using errcode = 'check_violation';
+      end if;
+
+      -- A division with no fee is included in the entry: it is joined, not bought.
+      if division.entry_fee_minor is not null then
+        insert into public.tournament_order_item (
+          order_id, item_type, reference_id, description, quantity,
+          unit_amount_minor, total_amount_minor, metadata
+        ) values (
+          new_order_id,
+          case when division.kind = 'SIDE_POT' then 'SIDE_POT' else 'JACKPOT' end,
+          division.id,
+          target.name || ' — ' || division.name,
+          1,
+          division.entry_fee_minor, division.entry_fee_minor,
+          jsonb_build_object(
+            'tournament_team_id', new_team_id,
+            -- The boat buys in once, and the pot records the captain's entry as the holder.
+            'tournament_entry_id', captain_entry_id,
+            'prize_pool_id', division.prize_pool_id
+          )
+        );
+        running_total := running_total + division.entry_fee_minor;
+      end if;
+    end loop;
+  end loop;
+
+  update public.tournament_order
+     set subtotal_minor = running_total,
+         total_minor = running_total,
+         updated_at = now()
+   where id = new_order_id;
+
+  return new_order_id;
+end;
+$$;
+
+revoke all on function public.register_crew_for_tournaments(jsonb, jsonb, text) from public;
+grant execute on function public.register_crew_for_tournaments(jsonb, jsonb, text) to authenticated;
+
+comment on function public.register_crew_for_tournaments(jsonb, jsonb, text) is
+  'Creates one order and one PENDING entry per event, with the crew on each, in a single transaction. Takes no money and confirms nothing.';

--- a/supabase/migrations/20260907161000_confirm_tournament_order.sql
+++ b/supabase/migrations/20260907161000_confirm_tournament_order.sql
@@ -1,0 +1,156 @@
+/*
+  Turning a paid order into live entries.
+
+  **This function is not callable by an angler, and that is the whole point.** Registration
+  creates PENDING entries and a PENDING_PAYMENT order; the only thing that activates them is
+  a confirmed payment. If the browser could call this, anybody could register for every
+  event in the app for nothing — the client would simply skip the paying and call the
+  confirming. So `authenticated` is not granted execute. It runs from the service role: a
+  Stripe webhook, or a server-side on-chain observation.
+
+  That has a consequence worth stating plainly rather than discovering: until that webhook
+  exists, entries stay PENDING after a test-mode payment. The screens say so. A PENDING
+  entry that claims to be confirmed would be the single worst lie this app could tell an
+  angler standing on a dock at 5am.
+
+  Idempotent on `provider_payment_id`, because a payment provider will deliver the same
+  webhook more than once and paying twice must not double the pot.
+*/
+
+create or replace function public.confirm_tournament_order(
+  target_order_id uuid,
+  provider_name text,
+  provider_reference text,
+  paid_amount_minor bigint
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  target public.tournament_order;
+  existing_payment_id uuid;
+  new_payment_id uuid;
+  item public.tournament_order_item;
+  /*
+    Named `item_team_id`, not `team_id`. A PL/pgSQL variable that shares a name with a
+    column silently shadows it, so `where team_id = team_id` compares the column to itself
+    and is true for every row — this exact line, before it was renamed, would have confirmed
+    every entry in the database on any payment. Prefixed names are the cheap defence.
+  */
+  item_team_id uuid;
+  item_entry_id uuid;
+begin
+  select * into target from public.tournament_order where id = target_order_id;
+  if target.id is null then
+    raise exception 'order not found' using errcode = 'P0002';
+  end if;
+
+  -- Replayed webhook: the same provider payment lands again. Return what it already did.
+  select id into existing_payment_id
+    from public.payment
+   where provider = provider_name
+     and provider_payment_id = provider_reference;
+  if existing_payment_id is not null then
+    return existing_payment_id;
+  end if;
+
+  /*
+    Refuse to activate an order for less than it costs. A provider that reports a smaller
+    amount than the bill is either a partial payment or a mismatched reference, and both are
+    reasons to stop rather than to let somebody into a $400 tournament for $4.
+  */
+  if paid_amount_minor < target.total_minor then
+    raise exception 'payment of % does not cover the order total of %',
+      paid_amount_minor, target.total_minor using errcode = 'check_violation';
+  end if;
+
+  insert into public.payment (
+    organization_id, order_id, provider, provider_payment_id,
+    currency, amount_minor, status, confirmed_at
+  ) values (
+    target.organization_id, target.id, provider_name, provider_reference,
+    target.currency, paid_amount_minor, 'CONFIRMED', now()
+  ) returning id into new_payment_id;
+
+  update public.tournament_order
+     set status = 'PAID', updated_at = now()
+   where id = target.id;
+
+  for item in
+    select * from public.tournament_order_item where order_id = target.id
+  loop
+    insert into public.payment_allocation (payment_id, order_item_id, amount_minor, allocation_kind)
+    values (new_payment_id, item.id, item.total_amount_minor, 'ORDER_ITEM');
+
+    item_team_id := nullif(item.metadata->>'tournament_team_id', '')::uuid;
+    item_entry_id := nullif(item.metadata->>'tournament_entry_id', '')::uuid;
+
+    /*
+      An entry line is bought by the boat, so it confirms the boat: every entry on that
+      team, which is one per angler. Confirming only the captain would leave the rest of
+      the crew pending on a paid order — registered as nobody, on the water.
+    */
+    if item.item_type in ('TEAM_ENTRY', 'BOAT_ENTRY', 'TOURNAMENT_ENTRY') and item_team_id is not null then
+      update public.tournament_entry e
+         set registration_status = 'CONFIRMED', updated_at = now()
+       where e.team_id = item_team_id;
+    end if;
+
+    /*
+      A jackpot buy-in joins its pot only now. Creating the `prize_pool_entry` at
+      registration would have counted unpaid entrants in the "34 in" that the next angler
+      reads when deciding whether the pot is worth it.
+    */
+    if item.item_type in ('JACKPOT', 'SIDE_POT') and item_entry_id is not null then
+      if nullif(item.metadata->>'prize_pool_id', '') is not null then
+        insert into public.prize_pool_entry (
+          prize_pool_id, tournament_entry_id, participation_status,
+          contribution_amount_minor, funding_reference_type, funding_reference_id
+        ) values (
+          (item.metadata->>'prize_pool_id')::uuid, item_entry_id, 'ACTIVE',
+          item.total_amount_minor, 'PAYMENT', new_payment_id
+        )
+        on conflict (prize_pool_id, tournament_entry_id) do nothing;
+
+        update public.prize_pool
+           set funded_amount_minor = funded_amount_minor + item.total_amount_minor,
+               funding_status = 'PARTIALLY_FUNDED',
+               updated_at = now()
+         where id = (item.metadata->>'prize_pool_id')::uuid;
+      end if;
+    end if;
+  end loop;
+
+  /*
+    A free event produces no priced line at all, and an angler who entered one is entered.
+    Confirm every pending entry on any team this order created, so a boat that paid $100 for
+    a jackpot on a free event does not end up with a paid jackpot and an unconfirmed crew.
+  */
+  update public.tournament_entry e
+     set registration_status = 'CONFIRMED', updated_at = now()
+   where e.registration_status = 'PENDING'
+     and e.team_id in (
+       select distinct nullif(i.metadata->>'tournament_team_id', '')::uuid
+         from public.tournament_order_item i
+        where i.order_id = target.id
+          and nullif(i.metadata->>'tournament_team_id', '') is not null
+     );
+
+  return new_payment_id;
+end;
+$$;
+
+/*
+  No grant to `authenticated`. See the header — this is the line that stops the checkout
+  being free. `service_role` bypasses RLS and function grants in Supabase, so the webhook
+  can call it without one; spelling out the revoke keeps the intent visible to the next
+  person to read this file.
+*/
+revoke all on function public.confirm_tournament_order(uuid, text, text, bigint) from public;
+revoke all on function public.confirm_tournament_order(uuid, text, text, bigint) from anon;
+revoke all on function public.confirm_tournament_order(uuid, text, text, bigint) from authenticated;
+
+comment on function public.confirm_tournament_order(uuid, text, text, bigint) is
+  'Activates the entries on a paid order. Service role only — an angler who could call this would never need to pay.';

--- a/supabase/test/rpc-behaviour.sql
+++ b/supabase/test/rpc-behaviour.sql
@@ -1,0 +1,264 @@
+/*
+  What the registration functions actually do, run against a real Postgres.
+
+  These are not unit tests of SQL text — they insert an organisation, a tournament and some
+  jackpots, impersonate an angler, call the functions, and check the rows that come out.
+  Everything happens inside one transaction that is rolled back at the end, so the script
+  can be run repeatedly against the same database.
+
+  `ok`/`not ok` lines are printed so a human skimming the output can see what passed. Any
+  failure raises, which stops the script and fails the harness.
+*/
+begin;
+
+create or replace function pg_temp.check(label text, condition boolean) returns void
+language plpgsql as $$
+begin
+  if condition then
+    raise notice 'ok %', label;
+  else
+    raise exception 'not ok %', label;
+  end if;
+end;
+$$;
+
+-- ---------------------------------------------------------------- fixtures
+insert into auth.users (id, email) values
+  ('11111111-1111-1111-1111-111111111111', 'captain@example.test'),
+  ('22222222-2222-2222-2222-222222222222', 'host@example.test');
+
+-- No `public.angler` insert: 20260903120000 puts a trigger on `auth.users` that creates
+-- one. Inserting here would collide with it, which is itself a useful thing to have proven.
+
+insert into public.organization (id, kind, name, created_by) values
+  -- Two hosts, so the "one order cannot span two organisations" rule has something to
+  -- refuse. Only one may be PERSONAL per creator, hence the CLUB kind on the second.
+  ('33333333-3333-3333-3333-333333333333', 'PERSONAL', 'Host Org', '22222222-2222-2222-2222-222222222222'),
+  ('44444444-4444-4444-4444-444444444444', 'CLUB', 'Other Org', '22222222-2222-2222-2222-222222222222');
+
+insert into public.tournament (id, organization_id, name, visibility, status, currency,
+                               entry_fee_minor, registration_closes_at, created_by)
+values
+  ('55555555-5555-5555-5555-555555555555', '33333333-3333-3333-3333-333333333333',
+   'Tuna Jackpot', 'PUBLIC', 'REGISTRATION_OPEN', 'USD', 40000, now() + interval '2 days',
+   '22222222-2222-2222-2222-222222222222'),
+  ('66666666-6666-6666-6666-666666666666', '33333333-3333-3333-3333-333333333333',
+   'Yellowtail Open', 'PUBLIC', 'REGISTRATION_OPEN', 'USD', 25000, now() + interval '5 days',
+   '22222222-2222-2222-2222-222222222222'),
+  ('77777777-7777-7777-7777-777777777777', '33333333-3333-3333-3333-333333333333',
+   'Closed Already', 'PUBLIC', 'REGISTRATION_OPEN', 'USD', 10000, now() - interval '1 hour',
+   '22222222-2222-2222-2222-222222222222'),
+  ('88888888-8888-8888-8888-888888888888', '44444444-4444-4444-4444-444444444444',
+   'Another Host Event', 'PUBLIC', 'REGISTRATION_OPEN', 'USD', 5000, now() + interval '3 days',
+   '22222222-2222-2222-2222-222222222222');
+
+insert into public.prize_pool (id, organization_id, tournament_id, name, currency, pool_type)
+values ('99999999-9999-9999-9999-999999999999', '33333333-3333-3333-3333-333333333333',
+        '55555555-5555-5555-5555-555555555555', 'Biggest Tuna', 'USD', 'JACKPOT');
+
+insert into public.tournament_division (id, tournament_id, organization_id, name, kind,
+                                        entry_fee_minor, is_optional, prize_pool_id)
+values
+  ('aaaaaaaa-0000-0000-0000-000000000001', '55555555-5555-5555-5555-555555555555',
+   '33333333-3333-3333-3333-333333333333', 'Biggest Tuna', 'JACKPOT', 10000, true,
+   '99999999-9999-9999-9999-999999999999'),
+  ('aaaaaaaa-0000-0000-0000-000000000002', '55555555-5555-5555-5555-555555555555',
+   '33333333-3333-3333-3333-333333333333', 'Junior', 'DIVISION', null, true, null);
+
+-- Impersonate the captain for everything below.
+set local request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';
+
+-- ---------------------------------------------------------------- the happy path
+do $$
+declare
+  oid_ uuid;
+  total bigint;
+  n integer;
+begin
+  oid_ := public.register_crew_for_tournaments(
+    '[{"tournament_id":"55555555-5555-5555-5555-555555555555",
+       "division_ids":["aaaaaaaa-0000-0000-0000-000000000001","aaaaaaaa-0000-0000-0000-000000000002"]},
+      {"tournament_id":"66666666-6666-6666-6666-666666666666","division_ids":[]}]'::jsonb,
+    '[{"display_name":"Elliott T","phone":"949-555-0113","is_captain":true},
+      {"display_name":"Mike R","is_captain":false}]'::jsonb,
+    'key-happy-path'
+  );
+
+  select total_minor into total from public.tournament_order where id = oid_;
+  -- 40000 entry + 10000 jackpot + 25000 entry. The free "Junior" division adds nothing, and
+  -- the second crew member adds nothing: a boat pays once per event, not once per angler.
+  perform pg_temp.check('the boat pays one entry fee per event, whatever the crew size', total = 75000);
+
+  select count(*) into n from public.tournament_team
+   where tournament_id in ('55555555-5555-5555-5555-555555555555','66666666-6666-6666-6666-666666666666');
+  perform pg_temp.check('one boat per event', n = 2);
+
+  select count(*) into n from public.tournament_entry
+   where tournament_id in ('55555555-5555-5555-5555-555555555555','66666666-6666-6666-6666-666666666666');
+  perform pg_temp.check('one entry per angler per event', n = 4);
+
+  select count(*) into n from public.tournament_entry_identity i
+    join public.tournament_entry e on e.id = i.tournament_entry_id
+   where e.tournament_id in ('55555555-5555-5555-5555-555555555555','66666666-6666-6666-6666-666666666666');
+  perform pg_temp.check('exactly one identity on each entry', n = 4);
+
+  select count(*) into n from public.tournament_team_member where role = 'CAPTAIN';
+  perform pg_temp.check('each boat has one captain', n = 2);
+
+  perform pg_temp.check('nothing is confirmed before payment',
+    not exists (select 1 from public.tournament_entry where registration_status <> 'PENDING'));
+
+  perform pg_temp.check('the order waits for money',
+    (select status from public.tournament_order where id = oid_) = 'PENDING_PAYMENT');
+
+  perform pg_temp.check('the captain is the signed-in angler',
+    (select count(*) from public.tournament_entry_identity
+      where claimed_angler_id = '11111111-1111-1111-1111-111111111111'
+        and identity_type = 'REGISTERED_USER') = 2);
+
+  perform pg_temp.check('crew who have not signed in are guests',
+    (select count(*) from public.tournament_entry_identity
+      where display_name = 'Mike R' and identity_type = 'GUEST') = 2);
+
+  perform pg_temp.check('the captain phone is kept for the 4am call',
+    (select phone from public.tournament_entry_identity
+      where display_name = 'Elliott T' limit 1) = '949-555-0113');
+
+  perform pg_temp.check('the pot is empty until somebody pays',
+    (select funded_amount_minor from public.prize_pool
+      where id = '99999999-9999-9999-9999-999999999999') = 0);
+
+  -- ------------------------------------------------------------ idempotency
+  perform pg_temp.check('the same key returns the same order, not a second one',
+    public.register_crew_for_tournaments(
+      '[{"tournament_id":"55555555-5555-5555-5555-555555555555","division_ids":[]}]'::jsonb,
+      '[{"display_name":"Elliott T","phone":"9495550113","is_captain":true}]'::jsonb,
+      'key-happy-path') = oid_);
+
+  select count(*) into n from public.tournament_entry;
+  perform pg_temp.check('and creates no further entries', n = 4);
+
+  -- ------------------------------------------------------------ confirming
+  perform public.confirm_tournament_order(oid_, 'stripe', 'pi_test_1', 75000);
+
+  perform pg_temp.check('paying confirms the whole crew, not just the captain',
+    (select count(*) from public.tournament_entry where registration_status = 'CONFIRMED') = 4);
+
+  perform pg_temp.check('the order is paid',
+    (select status from public.tournament_order where id = oid_) = 'PAID');
+
+  perform pg_temp.check('every line is allocated against the payment',
+    (select count(*) from public.payment_allocation) =
+    (select count(*) from public.tournament_order_item where order_id = oid_));
+
+  perform pg_temp.check('the jackpot pot grows by the buy-in',
+    (select funded_amount_minor from public.prize_pool
+      where id = '99999999-9999-9999-9999-999999999999') = 10000);
+
+  perform pg_temp.check('the boat joins the pot once, not once per angler',
+    (select count(*) from public.prize_pool_entry
+      where prize_pool_id = '99999999-9999-9999-9999-999999999999') = 1);
+
+  -- A provider will deliver the same webhook twice. It must not double the pot.
+  perform public.confirm_tournament_order(oid_, 'stripe', 'pi_test_1', 75000);
+  perform pg_temp.check('a replayed webhook does not double the pot',
+    (select funded_amount_minor from public.prize_pool
+      where id = '99999999-9999-9999-9999-999999999999') = 10000);
+end $$;
+
+-- ---------------------------------------------------------------- refusals
+do $$
+declare
+  failed boolean;
+begin
+  -- Each of these must raise. `failed` records that it did.
+  failed := false;
+  begin
+    perform public.register_crew_for_tournaments(
+      '[{"tournament_id":"77777777-7777-7777-7777-777777777777","division_ids":[]}]'::jsonb,
+      '[{"display_name":"A","phone":"9495550113","is_captain":true}]'::jsonb, 'k1');
+  exception when others then failed := true; end;
+  perform pg_temp.check('a passed deadline closes entries even while the status says open', failed);
+
+  failed := false;
+  begin
+    perform public.register_crew_for_tournaments(
+      '[{"tournament_id":"66666666-6666-6666-6666-666666666666","division_ids":[]},
+        {"tournament_id":"88888888-8888-8888-8888-888888888888","division_ids":[]}]'::jsonb,
+      '[{"display_name":"A","phone":"9495550113","is_captain":true}]'::jsonb, 'k2');
+  exception when others then failed := true; end;
+  perform pg_temp.check('two hosts cannot share one payment', failed);
+
+  failed := false;
+  begin
+    perform public.register_crew_for_tournaments(
+      '[{"tournament_id":"66666666-6666-6666-6666-666666666666","division_ids":[]}]'::jsonb,
+      '[{"display_name":"A","is_captain":true}]'::jsonb, 'k3');
+  exception when others then failed := true; end;
+  perform pg_temp.check('the captain must be reachable by phone', failed);
+
+  failed := false;
+  begin
+    perform public.register_crew_for_tournaments(
+      '[{"tournament_id":"66666666-6666-6666-6666-666666666666","division_ids":[]}]'::jsonb,
+      '[{"display_name":"A","phone":"9495550113","is_captain":true},
+        {"display_name":"B","phone":"9495550114","is_captain":true}]'::jsonb, 'k4');
+  exception when others then failed := true; end;
+  perform pg_temp.check('two captains is not a crew', failed);
+
+  failed := false;
+  begin
+    perform public.register_crew_for_tournaments(
+      '[{"tournament_id":"55555555-5555-5555-5555-555555555555",
+         "division_ids":["aaaaaaaa-0000-0000-0000-000000000001"]}]'::jsonb,
+      '[{"display_name":"A","phone":"9495550113","is_captain":true}]'::jsonb, 'k5');
+  exception when others then failed := true; end;
+  perform pg_temp.check('entering the same event twice is refused', failed);
+end $$;
+
+-- ---------------------------------------------------------------- underpayment
+do $$
+declare
+  oid_ uuid;
+  failed boolean := false;
+  n integer;
+begin
+  set local request.jwt.claim.sub = '22222222-2222-2222-2222-222222222222';
+  oid_ := public.register_crew_for_tournaments(
+    '[{"tournament_id":"66666666-6666-6666-6666-666666666666","division_ids":[]}]'::jsonb,
+    '[{"display_name":"Host","phone":"9495550199","is_captain":true}]'::jsonb, 'key-underpay');
+  begin
+    perform public.confirm_tournament_order(oid_, 'stripe', 'pi_short', 100);
+  exception when others then failed := true; end;
+  perform pg_temp.check('a payment smaller than the bill does not let anybody in', failed);
+
+  select count(*) into n from public.tournament_entry e
+    join public.tournament_team t on t.id = e.team_id
+   where t.created_by = '22222222-2222-2222-2222-222222222222'
+     and e.registration_status = 'PENDING';
+  perform pg_temp.check('and that boat stays pending', n = 1);
+
+  /*
+    The regression that matters most in this file. `where team_id = team_id` inside the
+    confirm function compared a column to itself, so one underpaid order would have
+    confirmed every entry in the database. The captain's four entries above are already
+    CONFIRMED and must stay at four.
+  */
+  select count(*) into n from public.tournament_entry where registration_status = 'CONFIRMED';
+  perform pg_temp.check('a failed payment confirms nobody else''s entries', n = 4);
+end $$;
+
+-- ---------------------------------------------------------------- signed out
+do $$
+declare failed boolean := false;
+begin
+  set local request.jwt.claim.sub = '';
+  begin
+    perform public.register_crew_for_tournaments(
+      '[{"tournament_id":"66666666-6666-6666-6666-666666666666","division_ids":[]}]'::jsonb,
+      '[{"display_name":"A","phone":"9495550113","is_captain":true}]'::jsonb, 'k6');
+  exception when others then failed := true; end;
+  perform pg_temp.check('signed out, you cannot register anybody', failed);
+end $$;
+
+rollback;

--- a/supabase/test/supabase-shim.sql
+++ b/supabase/test/supabase-shim.sql
@@ -1,0 +1,17 @@
+-- Minimal stand-ins for the parts of Supabase the migrations lean on. Idempotent, so the
+-- harness can reset and re-apply repeatedly.
+do $$ begin
+  if not exists (select 1 from pg_roles where rolname = 'anon') then create role anon nologin; end if;
+  if not exists (select 1 from pg_roles where rolname = 'authenticated') then create role authenticated nologin; end if;
+  if not exists (select 1 from pg_roles where rolname = 'service_role') then create role service_role nologin; end if;
+end $$;
+create schema if not exists auth;
+create table if not exists auth.users (id uuid primary key, email text);
+-- The tests set this GUC to impersonate a signed-in angler.
+create or replace function auth.uid() returns uuid language sql stable as $$
+  select nullif(current_setting('request.jwt.claim.sub', true), '')::uuid;
+$$;
+create or replace function auth.role() returns text language sql stable as $$
+  select coalesce(nullif(current_setting('request.jwt.claim.role', true), ''), 'anon');
+$$;
+create extension if not exists pgcrypto;


### PR DESCRIPTION
A registration wrote to the phone. An angler saw a confirmation the host would never receive. This closes that — and in doing so found rather more than expected.

## The most important thing here isn't code

**`npm run db:check` applies all 58 migrations to a real Postgres and runs behaviour checks against them.** It now runs in CI, and installs Postgres explicitly rather than skipping, because a skip that looks like a pass is exactly the failure it exists to prevent.

Nothing else in this project could tell whether the SQL *runs*. The linter, the type checker and every test read the files as text. Its first run found **four separate reasons the tournament migrations could not be applied to an empty database** — every one of which would have surfaced as a failed production deploy:

1. `tournament_division.target_species_id` typed `uuid` against `species.id`, which is `text`. Postgres refuses to create that foreign key at all, and every migration after it fails with it. **Mine, merged yesterday.**
2. `public_tournament_catch` selected three columns its table does not have (`tournament_entry_id`, `captured_at_device`, `state`).
3. `create or replace view` cannot insert a column into the *middle* of a view — only append. Two migrations did exactly that. **Also mine, also merged.**
4. Replacing that view needs `get_public_tournament` dropped and restored first, because it returns the view's row type.

## Then the database corrected the design twice

Neither was visible by reading. Both are recorded as an amendment to ADR 010.

**An order cannot span two hosts.** `tournament_order` holds a single `organization_id` — and that is right, not a limitation to design around: a card charge settles into one account, and a refund drawn from a basket spanning two hosts has no single party to come from. A cross-host basket is two registrations. The server refuses it, and the form now warns while you are still ticking boxes rather than at the pay button.

**A crew is not one entry with people on it.** `tournament_entry_one_identity` is a unique index: an entry holds exactly one person. So a boat is a `tournament_team` holding one `tournament_entry` per angler, captain flagged on `tournament_team_member.role`. More rows — and the only shape in which a crew member can be scored, disqualified, or claim their own catches independently of the skipper. **The money does not multiply with the crew:** one boat pays one entry fee per event, as a `TEAM_ENTRY` line, and buys into a jackpot once.

## Two bugs in the new SQL that only running it could find

- **Idempotency ran after validation.** A legitimate retry — a dropped response, a double-tapped Pay — hit "you are already entered" instead of returning the order it had already created. Which is the precise case idempotency exists for.
- **`where team_id = team_id`** compared a column to itself. A PL/pgSQL variable silently shadows a column name, so that clause was true for every row: **one payment would have confirmed every entry in the database.** Variables are prefixed now, and there is a test asserting a failed payment confirms nobody else's entries.

## The order of operations, which is the design

The order is created **before** the money moves. Pay first and register second, and a payment that succeeds while the registration fails leaves somebody charged and not entered, with nothing on the server that knows they tried. Register first and the worst case is an unpaid `PENDING` order — a row a host can see, chase, or expire.

Activation runs the other way. **`confirm_tournament_order` is granted to nobody.** An angler who could call it would never need to pay: skip the paying, call the confirming. So there is no client path to it, it runs from the service role, and until a payment webhook exists an entry stays `PENDING` after a test-mode payment. The checkout says exactly that instead of claiming an entry the server has not confirmed — the worst lie this app could tell somebody standing on a dock at 5am.

## How it was checked

- **58 migrations apply cleanly** to real Postgres 16, and **28 database behaviour checks pass** — one boat per event, one entry per angler, the crew on every entry, the pot empty until somebody pays, a replayed webhook not doubling the pot, a passed deadline closing entries while the status still says open, two hosts refused, the captain's phone required, an underpayment letting nobody in.
- `npm run verify` clean — 955 tests across 92 files. 8 lint warnings, all pre-existing. `npm run build` clean.
- Walked in a browser at 390px against the production build: crew of two, two events, a jackpot, paid, and both events appear in My Tournaments as entered. No console errors.

## Still open

- **The payment webhook** that calls `confirm_tournament_order` is the missing piece, and it needs a server.
- Host admin is still not built; live catches are still device-local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NvrbeVyuL4CQXbpPMijvnv

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvrbeVyuL4CQXbpPMijvnv)_