### PR TITLE
Payment webhook — and two security holes the review found in my own SQL

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -4,3 +4,24 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=YOUR-ANON-PUBLIC-KEY
 
 # Skip the sign-in redirect in `next dev` only — see docs/development/dev-auth-bypass.md. Never set this in a deployed environment.
 # DEV_AUTH_BYPASS=true
+
+# ---------------------------------------------------------------------------
+# Taking tournament entry fees. Every one of these is absent by default, and the
+# payment webhook refuses every request until they are all set — which is the
+# correct state for a deployment that has not been through Stripe onboarding and
+# the legal work that holding other people's entry fees requires (ADR 010 §3).
+# ---------------------------------------------------------------------------
+
+# Stripe → Developers → Webhooks → your endpoint → Signing secret.
+# This is the ONLY thing standing between the internet and a function that turns a
+# pending registration into a paid one. Treat it like a password.
+# STRIPE_WEBHOOK_SECRET=whsec_...
+
+# Supabase → Project Settings → API → service_role key.
+# Bypasses row-level security entirely. Server-side only: it must never appear in a
+# NEXT_PUBLIC_ variable, in client code, or in a browser bundle.
+# SUPABASE_SERVICE_ROLE_KEY=...
+
+# Set to "true" only on a deployment wired to a LIVE Stripe account. Left unset, the
+# webhook rejects live payments, so a staging endpoint cannot quietly swallow a real one.
+# STRIPE_LIVE_MODE=false

--- a/docs/team/worklog/2026-09-07-05-head-dev.md
+++ b/docs/team/worklog/2026-09-07-05-head-dev.md
@@ -1,0 +1,41 @@
+### 2026-09-07 | head-dev | 2h
+
+The payment webhook — the piece that turns a payment into a confirmed entry. It is the only
+route in the app that can do that, and `confirm_tournament_order` is granted to nobody
+precisely so that it is the only door.
+
+- **Signature verification is written out properly**, not assumed: real HMAC-SHA256 over
+  `timestamp.rawBody`, a timing-safe comparison, a five-minute replay window checked in both
+  directions, and support for several signatures at once because secrets get rotated. 17
+  tests, each one a way somebody gets into a $400 tournament for nothing if it is wrong.
+- **The raw body is read before anything touches it.** Parsing and re-serialising changes
+  the bytes the signature was computed over. There is a test that tampers with a signed body
+  and expects a 400.
+- **Found a contract that would have silently failed:** the Stripe provider set
+  `metadata.order_id` and the webhook read `metadata.tournament_order_id`. Every real payment
+  would have arrived unattributable, and nothing would have caught it. One exported constant
+  now, used by both ends, pinned by a test.
+
+**Then I ran the security review over my own work and it found two real holes.** Both were
+in the SQL I wrote earlier today:
+
+- **Anyone holding a tournament's id could self-register into a PRIVATE or INVITE_ONLY
+  event.** The function checked that registration was open and never checked visibility, and
+  row-level security cannot help — a `security definer` function runs with the owner's
+  rights, so RLS never gets a say. An id is not a secret: it is in a URL somebody was sent,
+  in a former entrant's history, in a screenshot.
+- **A payment's currency was never compared to the order's.** 75000 minor units is $750, and
+  also a good deal less in several other currencies, so a payment in a cheap one satisfied
+  the amount check numerically and bought a dollar entry.
+
+Both are fixed, and both have tests I proved by deleting the fix and watching them fail.
+
+Checked: 58 migrations apply cleanly and 30 database behaviour checks pass against real
+Postgres 16; `npm run verify` clean with 997 tests; `npm run build` clean.
+
+- Files: src/lib/payments/stripe-signature.ts (+test), src/lib/supabase/service-role.ts,
+  src/core/tournaments/webhook-intent.ts (+test), src/app/api/payments/stripe/webhook/,
+  src/core/tournaments/payments.ts, .env.local.example, supabase/migrations/2026090716*.
+- Next: nothing here can take a real payment — it needs Stripe keys, Connect onboarding for
+  hosts, and the legal work on money transmission and state contest law. Host admin is still
+  not built; live catches are still device-local.

--- a/src/app/api/payments/stripe/webhook/route.test.ts
+++ b/src/app/api/payments/stripe/webhook/route.test.ts
@@ -1,0 +1,175 @@
+import { createHmac } from "node:crypto";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ORDER_METADATA_KEY } from "@/core/tournaments/payments";
+
+/**
+ * The webhook endpoint, exercised as a request rather than as a function.
+ *
+ * It is the only route in the app that can turn a pending registration into a paid one, so
+ * the cases below are the ways somebody gets in for free if it is wrong, plus the ways a
+ * real payment gets silently lost if it is wrong in the other direction.
+ *
+ * The Supabase client is mocked because the point here is the handler's decisions, not the
+ * database function — that has its own tests, run against a real Postgres by
+ * `npm run db:check`.
+ */
+
+const SECRET = "whsec_test_only";
+const rpc = vi.fn();
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({ rpc }),
+}));
+
+function sign(body: string, timestamp = Math.floor(Date.now() / 1000)): string {
+  const digest = createHmac("sha256", SECRET).update(`${timestamp}.${body}`, "utf8").digest("hex");
+  return `t=${timestamp},v1=${digest}`;
+}
+
+function event(over: Record<string, unknown> = {}, object: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    id: "evt_1",
+    type: "payment_intent.succeeded",
+    livemode: false,
+    data: {
+      object: {
+        id: "pi_1",
+        amount_received: 75000,
+        currency: "usd",
+        metadata: { [ORDER_METADATA_KEY]: "11111111-1111-1111-1111-111111111111" },
+        ...object,
+      },
+    },
+    ...over,
+  });
+}
+
+function post(body: string, signature?: string | null): Request {
+  return new Request("https://example.test/api/payments/stripe/webhook", {
+    method: "POST",
+    headers: signature === null ? {} : { "stripe-signature": signature ?? sign(body) },
+    body,
+  });
+}
+
+async function handler() {
+  return (await import("./route")).POST;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  rpc.mockReset();
+  rpc.mockResolvedValue({ error: null });
+  process.env.STRIPE_WEBHOOK_SECRET = SECRET;
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-key";
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://project.supabase.co";
+  delete process.env.STRIPE_LIVE_MODE;
+});
+
+afterEach(() => {
+  delete process.env.STRIPE_WEBHOOK_SECRET;
+  delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+});
+
+describe("the payment webhook", () => {
+  it("confirms the order a correctly signed payment names", async () => {
+    const body = event();
+    const response = await (await handler())(post(body));
+    expect(response.status).toBe(200);
+    expect(rpc).toHaveBeenCalledWith("confirm_tournament_order", {
+      target_order_id: "11111111-1111-1111-1111-111111111111",
+      provider_name: "stripe",
+      provider_reference: "pi_1",
+      paid_amount_minor: 75000,
+      paid_currency: "usd",
+    });
+  });
+
+  it("confirms nothing when the signature is wrong", async () => {
+    const response = await (await handler())(post(event(), "t=1,v1=" + "0".repeat(64)));
+    expect(response.status).toBe(400);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("confirms nothing when there is no signature at all", async () => {
+    const response = await (await handler())(post(event(), null));
+    expect(response.status).toBe(400);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("confirms nothing when the body was changed after signing", async () => {
+    // The classic bug this guards: an endpoint that re-serialises before verifying.
+    const body = event();
+    const signature = sign(body);
+    const tampered = body.replace("75000", "1");
+    const response = await (await handler())(post(tampered, signature));
+    expect(response.status).toBe(400);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("confirms nothing when a signature is replayed hours later", async () => {
+    const body = event();
+    const old = sign(body, Math.floor(Date.now() / 1000) - 3600);
+    const response = await (await handler())(post(body, old));
+    expect(response.status).toBe(400);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("refuses to take payments at all when nothing is configured", async () => {
+    // The default state of this repository, and the correct behaviour for it.
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+    const response = await (await handler())(post(event()));
+    expect(response.status).toBe(503);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("refuses when the service role key is missing, even with a good signature", async () => {
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    expect((await (await handler())(post(event()))).status).toBe(503);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("acknowledges an event it does not act on, so Stripe stops retrying", async () => {
+    const body = event({ type: "customer.created" });
+    const response = await (await handler())(post(body));
+    expect(response.status).toBe(200);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("refuses a live payment arriving at a test deployment", async () => {
+    const body = event({ livemode: true });
+    const response = await (await handler())(post(body));
+    expect(response.status).toBe(422);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("refuses a succeeded payment that names no order", async () => {
+    const body = event({}, { metadata: {} });
+    expect((await (await handler())(post(body))).status).toBe(422);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("refuses a succeeded payment with no currency, rather than assuming dollars", async () => {
+    // An amount without a currency is a number, not a price. The database compares the two,
+    // so guessing here would defeat that check before it ran.
+    const body = event({}, { currency: undefined });
+    expect((await (await handler())(post(body))).status).toBe(422);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("asks Stripe to retry when the database call fails", async () => {
+    // 500 rather than 200: the confirm function is idempotent, so a retry is safe, and a
+    // real problem surfaces in the Stripe dashboard instead of being swallowed.
+    rpc.mockResolvedValue({ error: { message: "order not found" } });
+    const response = await (await handler())(post(event()));
+    expect(response.status).toBe(500);
+  });
+
+  it("does not answer a GET with anything useful", async () => {
+    const { GET } = await import("./route");
+    expect(GET().status).toBe(405);
+  });
+});

--- a/src/app/api/payments/stripe/webhook/route.ts
+++ b/src/app/api/payments/stripe/webhook/route.ts
@@ -1,0 +1,130 @@
+import { stripeEventFacts, webhookIntent } from "@/core/tournaments/webhook-intent";
+import { verifyStripeWebhook } from "@/core/tournaments/stripe-provider";
+import { createStripeWebhookVerifier } from "@/lib/payments/stripe-signature";
+import { confirmTournamentOrder, paymentsConfigured } from "@/lib/supabase/service-role";
+
+/**
+ * The one route that may turn a pending registration into a paid one.
+ *
+ * Everything else in this app registers people; nothing else confirms them.
+ * `confirm_tournament_order` is granted to no client role precisely so that this endpoint
+ * is the only door, and the door is guarded by a signature the caller cannot forge.
+ *
+ * The order of operations here is the security, and it is deliberate:
+ *
+ *   1. read the RAW body — never `request.json()`, because parsing and re-serialising
+ *      changes the bytes the signature was computed over, and the check would fail for
+ *      every legitimate request while a hand-crafted one might still slip through a
+ *      looser comparison;
+ *   2. verify the signature, which also enforces a five-minute replay window;
+ *   3. only then parse, and only then decide;
+ *   4. call the database with the service role, which is the only credential that can
+ *      confirm an order, and which never leaves the server.
+ *
+ * Nothing is configured by default. Without `STRIPE_WEBHOOK_SECRET` and
+ * `SUPABASE_SERVICE_ROLE_KEY` this route refuses every request, which is the correct
+ * behaviour for a deployment that has not been through Stripe onboarding and the legal work
+ * that taking entry fees requires (ADR 010 §3).
+ */
+
+/** A webhook is a request, never a build artifact — this must not be prerendered. */
+export const dynamic = "force-dynamic";
+
+/** `node:crypto` for the HMAC, so this is the Node runtime rather than the edge. */
+export const runtime = "nodejs";
+
+export async function POST(request: Request): Promise<Response> {
+  const secret = process.env.STRIPE_WEBHOOK_SECRET;
+
+  if (!paymentsConfigured() || !secret) {
+    /*
+      503, not 500: nothing is broken, this deployment simply does not take payments. The
+      message says which half is missing without naming a value, because a webhook endpoint
+      is a public URL and its error bodies are readable by anybody who probes it.
+    */
+    return Response.json(
+      { error: "payments are not configured on this deployment" },
+      { status: 503 },
+    );
+  }
+
+  // Raw bytes, before anything else touches them. See step 1 above.
+  const rawBody = await request.text();
+  const signature = request.headers.get("stripe-signature");
+
+  let verified;
+  try {
+    verified = verifyStripeWebhook(
+      createStripeWebhookVerifier({ secret }),
+      rawBody,
+      signature,
+    );
+  } catch {
+    // Deliberately not echoing the reason. A caller probing this endpoint learns only that
+    // the signature was wrong, not which part of it was wrong.
+    return Response.json({ error: "invalid signature" }, { status: 400 });
+  }
+
+  const parsed = stripeEventFacts(JSON.parse(rawBody));
+  if (!parsed) {
+    return Response.json({ error: "unrecognised event" }, { status: 400 });
+  }
+
+  /*
+    The verifier is the authority on what the event IS — its id, its type, and whether it is
+    live — because those are the fields it checked a signature over and normalised. The
+    parse supplies the payment details it does not carry: the amount and the order the
+    payment names. Taking identity from the verified struct rather than re-deriving it means
+    there is one answer to "was this live", not two that could drift.
+  */
+  const intent = webhookIntent({
+    ...parsed,
+    id: verified.id,
+    type: verified.type,
+    livemode: verified.livemode,
+  }, {
+    // A deployment is live when it says so. Defaulting to test means a misconfigured
+    // production endpoint rejects real payments loudly rather than confirming them quietly.
+    expectLivemode: process.env.STRIPE_LIVE_MODE === "true",
+  });
+
+  if (intent.kind === "ignore") {
+    // 200 so Stripe stops retrying something we understand and do not act on.
+    return Response.json({ received: true, ignored: intent.reason });
+  }
+
+  if (intent.kind === "reject") {
+    return Response.json({ error: intent.reason }, { status: 422 });
+  }
+
+  const confirmed = await confirmTournamentOrder({
+    orderId: intent.orderId,
+    provider: "stripe",
+    providerPaymentId: intent.paymentId,
+    amountMinor: intent.amountMinor,
+    currency: intent.currency,
+  });
+
+  if (!confirmed.ok) {
+    /*
+      500 so Stripe retries. The function is idempotent on the provider payment id, so a
+      retry after a partial failure is safe, and a genuine problem — an order that does not
+      exist, an amount below the total — shows up repeatedly in the Stripe dashboard where
+      somebody will see it, rather than being swallowed by a 200.
+    */
+    return Response.json(
+      { error: confirmed.reason === "failed" ? confirmed.message : confirmed.reason },
+      { status: 500 },
+    );
+  }
+
+  return Response.json({ received: true, confirmed: intent.orderId });
+}
+
+/**
+ * Anything that is not a POST. Stripe only ever POSTs; a GET here is a person or a scanner,
+ * and answering it with the shape of the endpoint helps neither.
+ */
+export function GET(): Response {
+  return Response.json({ error: "method not allowed" }, { status: 405 });
+}

--- a/src/core/tournaments/payments.ts
+++ b/src/core/tournaments/payments.ts
@@ -8,6 +8,21 @@ export type PaymentStatus =
   | "PARTIALLY_REFUNDED"
   | "REFUNDED";
 
+/**
+ * The metadata key that carries our order id on a provider's payment object.
+ *
+ * Exported and shared because the two ends of this contract are written months apart and
+ * in different languages: `StripePaymentProvider` sets it when a payment is created, and
+ * the webhook route reads it back to decide which order was paid. When they were written
+ * separately they disagreed — the provider sent `order_id` and the webhook looked for
+ * `tournament_order_id` — which is not a bug any type or test would have caught, and would
+ * have meant every real payment arriving unattributable.
+ *
+ * `tournament_order_id` rather than `order_id`: a Stripe account may carry orders from more
+ * than one system, and a dashboard reader deserves to know whose this is.
+ */
+export const ORDER_METADATA_KEY = "tournament_order_id";
+
 export interface PaymentRequest {
   orderId: string;
   amountMinor: number;

--- a/src/core/tournaments/stripe-provider.test.ts
+++ b/src/core/tournaments/stripe-provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { ORDER_METADATA_KEY } from "./payments";
 
 import {
   StripePaymentProvider,
@@ -40,7 +41,9 @@ describe("StripePaymentProvider", () => {
       amount: 5000,
       currency: "usd",
       idempotencyKey: "idem-1",
-      metadata: expect.objectContaining({ order_id: "o1" }),
+      // The key the webhook reads back. Pinned to the shared constant so the two ends
+      // of the contract cannot drift apart again — they already did once.
+      metadata: expect.objectContaining({ [ORDER_METADATA_KEY]: "o1" }),
     }));
   });
 

--- a/src/core/tournaments/stripe-provider.ts
+++ b/src/core/tournaments/stripe-provider.ts
@@ -1,4 +1,4 @@
-import type { PaymentProvider, PaymentRequest, PaymentResult, RefundRequest, RefundResult } from "./payments";
+import { ORDER_METADATA_KEY, type PaymentProvider, type PaymentRequest, type PaymentResult, type RefundRequest, type RefundResult } from "./payments";
 
 export interface StripePaymentIntentLike {
   id: string;
@@ -68,7 +68,7 @@ export class StripePaymentProvider implements PaymentProvider {
       amount: request.amountMinor,
       currency: request.currency.toLowerCase(),
       idempotencyKey: request.idempotencyKey,
-      metadata: { order_id: request.orderId, ...(request.metadata ?? {}) },
+      metadata: { [ORDER_METADATA_KEY]: request.orderId, ...(request.metadata ?? {}) },
       connectedAccountId: this.options.connectedAccountId,
       applicationFeeAmount: this.options.applicationFeeAmount?.(request),
     });

--- a/src/core/tournaments/webhook-intent.test.ts
+++ b/src/core/tournaments/webhook-intent.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import { stripeEventFacts, webhookIntent } from "./webhook-intent";
+
+const TEST_ENV = { expectLivemode: false };
+
+function facts(over: Partial<Parameters<typeof webhookIntent>[0]> = {}) {
+  return {
+    id: "evt_1",
+    type: "payment_intent.succeeded",
+    livemode: false,
+    objectId: "pi_1",
+    amountMinor: 75000,
+    currency: "usd",
+    orderId: "11111111-1111-1111-1111-111111111111",
+    ...over,
+  };
+}
+
+describe("webhookIntent", () => {
+  it("confirms a succeeded payment that names its order", () => {
+    expect(webhookIntent(facts(), TEST_ENV)).toEqual({
+      kind: "confirm",
+      orderId: "11111111-1111-1111-1111-111111111111",
+      paymentId: "pi_1",
+      amountMinor: 75000,
+      currency: "usd",
+    });
+  });
+
+  it("acknowledges events it does not act on, so Stripe stops retrying", () => {
+    // A 500 on an event we simply do not handle makes Stripe retry it for days.
+    expect(webhookIntent(facts({ type: "customer.created" }), TEST_ENV).kind).toBe("ignore");
+    expect(webhookIntent(facts({ type: "payment_intent.created" }), TEST_ENV).kind).toBe("ignore");
+  });
+
+  it("refuses a live payment at a test endpoint, rather than dropping it", () => {
+    // This is a wiring mistake somebody must fix. A silent 200 would let a real payment be
+    // swallowed by a staging deployment.
+    const intent = webhookIntent(facts({ livemode: true }), TEST_ENV);
+    expect(intent.kind).toBe("reject");
+    expect(intent.kind === "reject" && intent.reason).toMatch(/live payment/);
+  });
+
+  it("refuses a test payment at a live endpoint", () => {
+    expect(webhookIntent(facts({ livemode: false }), { expectLivemode: true }).kind).toBe("reject");
+  });
+
+  it("refuses a succeeded payment with no order on it — that is unattributed money", () => {
+    const intent = webhookIntent(facts({ orderId: undefined }), TEST_ENV);
+    expect(intent.kind).toBe("reject");
+  });
+
+  it("refuses a succeeded payment with no amount, rather than confirming for zero", () => {
+    for (const amountMinor of [undefined, Number.NaN, -1]) {
+      expect(webhookIntent(facts({ amountMinor }), TEST_ENV).kind).toBe("reject");
+    }
+  });
+
+  it("refuses a succeeded payment with no payment id — it could not be made idempotent", () => {
+    expect(webhookIntent(facts({ objectId: undefined }), TEST_ENV).kind).toBe("reject");
+  });
+
+  it("refuses a succeeded payment with no currency", () => {
+    // 75000 minor units is $750 and also far less in several other currencies. Comparing
+    // the amount without the currency is how a cheap payment buys a dollar entry.
+    expect(webhookIntent(facts({ currency: undefined }), TEST_ENV).kind).toBe("reject");
+  });
+});
+
+describe("stripeEventFacts", () => {
+  it("reads a payment intent the way Stripe sends one", () => {
+    const parsed = stripeEventFacts({
+      id: "evt_9",
+      type: "payment_intent.succeeded",
+      livemode: false,
+      data: {
+        object: {
+          id: "pi_9",
+          amount: 80000,
+          amount_received: 75000,
+          currency: "usd",
+          metadata: { tournament_order_id: "order-9" },
+        },
+      },
+    });
+    // The captured amount, not the requested one: those differ on a partial capture, and
+    // only what was actually taken may activate a registration.
+    expect(parsed?.amountMinor).toBe(75000);
+    expect(parsed?.orderId).toBe("order-9");
+    expect(parsed?.objectId).toBe("pi_9");
+  });
+
+  it("falls back to `amount` when nothing was captured separately", () => {
+    const parsed = stripeEventFacts({
+      id: "evt_10",
+      type: "charge.succeeded",
+      data: { object: { id: "ch_10", amount: 25000, metadata: { tournament_order_id: "o" } } },
+    });
+    expect(parsed?.amountMinor).toBe(25000);
+  });
+
+  it("survives a shape it has never seen without throwing", () => {
+    expect(stripeEventFacts({ id: "evt", type: "x" })?.orderId).toBeUndefined();
+    expect(stripeEventFacts({ id: "evt", type: "x", data: {} })?.amountMinor).toBeUndefined();
+    expect(stripeEventFacts(null)).toBeNull();
+    expect(stripeEventFacts("nope")).toBeNull();
+    expect(stripeEventFacts({ type: "x" })).toBeNull();
+  });
+
+  it("treats a missing livemode as not live", () => {
+    expect(stripeEventFacts({ id: "e", type: "t" })?.livemode).toBe(false);
+  });
+});

--- a/src/core/tournaments/webhook-intent.ts
+++ b/src/core/tournaments/webhook-intent.ts
@@ -1,0 +1,129 @@
+import { ORDER_METADATA_KEY } from "./payments";
+
+/**
+ * What a verified Stripe event means for an order — decided here, away from the network.
+ *
+ * The route handler's job is to verify a signature and then do what this says. Keeping the
+ * decision pure means the interesting cases — an event for an order we do not know, a
+ * livemode event arriving at a test deployment, a type we do not handle — are testable
+ * without a webhook, a database, or a running server.
+ */
+
+export interface StripeEventFacts {
+  readonly id: string;
+  readonly type: string;
+  readonly livemode: boolean;
+  /** `data.object.id` — the payment intent, for the events we care about. */
+  readonly objectId?: string;
+  /** `data.object.amount_received` (or `amount`), in minor units. */
+  readonly amountMinor?: number;
+  /** `data.object.currency`. Checked against the order's — see `confirm_tournament_order`. */
+  readonly currency?: string;
+  /** Our order id, which we set as metadata when the payment was created. */
+  readonly orderId?: string;
+}
+
+export type WebhookIntent =
+  | {
+      readonly kind: "confirm";
+      readonly orderId: string;
+      readonly paymentId: string;
+      readonly amountMinor: number;
+      readonly currency: string;
+    }
+  /** Understood, and nothing to do. Answered 200 so the provider stops retrying. */
+  | { readonly kind: "ignore"; readonly reason: string }
+  /** Something is wrong enough that the provider should retry or a human should look. */
+  | { readonly kind: "reject"; readonly reason: string };
+
+/** The only event that activates a registration. Others are acknowledged and dropped. */
+const CONFIRMING_TYPES = new Set(["payment_intent.succeeded", "charge.succeeded"]);
+
+export function webhookIntent(
+  event: StripeEventFacts,
+  environment: { readonly expectLivemode: boolean },
+): WebhookIntent {
+  /*
+    A live event arriving at a test deployment (or the reverse) means the endpoint is wired
+    to the wrong Stripe account or the wrong environment. Rejecting rather than ignoring is
+    deliberate: this is a misconfiguration somebody has to fix, and a silent 200 would let a
+    production payment be quietly dropped by a staging server.
+  */
+  if (event.livemode !== environment.expectLivemode) {
+    return {
+      kind: "reject",
+      reason: event.livemode
+        ? "a live payment reached an endpoint configured for test mode"
+        : "a test payment reached an endpoint configured for live mode",
+    };
+  }
+
+  if (!CONFIRMING_TYPES.has(event.type)) {
+    return { kind: "ignore", reason: `nothing to do for ${event.type}` };
+  }
+
+  if (!event.orderId) {
+    /*
+      A succeeded payment with no order on it is money we cannot attribute. Rejecting makes
+      the provider retry and puts it in a failure log where somebody will see it; ignoring
+      would lose it silently, and it is somebody's entry fee.
+    */
+    return { kind: "reject", reason: "a succeeded payment carried no order reference" };
+  }
+
+  if (!event.objectId) {
+    return { kind: "reject", reason: "a succeeded payment carried no payment id" };
+  }
+
+  if (typeof event.amountMinor !== "number" || !Number.isFinite(event.amountMinor) || event.amountMinor < 0) {
+    return { kind: "reject", reason: "a succeeded payment carried no readable amount" };
+  }
+
+  if (!event.currency) {
+    // An amount without a currency is a number, not a price. Refusing sends it back for a
+    // retry and puts it in front of a person, rather than guessing USD.
+    return { kind: "reject", reason: "a succeeded payment carried no currency" };
+  }
+
+  return {
+    kind: "confirm",
+    orderId: event.orderId,
+    paymentId: event.objectId,
+    amountMinor: event.amountMinor,
+    currency: event.currency,
+  };
+}
+
+/**
+ * Pulls the facts out of a Stripe event body that has already been signature-verified.
+ *
+ * Defensive about shape rather than trusting it: this is JSON from the network, and while
+ * the signature proves it came from Stripe, it does not prove the shape is what this
+ * version of the code expects.
+ */
+export function stripeEventFacts(payload: unknown): StripeEventFacts | null {
+  if (typeof payload !== "object" || payload === null) return null;
+  const event = payload as Record<string, unknown>;
+  if (typeof event.id !== "string" || typeof event.type !== "string") return null;
+
+  const data = event.data as { object?: Record<string, unknown> } | undefined;
+  const object = data?.object ?? {};
+  const metadata = (object.metadata as Record<string, unknown> | undefined) ?? {};
+
+  // `amount_received` is the amount actually captured; `amount` is what was requested. The
+  // captured one is the one that may activate a registration.
+  const amountRaw = object.amount_received ?? object.amount;
+
+  return {
+    id: event.id,
+    type: event.type,
+    livemode: event.livemode === true,
+    objectId: typeof object.id === "string" ? object.id : undefined,
+    amountMinor: typeof amountRaw === "number" && Number.isFinite(amountRaw) ? amountRaw : undefined,
+    currency: typeof object.currency === "string" && object.currency.length > 0 ? object.currency : undefined,
+    orderId:
+      typeof metadata[ORDER_METADATA_KEY] === "string"
+        ? (metadata[ORDER_METADATA_KEY] as string)
+        : undefined,
+  };
+}

--- a/src/lib/payments/stripe-signature.test.ts
+++ b/src/lib/payments/stripe-signature.test.ts
@@ -1,0 +1,177 @@
+import { createHmac } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  StripeSignatureError,
+  createStripeWebhookVerifier,
+  parseSignatureHeader,
+  verifySignature,
+} from "./stripe-signature";
+
+/**
+ * This is the only thing between the internet and a function that turns a pending
+ * registration into a paid one. Every one of these tests is a way somebody gets into a
+ * $400 tournament for nothing if the check is wrong in the permissive direction.
+ */
+
+const SECRET = "whsec_test_do_not_use_anywhere_real";
+const NOW = 1_788_000_000;
+
+function sign(body: string, timestamp = NOW, secret = SECRET): string {
+  const digest = createHmac("sha256", secret).update(`${timestamp}.${body}`, "utf8").digest("hex");
+  return `t=${timestamp},v1=${digest}`;
+}
+
+const BODY = JSON.stringify({
+  id: "evt_1",
+  type: "payment_intent.succeeded",
+  livemode: false,
+  data: { object: { id: "pi_1", amount: 75000, currency: "usd" } },
+});
+
+describe("verifySignature", () => {
+  it("accepts a signature Stripe would have produced", () => {
+    expect(() =>
+      verifySignature({ rawBody: BODY, header: sign(BODY), secret: SECRET, nowSeconds: NOW }),
+    ).not.toThrow();
+  });
+
+  it("rejects a body that changed by one byte", () => {
+    const header = sign(BODY);
+    expect(() =>
+      verifySignature({ rawBody: BODY + " ", header, secret: SECRET, nowSeconds: NOW }),
+    ).toThrow(StripeSignatureError);
+  });
+
+  it("rejects a signature made with a different secret", () => {
+    const header = sign(BODY, NOW, "whsec_someone_elses");
+    expect(() =>
+      verifySignature({ rawBody: BODY, header, secret: SECRET, nowSeconds: NOW }),
+    ).toThrow(StripeSignatureError);
+  });
+
+  it("rejects a replay from outside the tolerance window", () => {
+    // A captured, genuinely-signed request must stop working. Without this check it is
+    // valid forever, and one intercepted webhook confirms an order whenever its holder likes.
+    const header = sign(BODY, NOW - 3600);
+    expect(() =>
+      verifySignature({ rawBody: BODY, header, secret: SECRET, nowSeconds: NOW }),
+    ).toThrow(/timestamp-outside-tolerance/);
+  });
+
+  it("rejects a timestamp far in the future, not just an old one", () => {
+    // A one-sided check is defeated by simply claiming a later time.
+    const header = sign(BODY, NOW + 3600);
+    expect(() =>
+      verifySignature({ rawBody: BODY, header, secret: SECRET, nowSeconds: NOW }),
+    ).toThrow(/timestamp-outside-tolerance/);
+  });
+
+  it("accepts inside the window on either side", () => {
+    for (const skew of [-299, -1, 0, 1, 299]) {
+      expect(() =>
+        verifySignature({
+          rawBody: BODY,
+          header: sign(BODY, NOW + skew),
+          secret: SECRET,
+          nowSeconds: NOW,
+        }),
+      ).not.toThrow();
+    }
+  });
+
+  it("accepts when any one of several v1 signatures matches — secrets get rotated", () => {
+    const good = sign(BODY).split("v1=")[1];
+    const header = `t=${NOW},v1=${"0".repeat(64)},v1=${good}`;
+    expect(() =>
+      verifySignature({ rawBody: BODY, header, secret: SECRET, nowSeconds: NOW }),
+    ).not.toThrow();
+  });
+
+  it("rejects a header with no signature in it at all", () => {
+    expect(() =>
+      verifySignature({ rawBody: BODY, header: `t=${NOW}`, secret: SECRET, nowSeconds: NOW }),
+    ).toThrow(/no-signatures/);
+  });
+
+  it("rejects a header with no timestamp", () => {
+    expect(() =>
+      verifySignature({ rawBody: BODY, header: "v1=abcdef", secret: SECRET, nowSeconds: NOW }),
+    ).toThrow(/malformed-header/);
+  });
+
+  it("rejects a digest of the wrong length rather than crashing on it", () => {
+    // Buffer.from(...,'hex') silently truncates bad input, so length is checked first.
+    for (const bogus of ["v1=ab", "v1=" + "f".repeat(63), "v1=zz"]) {
+      expect(() =>
+        verifySignature({
+          rawBody: BODY,
+          header: `t=${NOW},${bogus}`,
+          secret: SECRET,
+          nowSeconds: NOW,
+        }),
+      ).toThrow(StripeSignatureError);
+    }
+  });
+
+  it("is not fooled by the signature appearing as a substring", () => {
+    const good = sign(BODY).split("v1=")[1];
+    expect(() =>
+      verifySignature({
+        rawBody: BODY,
+        header: `t=${NOW},v1=${good.slice(0, 60)}`,
+        secret: SECRET,
+        nowSeconds: NOW,
+      }),
+    ).toThrow(StripeSignatureError);
+  });
+});
+
+describe("parseSignatureHeader", () => {
+  it("ignores schemes it does not know, like v0", () => {
+    const good = sign(BODY).split("v1=")[1];
+    const parsed = parseSignatureHeader(`t=${NOW},v0=deadbeef,v1=${good}`);
+    expect(parsed.signatures).toEqual([good]);
+    expect(parsed.timestamp).toBe(NOW);
+  });
+
+  it("refuses a fractional or negative timestamp", () => {
+    expect(() => parseSignatureHeader("t=1.5,v1=abcdef")).toThrow(/malformed-header/);
+    expect(() => parseSignatureHeader("t=-1,v1=abcdef")).toThrow(/malformed-header/);
+  });
+});
+
+describe("createStripeWebhookVerifier", () => {
+  it("returns the event only after the signature has been checked", () => {
+    const verifier = createStripeWebhookVerifier({ secret: SECRET, now: () => NOW * 1000 });
+    const event = verifier.verify(BODY, sign(BODY));
+    expect(event).toEqual({
+      id: "evt_1",
+      type: "payment_intent.succeeded",
+      livemode: false,
+      objectId: "pi_1",
+    });
+  });
+
+  it("does not parse an unverified body", () => {
+    // The body is untrusted input until the signature passes. A parse error here would mean
+    // JSON.parse ran on it first.
+    const verifier = createStripeWebhookVerifier({ secret: SECRET, now: () => NOW * 1000 });
+    expect(() => verifier.verify("this is not json", `t=${NOW},v1=${"a".repeat(64)}`)).toThrow(
+      StripeSignatureError,
+    );
+  });
+
+  it("refuses a verified body that is not a Stripe event", () => {
+    const body = JSON.stringify({ hello: "world" });
+    const verifier = createStripeWebhookVerifier({ secret: SECRET, now: () => NOW * 1000 });
+    expect(() => verifier.verify(body, sign(body))).toThrow(/missing an id or a type/);
+  });
+
+  it("reports livemode honestly, so a test event cannot pass for a real one", () => {
+    const body = JSON.stringify({ id: "evt_2", type: "payment_intent.succeeded", livemode: true });
+    const verifier = createStripeWebhookVerifier({ secret: SECRET, now: () => NOW * 1000 });
+    expect(verifier.verify(body, sign(body)).livemode).toBe(true);
+  });
+});

--- a/src/lib/payments/stripe-signature.ts
+++ b/src/lib/payments/stripe-signature.ts
@@ -1,0 +1,151 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+import type { StripeWebhookVerifier, VerifiedStripeWebhook } from "@/core/tournaments/stripe-provider";
+
+/**
+ * Checking that a webhook really came from Stripe.
+ *
+ * This is the only thing standing between the internet and `confirm_tournament_order`,
+ * which turns a pending registration into a paid one. Anybody can POST to a public URL. If
+ * this function is wrong in the permissive direction, entry to every tournament in the app
+ * is free to whoever notices — so it is written out in full, with the failure modes named,
+ * rather than assumed.
+ *
+ * Stripe's scheme, for the reader who has not met it: the `Stripe-Signature` header is a
+ * comma-separated list of `key=value` pairs — one `t` (a unix timestamp) and one or more
+ * `v1` (hex HMAC-SHA256 digests). The signed payload is literally `${t}.${rawBody}`, and
+ * the key is the endpoint's signing secret.
+ *
+ * Three properties this has to get right, each of which is a real attack if missed:
+ *
+ * - **The raw body, byte for byte.** `JSON.parse` then `JSON.stringify` produces different
+ *   bytes — key order, whitespace, number formatting — and the digest will not match. The
+ *   route handler must pass `await request.text()`, never a parsed object.
+ * - **Timing-safe comparison.** A `===` on digests leaks, through response time, how many
+ *   leading bytes were right, which is enough to forge one byte at a time.
+ * - **A timestamp tolerance.** Without it a valid request captured once can be replayed
+ *   forever. Five minutes is Stripe's own recommendation.
+ */
+
+/** Stripe's recommended replay window. */
+export const DEFAULT_TOLERANCE_SECONDS = 300;
+
+export type SignatureFailure =
+  | "malformed-header"
+  | "no-signatures"
+  | "timestamp-outside-tolerance"
+  | "no-matching-signature";
+
+export class StripeSignatureError extends Error {
+  constructor(readonly reason: SignatureFailure) {
+    super(`stripe signature rejected: ${reason}`);
+    this.name = "StripeSignatureError";
+  }
+}
+
+interface ParsedHeader {
+  readonly timestamp: number;
+  readonly signatures: readonly string[];
+}
+
+/** Splits `t=...,v1=...,v1=...` without trusting anything about its shape. */
+export function parseSignatureHeader(header: string): ParsedHeader {
+  let timestamp: number | null = null;
+  const signatures: string[] = [];
+
+  for (const part of header.split(",")) {
+    const index = part.indexOf("=");
+    if (index <= 0) continue;
+    const key = part.slice(0, index).trim();
+    const value = part.slice(index + 1).trim();
+    if (key === "t") {
+      const parsed = Number(value);
+      // A non-numeric or fractional `t` is malformed, not "close enough".
+      if (Number.isInteger(parsed) && parsed > 0) timestamp = parsed;
+    } else if (key === "v1" && /^[0-9a-f]+$/i.test(value)) {
+      // Stripe sends several v1 entries while a secret is being rotated; any may match.
+      signatures.push(value.toLowerCase());
+    }
+  }
+
+  if (timestamp === null) throw new StripeSignatureError("malformed-header");
+  if (signatures.length === 0) throw new StripeSignatureError("no-signatures");
+  return { timestamp, signatures };
+}
+
+/** Constant-time hex digest comparison. Length mismatch short-circuits, which is safe. */
+function digestsMatch(expected: string, candidate: string): boolean {
+  if (expected.length !== candidate.length) return false;
+  return timingSafeEqual(Buffer.from(expected, "hex"), Buffer.from(candidate, "hex"));
+}
+
+export function verifySignature(input: {
+  readonly rawBody: string;
+  readonly header: string;
+  readonly secret: string;
+  readonly nowSeconds: number;
+  readonly toleranceSeconds?: number;
+}): void {
+  const { timestamp, signatures } = parseSignatureHeader(input.header);
+  const tolerance = input.toleranceSeconds ?? DEFAULT_TOLERANCE_SECONDS;
+
+  // Absolute difference: a timestamp far in the FUTURE is as suspicious as an old one, and
+  // a one-sided check is trivially defeated by a clock claim.
+  if (Math.abs(input.nowSeconds - timestamp) > tolerance) {
+    throw new StripeSignatureError("timestamp-outside-tolerance");
+  }
+
+  const expected = createHmac("sha256", input.secret)
+    .update(`${timestamp}.${input.rawBody}`, "utf8")
+    .digest("hex");
+
+  // Every candidate is compared, without an early return on the first match, so the time
+  // taken does not reveal which one matched.
+  let matched = false;
+  for (const candidate of signatures) {
+    if (digestsMatch(expected, candidate)) matched = true;
+  }
+  if (!matched) throw new StripeSignatureError("no-matching-signature");
+}
+
+/**
+ * The `StripeWebhookVerifier` the core payment code expects, backed by real crypto.
+ *
+ * Parsing happens only after the signature is verified — the body is untrusted input until
+ * that moment, and it is worth being able to say so from the shape of the code.
+ */
+export function createStripeWebhookVerifier(options: {
+  readonly secret: string;
+  readonly now?: () => number;
+  readonly toleranceSeconds?: number;
+}): StripeWebhookVerifier {
+  return {
+    verify(rawBody: string, signatureHeader: string): VerifiedStripeWebhook {
+      verifySignature({
+        rawBody,
+        header: signatureHeader,
+        secret: options.secret,
+        nowSeconds: Math.floor((options.now?.() ?? Date.now()) / 1000),
+        toleranceSeconds: options.toleranceSeconds,
+      });
+
+      const event = JSON.parse(rawBody) as {
+        id?: unknown;
+        type?: unknown;
+        livemode?: unknown;
+        data?: { object?: { id?: unknown } };
+      };
+
+      if (typeof event.id !== "string" || typeof event.type !== "string") {
+        throw new Error("stripe event is missing an id or a type");
+      }
+
+      return {
+        id: event.id,
+        type: event.type,
+        livemode: event.livemode === true,
+        objectId: typeof event.data?.object?.id === "string" ? event.data.object.id : undefined,
+      };
+    },
+  };
+}

--- a/src/lib/supabase/service-role.ts
+++ b/src/lib/supabase/service-role.ts
@@ -1,0 +1,85 @@
+import { createClient } from "@supabase/supabase-js";
+
+/**
+ * The service-role credential, and the one thing it is allowed to do.
+ *
+ * The service role bypasses row-level security entirely. It is the most dangerous
+ * credential this system has, so it is deliberately NOT exposed as a client that callers
+ * can do anything with — this module exports one narrow function, and the only caller is
+ * the payment webhook.
+ *
+ * That shape is the point. A `createServiceRoleClient()` export would be reused within a
+ * month by something that only needed to read one row, and the blast radius of a mistake in
+ * that caller would be every table in the database. A function that can confirm exactly one
+ * order and return nothing else cannot be repurposed by accident.
+ *
+ * It lives in `src/lib/supabase/` because that is where network clients live (ADR 005 §3)
+ * and because route files are forbidden from importing Supabase directly — a rule this file
+ * exists to satisfy rather than to work around. The linter caught the first version of the
+ * webhook doing exactly that.
+ *
+ * **Server only, and it fails closed rather than leaking.** `SUPABASE_SERVICE_ROLE_KEY` has
+ * no `NEXT_PUBLIC_` prefix, so Next never inlines it into a client bundle: importing this
+ * module from a client component would leave the key `undefined`, `confirmTournamentOrder`
+ * would return `not-configured`, and nothing would be sent. The `server-only` package would
+ * turn that runtime failure into a build error, which is better; it is not a dependency of
+ * this project today, and adding one to a payments branch is not the place to start.
+ */
+
+export type ConfirmResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: "not-configured" }
+  | { readonly ok: false; readonly reason: "failed"; readonly message: string };
+
+export interface ConfirmOrderInput {
+  readonly orderId: string;
+  readonly provider: string;
+  readonly providerPaymentId: string;
+  readonly amountMinor: number;
+  /**
+   * The currency the payment was actually taken in.
+   *
+   * Required, and checked against the order's own currency by the database function.
+   * Comparing amounts without it is meaningless: 75000 minor units is $750 and also a good
+   * deal less in several other currencies, so a payment in a cheaper one would satisfy the
+   * amount check numerically.
+   */
+  readonly currency: string;
+}
+
+/**
+ * Activates the entries on a paid order, via `confirm_tournament_order`.
+ *
+ * The database function is idempotent on `(provider, provider_payment_id)`, so calling this
+ * twice for the same payment is safe — which matters, because a payment provider will
+ * deliver the same webhook more than once.
+ */
+export async function confirmTournamentOrder(input: ConfirmOrderInput): Promise<ConfirmResult> {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceRoleKey) return { ok: false, reason: "not-configured" };
+
+  const supabase = createClient(url, serviceRoleKey, {
+    // No session, no refresh: this is a machine calling once, not a signed-in person.
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const { error } = await supabase.rpc("confirm_tournament_order", {
+    target_order_id: input.orderId,
+    provider_name: input.provider,
+    provider_reference: input.providerPaymentId,
+    paid_amount_minor: input.amountMinor,
+    paid_currency: input.currency,
+  });
+
+  return error ? { ok: false, reason: "failed", message: error.message } : { ok: true };
+}
+
+/** Whether this deployment is configured to confirm payments at all. */
+export function paymentsConfigured(): boolean {
+  return Boolean(
+    process.env.NEXT_PUBLIC_SUPABASE_URL &&
+      process.env.SUPABASE_SERVICE_ROLE_KEY &&
+      process.env.STRIPE_WEBHOOK_SECRET,
+  );
+}

--- a/supabase/migrations/20260907160000_crew_registration_rpc.sql
+++ b/supabase/migrations/20260907160000_crew_registration_rpc.sql
@@ -139,6 +139,24 @@ begin
     if target.status <> 'REGISTRATION_OPEN' then
       raise exception 'registration is not open for %', target.name using errcode = 'check_violation';
     end if;
+
+    /*
+      Only an event that is offering itself publicly may be self-registered into.
+
+      Without this, holding a tournament's id was enough to enter a PRIVATE or INVITE_ONLY
+      event — the id is not a secret in any useful sense (it is in a URL somebody was sent,
+      in a former entrant's history, in a screenshot), and "invite only" would have meant
+      nothing. Row-level security does not cover it either: this is a `security definer`
+      function, so it runs with the owner's rights and RLS never gets a say. The check has
+      to be here, explicitly.
+
+      Private and invite-only events are still filled — by the organiser, through the
+      admin path that `tournament_entry`'s OWNER/ADMIN/STAFF policy already guards.
+    */
+    if target.visibility not in ('PUBLIC', 'UNLISTED') then
+      raise exception 'this event is not open to self-registration'
+        using errcode = '42501';
+    end if;
     -- The deadline is enforced by the clock, not by whoever last set the status column.
     if target.registration_closes_at is not null and target.registration_closes_at <= now() then
       raise exception 'entries have closed for %', target.name using errcode = 'check_violation';

--- a/supabase/migrations/20260907161000_confirm_tournament_order.sql
+++ b/supabase/migrations/20260907161000_confirm_tournament_order.sql
@@ -21,7 +21,8 @@ create or replace function public.confirm_tournament_order(
   target_order_id uuid,
   provider_name text,
   provider_reference text,
-  paid_amount_minor bigint
+  paid_amount_minor bigint,
+  paid_currency text
 )
 returns uuid
 language plpgsql
@@ -57,6 +58,18 @@ begin
   end if;
 
   /*
+    The currency, before the amount — because comparing amounts across currencies is
+    meaningless and dangerous. 75000 minor units is $750, and it is also about £590, ¥490 and
+    a great deal less in several other currencies. Without this check a payment made in a
+    cheaper currency satisfies `paid_amount_minor >= total_minor` numerically and buys a
+    $750 entry for a fraction of it.
+  */
+  if upper(coalesce(paid_currency, '')) <> upper(target.currency) then
+    raise exception 'payment currency % does not match the order currency %',
+      paid_currency, target.currency using errcode = 'check_violation';
+  end if;
+
+  /*
     Refuse to activate an order for less than it costs. A provider that reports a smaller
     amount than the bill is either a partial payment or a mismatched reference, and both are
     reasons to stop rather than to let somebody into a $400 tournament for $4.
@@ -71,7 +84,7 @@ begin
     currency, amount_minor, status, confirmed_at
   ) values (
     target.organization_id, target.id, provider_name, provider_reference,
-    target.currency, paid_amount_minor, 'CONFIRMED', now()
+    upper(paid_currency), paid_amount_minor, 'CONFIRMED', now()
   ) returning id into new_payment_id;
 
   update public.tournament_order
@@ -148,9 +161,9 @@ $$;
   can call it without one; spelling out the revoke keeps the intent visible to the next
   person to read this file.
 */
-revoke all on function public.confirm_tournament_order(uuid, text, text, bigint) from public;
-revoke all on function public.confirm_tournament_order(uuid, text, text, bigint) from anon;
-revoke all on function public.confirm_tournament_order(uuid, text, text, bigint) from authenticated;
+revoke all on function public.confirm_tournament_order(uuid, text, text, bigint, text) from public;
+revoke all on function public.confirm_tournament_order(uuid, text, text, bigint, text) from anon;
+revoke all on function public.confirm_tournament_order(uuid, text, text, bigint, text) from authenticated;
 
-comment on function public.confirm_tournament_order(uuid, text, text, bigint) is
+comment on function public.confirm_tournament_order(uuid, text, text, bigint, text) is
   'Activates the entries on a paid order. Service role only — an angler who could call this would never need to pay.';

--- a/supabase/test/rpc-behaviour.sql
+++ b/supabase/test/rpc-behaviour.sql
@@ -50,7 +50,14 @@ values
    '22222222-2222-2222-2222-222222222222'),
   ('88888888-8888-8888-8888-888888888888', '44444444-4444-4444-4444-444444444444',
    'Another Host Event', 'PUBLIC', 'REGISTRATION_OPEN', 'USD', 5000, now() + interval '3 days',
-   '22222222-2222-2222-2222-222222222222');
+   '22222222-2222-2222-2222-222222222222'),
+  -- Open for entries, but not to the public. Holding its id must not be enough.
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '33333333-3333-3333-3333-333333333333',
+   'Invite Only Shootout', 'INVITE_ONLY', 'REGISTRATION_OPEN', 'USD', 20000,
+   now() + interval '4 days', '22222222-2222-2222-2222-222222222222'),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', '33333333-3333-3333-3333-333333333333',
+   'Private Crew Day', 'PRIVATE', 'REGISTRATION_OPEN', 'USD', 20000,
+   now() + interval '4 days', '22222222-2222-2222-2222-222222222222');
 
 insert into public.prize_pool (id, organization_id, tournament_id, name, currency, pool_type)
 values ('99999999-9999-9999-9999-999999999999', '33333333-3333-3333-3333-333333333333',
@@ -139,7 +146,20 @@ begin
   perform pg_temp.check('and creates no further entries', n = 4);
 
   -- ------------------------------------------------------------ confirming
-  perform public.confirm_tournament_order(oid_, 'stripe', 'pi_test_1', 75000);
+  /*
+    75000 minor units is $750, and also a good deal less in several other currencies. A
+    payment made in a cheaper one satisfies the amount check numerically, so the currency is
+    compared first.
+  */
+  declare wrong_currency boolean := false;
+  begin
+    begin
+      perform public.confirm_tournament_order(oid_, 'stripe', 'pi_wrong_ccy', 75000, 'JPY');
+    exception when others then wrong_currency := true; end;
+    perform pg_temp.check('a payment in another currency does not buy a dollar entry', wrong_currency);
+  end;
+
+  perform public.confirm_tournament_order(oid_, 'stripe', 'pi_test_1', 75000, 'USD');
 
   perform pg_temp.check('paying confirms the whole crew, not just the captain',
     (select count(*) from public.tournament_entry where registration_status = 'CONFIRMED') = 4);
@@ -160,7 +180,7 @@ begin
       where prize_pool_id = '99999999-9999-9999-9999-999999999999') = 1);
 
   -- A provider will deliver the same webhook twice. It must not double the pot.
-  perform public.confirm_tournament_order(oid_, 'stripe', 'pi_test_1', 75000);
+  perform public.confirm_tournament_order(oid_, 'stripe', 'pi_test_1', 75000, 'usd');
   perform pg_temp.check('a replayed webhook does not double the pot',
     (select funded_amount_minor from public.prize_pool
       where id = '99999999-9999-9999-9999-999999999999') = 10000);
@@ -214,6 +234,34 @@ begin
       '[{"display_name":"A","phone":"9495550113","is_captain":true}]'::jsonb, 'k5');
   exception when others then failed := true; end;
   perform pg_temp.check('entering the same event twice is refused', failed);
+
+  /*
+    An invite-only or private event is not something a stranger may walk into by knowing
+    its id — and an id is not a secret in any useful sense: it is in a URL somebody was
+    sent, in a former entrant's history, in a screenshot. Row-level security cannot help
+    here, because a `security definer` function runs with the owner's rights and RLS never
+    gets a say, so the check has to be explicit in the function.
+  */
+  failed := false;
+  begin
+    perform public.register_crew_for_tournaments(
+      '[{"tournament_id":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb","division_ids":[]}]'::jsonb,
+      '[{"display_name":"A","phone":"9495550113","is_captain":true}]'::jsonb, 'k7');
+  exception when others then failed := true; end;
+  perform pg_temp.check('an invite-only event cannot be self-registered into', failed);
+
+  failed := false;
+  begin
+    perform public.register_crew_for_tournaments(
+      '[{"tournament_id":"cccccccc-cccc-cccc-cccc-cccccccccccc","division_ids":[]}]'::jsonb,
+      '[{"display_name":"A","phone":"9495550113","is_captain":true}]'::jsonb, 'k8');
+  exception when others then failed := true; end;
+  perform pg_temp.check('a private event cannot be self-registered into', failed);
+
+  perform pg_temp.check('and neither created an entry',
+    not exists (select 1 from public.tournament_entry
+                 where tournament_id in ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+                                         'cccccccc-cccc-cccc-cccc-cccccccccccc')));
 end $$;
 
 -- ---------------------------------------------------------------- underpayment
@@ -228,7 +276,7 @@ begin
     '[{"tournament_id":"66666666-6666-6666-6666-666666666666","division_ids":[]}]'::jsonb,
     '[{"display_name":"Host","phone":"9495550199","is_captain":true}]'::jsonb, 'key-underpay');
   begin
-    perform public.confirm_tournament_order(oid_, 'stripe', 'pi_short', 100);
+    perform public.confirm_tournament_order(oid_, 'stripe', 'pi_short', 100, 'USD');
   exception when others then failed := true; end;
   perform pg_temp.check('a payment smaller than the bill does not let anybody in', failed);
 


### PR DESCRIPTION
#130 is merged, so this now targets `main` directly.

This is the piece that turns a payment into a confirmed entry. It is the only route that can: `confirm_tournament_order` is granted to no client role, because an angler who could call it would never need to pay.

## The verification is the security, so it's written out

Real HMAC-SHA256 over `timestamp.rawBody`, **timing-safe** comparison, a five-minute replay window checked **in both directions** (a one-sided check is defeated by claiming a later time), and several candidate signatures accepted because secrets get rotated. 17 tests, each one a way somebody gets into a $400 tournament for nothing if this is wrong.

**The raw body is read before anything touches it.** Parsing and re-serialising changes the bytes the signature was computed over — there's a test that tampers with a signed body and expects a 400.

## A contract that would have failed silently

The Stripe provider set `metadata.order_id`. The webhook read `metadata.tournament_order_id`. **Every real payment would have arrived unattributable**, and no type, test or lint rule would have said a word — it's the two-character drift this repo's CI workflow was created for. There's one exported constant now, used by both ends and pinned by a test.

## Then I ran the security review over my own work, and it found two real holes

Both in SQL I wrote earlier today. Both fixed. Both have database tests I proved by **deleting the fix and watching them fail**.

### 1. Self-registration ignored visibility — HIGH

`register_crew_for_tournaments` checked that registration was *open* and never checked *who it was open to*. Anyone holding a tournament's id could enter a `PRIVATE` or `INVITE_ONLY` event.

Row-level security cannot help here: a `security definer` function runs with the owner's rights, so RLS never gets a say. The check has to be explicit in the function, and now is.

And an id is not a secret in any useful sense — it's in a URL somebody was sent, in a former entrant's history, in a screenshot. "Invite only" would have meant nothing.

```
not ok an invite-only event cannot be self-registered into   ← with the fix removed
```

### 2. The amount was compared without regard to currency — MEDIUM

`confirm_tournament_order` checked `paid_amount_minor >= total_minor` and never compared currencies. **75000 minor units is $750 — and also a good deal less in several other currencies.** A payment in a cheap one satisfies the check numerically and buys a dollar entry.

Currency is now checked *before* the amount, threaded end to end (event → intent → service role → function), and a payment with no currency at all is refused rather than assumed to be dollars.

```
not ok a payment in another currency does not buy a dollar entry   ← with the fix removed
```

## Nothing here can take a real payment

No key is configured, and the route returns **503** until `STRIPE_WEBHOOK_SECRET` and `SUPABASE_SERVICE_ROLE_KEY` are both set — the correct state for a deployment that has not been through Stripe onboarding and the legal work that holding entry fees requires. `.env.local.example` documents all three variables and what each one is capable of.

The service role bypasses RLS entirely, so it is not exposed as a client: `lib/supabase/service-role.ts` exports **one narrow function** that can confirm exactly one order and return nothing else. A general `createServiceRoleClient()` would be reused within a month by something that only needed to read a row, and the blast radius of a mistake there is every table in the database.

(The repo's own lint rule caught my first draft importing Supabase directly into a route file. That rule was right, and obeying it made the security better.)

## How it was checked

- **58 migrations apply cleanly and 30 database behaviour checks pass** against real Postgres 16 (`npm run db:check`).
- `npm run verify` clean — **997 tests across 95 files**. 8 lint warnings, all pre-existing. `npm run build` clean; the route builds as `ƒ /api/payments/stripe/webhook`.
- 29 new tests on this branch: signature forgery, tampering, replay, rotation, unconfigured deployment, live-event-at-test-endpoint, unattributed payment, missing currency, database failure → 500 so Stripe retries.

## Still open

Going live is Stripe keys, Connect onboarding for hosts, and the legal work on money transmission and state contest law — not a code change. Host admin is still not built; live catches are still device-local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NvrbeVyuL4CQXbpPMijvnv