### PR TITLE
Host admin — and the role that was in the database doing nothing

### DIFF
--- a/docs/architecture/decisions/011-host-roles.md
+++ b/docs/architecture/decisions/011-host-roles.md
@@ -1,0 +1,90 @@
+# 011 — Host roles: what a treasurer may see
+
+**Date:** 2026-09-07 · **Status:** accepted
+**Answers:** the founder's tournament brief (2026-09-06) — "there will also be a host admin
+page, so if you're a host you have upgraded permissions" — and the follow-up instruction to
+harden the section before production.
+**Depends on:** `010-tournament-checkout-and-payment-methods.md` (the order and payment
+tables these roles govern), `005-front-end-architecture.md` §3 (directory contract).
+**Supersedes:** nothing.
+
+## Context
+
+`organization_member.role` has allowed four values since the first tournament migration:
+`OWNER`, `ADMIN`, `STAFF`, `FINANCE`. Row-level security across twenty-odd tables names the
+first three. It names `FINANCE` nowhere.
+
+The consequence is worth stating plainly, because it inverts the intent of the role. A club
+that granted `FINANCE` to its treasurer gave that person strictly *less* than event staff:
+no order, no payment, no refund, no payout instruction, no prize pool, no financial event.
+The only way to let somebody handle the money was to make them an `ADMIN` — which also
+grants the rules, the scoring, the boundaries, the roster and the power to cancel the
+event. The separation of duty that `FINANCE` exists to express could not be expressed.
+
+Meanwhile `/tournaments/[id]/operations` asked nobody's permission at all. It rendered the
+host heading, the lifecycle controls, the judging queue and the money panel to any visitor
+who knew the address. RLS meant the panels came back empty rather than full, so this was
+never a data leak; it was a screen telling a stranger they were the host of an event,
+with a "Cancel the tournament" control on it. The money panel was worse than empty — it
+printed *"Nothing has been taken and nothing is owed"* as a constant, a sentence that would
+have survived the first real entry fee and looked exactly like a quiet tournament.
+
+## Decision
+
+**1. Four roles, and the money is one of them.**
+
+| | Owner | Administrator | Event staff | Treasurer |
+|---|---|---|---|---|
+| Open the host screen | ✓ | ✓ | ✓ | ✓ |
+| Change rules, scoring, boundaries, event state | ✓ | ✓ | | |
+| Read and change the roster | ✓ | ✓ | ✓ | |
+| Judge catches, penalties, disputes | ✓ | ✓ | ✓ | |
+| Read the ledger and the prize pool | ✓ | ✓ | | ✓ |
+| Approve a payout | ✓ | ✓ | | ✓ |
+| Add or re-role the host team | ✓ | ✓ | | |
+
+`FINANCE` is added to every money-read policy. It is *not* added to judging, to the roster,
+or to the event's settings, because a treasurer who could disqualify a boat is not a
+separation of duty, it is an administrator with a different name.
+
+**2. Event staff come off the order tables.** This is a reduction and it is deliberate.
+Staff run the dock; whether a boat has paid is `tournament_entry.registration_status`, not
+the ledger. Nothing in the application read `tournament_order` as staff, so the change
+removes an unused capability rather than a working screen. An entrant's read of their own
+order is untouched — it hangs off `purchaser_angler_id = auth.uid()`, not off a role.
+
+**3. The screen asks the server who you are, through one function.**
+`my_tournament_host_role(uuid)` returns the caller's own active role or null.
+
+It exists rather than a client-side join because a non-member's `select` on `tournament`
+returns no rows, making "you are not a host" and "no such tournament" indistinguishable —
+the screen would have to guess between sending somebody to the public page and telling them
+the event does not exist. Being `security definer` it states its own authorization, and it
+states the narrowest possible one: the only row it can reach is the caller's own
+membership. It is granted to `anon` as well as `authenticated`, because a signed-out
+visitor's `auth.uid()` is null, the join cannot match, and null is the correct answer —
+without the grant they would meet a permission error where they should meet a way back.
+
+**4. The capability table lives in the core and is checked against the SQL.**
+`src/core/tournaments/host-role.ts` is the single answer to "may I", and
+`host-role.sql.test.ts` reads the migrations and fails if the two ever disagree. Two
+statements of one rule, written in two languages a week apart, drift — and drift here is
+either a treasurer shown a button that errors or, worse, a lane hidden from somebody the
+database would have admitted.
+
+**5. The client check is presentation, never enforcement.** The server decides what a
+request may touch; this decides what a person is shown. A lane hidden by
+`hostCapabilities` is a courtesy, not a control, and no rule may ever be enforced only
+there.
+
+## Consequences
+
+- A treasurer can do the job the role was named for, without being handed the tournament.
+- A stranger on a host URL gets a sentence and two links rather than a locked room.
+- The money panel reads `tournament_order` and, when it cannot, says so rather than
+  showing a zero. A zero and "not allowed to look" must never render the same.
+- Adding somebody to a host team is still not possible from the app: it needs an invitation
+  with an email and an expiring token, and none of that half exists. The screen says so
+  instead of offering a button that would appear to grant an administrator and would not.
+- The event-state controls remain visible and disabled, per ADR 010's line that activation
+  is a server-side act. Roles do not change that.

--- a/docs/team/worklog/2026-09-07-05-head-dev.md
+++ b/docs/team/worklog/2026-09-07-05-head-dev.md
@@ -1,0 +1,53 @@
+### 2026-09-07 | head-dev | 2h
+
+- The host screen showed "Host controls" — including the judging queue and the money
+  panel — to anybody who typed the address. The database kept the actual data empty for a
+  stranger, so nothing leaked; what leaked was the impression of being the host, on a page
+  with a "Cancel the tournament" button on it. It now asks who you are first, and somebody
+  who is not on the host team gets a plain sentence and a link back to the event.
+
+- Found a real hole while doing it. The four host roles — owner, administrator, event
+  staff, treasurer — have existed since the first tournament migration. Three of them are
+  used. **Treasurer was used by nothing at all**: searching the whole database for the word
+  outside the list of allowed values returned no results. So handing somebody the treasurer
+  role gave them *less* than event staff — they could not see a single order, payment or
+  refund — and the only way to let a person handle the money was to make them an
+  administrator, which also hands over the rules, the scoring and the power to cancel the
+  event. That is now fixed: the treasurer sees the money and nothing else.
+
+- Event staff no longer see the ledger. That is on purpose. Their job is the dock, and
+  whether a boat has paid shows on the boat, not in the accounts. Nothing in the app read
+  the ledger as staff, so nothing broke.
+
+- The screen and the database now have to agree about all of this, or a test fails and
+  names the exact rule that has drifted. I checked that by deliberately breaking it and
+  watching fourteen tests go red.
+
+- The money panel used to say "Nothing has been taken and nothing is owed" as a fixed
+  sentence. The first real entry fee would have left that on the screen and nobody would
+  have noticed, because it looks like a quiet tournament. It reads the real figures now,
+  and if it cannot read them it says so rather than showing a zero.
+
+- Added a "who's entered" list for hosts: boats, crews, who the captain is, and a phone
+  number you can tap to call. Boats with something outstanding sort to the top. That list
+  is the one thing a host needs at 4am when weather cancels an event.
+
+- Found and fixed a flaw in our own database test harness along the way: the signed-in
+  test roles were never given permission to use the sign-in function, so any test of "who
+  can see what" would have read zero rows for the wrong reason and reported a pass.
+
+- Files: src/core/tournaments/host-role.ts, src/core/tournaments/host-role.test.ts,
+  src/core/tournaments/host-role.sql.test.ts,
+  src/features/tournaments/queries/use-host-role.ts,
+  src/features/tournaments/queries/use-roster.ts,
+  src/features/tournaments/queries/use-tournament-money.ts,
+  src/features/tournaments/components/tournament-operations.tsx,
+  supabase/migrations/20260907170000_host_roles.sql, supabase/test/rpc-behaviour.sql,
+  supabase/test/supabase-shim.sql, docs/architecture/decisions/011-host-roles.md
+
+- Next, and still honestly missing: nobody can be *added* to a host team from the app yet —
+  that needs an invitation with an email and an expiring token behind it, and the screen
+  says so rather than showing a button that does nothing. The event-state buttons (open
+  entries, start fishing, cancel) are still shown and disabled for the same reason: that
+  half is the server's decision and is not built. And none of this has been tried on a
+  real phone.

--- a/src/core/tournaments/host-role.sql.test.ts
+++ b/src/core/tournaments/host-role.sql.test.ts
@@ -1,0 +1,155 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  HOST_ROLES,
+  HOST_ROLE_LABEL,
+  HOST_ROLE_SUMMARY,
+  hostCapabilities,
+  type HostCapabilities,
+  type HostRole,
+} from "./host-role";
+
+/**
+ * The screen's capability table and the database's policies are two statements of the same
+ * rule, written a week apart in two languages, and nothing but this file stops them
+ * drifting. Drift here is not a crash: it is a treasurer who is shown a "Approve a payout"
+ * button that errors, or worse, a lane hidden from somebody the database would have let in.
+ *
+ * So the roles are read out of the migration text and compared to the table. If a later
+ * migration adds FINANCE to judging, or drops STAFF from the roster, the test names the
+ * policy and the capability that no longer agree.
+ */
+
+const migrationsDir = fileURLToPath(new URL("../../../supabase/migrations/", import.meta.url));
+
+const sqlByFile = new Map<string, string>(
+  readdirSync(migrationsDir)
+    .filter((name) => name.endsWith(".sql"))
+    .map((name) => [name, readFileSync(`${migrationsDir}${name}`, "utf8")]),
+);
+
+/** The whole migration corpus, newest last — policies are replaced, so later wins. */
+const allSql = [...sqlByFile.keys()].sort().map((name) => sqlByFile.get(name) ?? "");
+
+/**
+ * The last `array[...]` role list attached to a named policy, across every migration in
+ * order. Later files replace earlier ones, which is how the host-roles migration takes
+ * effect, so reading the last occurrence is reading the live rule.
+ */
+function rolesForPolicy(policyName: string): readonly string[] | null {
+  let found: readonly string[] | null = null;
+
+  for (const sql of allSql) {
+    const pattern = new RegExp(
+      `create policy ${policyName}\\b[\\s\\S]*?(?=\\ncreate policy |\\ndrop policy |\\ncreate trigger |\\ncomment on |$)`,
+      "gi",
+    );
+    for (const block of sql.match(pattern) ?? []) {
+      const arrays = [...block.matchAll(/array\[([^\]]*)\]/gi)];
+      if (arrays.length === 0) continue;
+      // Every role array inside one policy must agree, or the policy is saying two
+      // different things about who may act and the "expected" below is meaningless.
+      const parsed = arrays.map((match) =>
+        match[1]
+          .split(",")
+          .map((role) => role.trim().replace(/^'|'$/g, ""))
+          .sort()
+          .join(","),
+      );
+      expect(new Set(parsed).size, `${policyName} names conflicting role sets`).toBe(1);
+      found = parsed[0].split(",");
+    }
+  }
+
+  return found;
+}
+
+function rolesWith(capability: keyof HostCapabilities): readonly string[] {
+  return HOST_ROLES.filter((role) => hostCapabilities(role)[capability]);
+}
+
+/** Policy → the capability in `host-role.ts` that must name exactly the same roles. */
+const PARITY: ReadonlyArray<{ policy: string; capability: keyof HostCapabilities }> = [
+  // Money, in every table the ledger is spread across.
+  { policy: "tournament_order_owner_read", capability: "readMoney" },
+  { policy: "tournament_order_owner_write", capability: "readMoney" },
+  { policy: "tournament_order_item_read", capability: "readMoney" },
+  { policy: "tournament_order_item_insert", capability: "readMoney" },
+  { policy: "financial_org_read", capability: "readMoney" },
+  { policy: "payment_attempt_read", capability: "readMoney" },
+  { policy: "payment_allocation_read", capability: "readMoney" },
+  { policy: "payment_refund_read", capability: "readMoney" },
+  { policy: "platform_fee_admin_read", capability: "readMoney" },
+  { policy: "financial_event_admin_read", capability: "readMoney" },
+  { policy: "payout_instruction_finance_read", capability: "readMoney" },
+  { policy: "payout_finance_read", capability: "readMoney" },
+  { policy: "payout_event_finance_read", capability: "readMoney" },
+  // Approving a payout is deliberately the same set as reading the money, and
+  // deliberately not the same as running the event.
+  { policy: "payout_instruction_finance_write", capability: "approvePayout" },
+  // The roster.
+  { policy: "tournament_entry_admin_write", capability: "writeRoster" },
+  { policy: "tournament_team_org_write", capability: "writeRoster" },
+  { policy: "tournament_boat_org_write", capability: "writeRoster" },
+  // The event itself.
+  { policy: "organization_member_insert_admin", capability: "manageStaff" },
+  { policy: "organization_member_update_admin", capability: "manageStaff" },
+  { policy: "organization_invitation_insert_admin", capability: "manageStaff" },
+];
+
+describe("host capabilities match the database policies", () => {
+  it.each(PARITY)("$policy names exactly the roles with $capability", ({ policy, capability }) => {
+    const actual = rolesForPolicy(policy);
+    expect(actual, `no role array found for policy ${policy}`).not.toBeNull();
+    expect([...(actual ?? [])].sort()).toEqual([...rolesWith(capability)].sort());
+  });
+
+  it("knows every role the check constraint allows", () => {
+    const foundation = sqlByFile.get("20260905183000_tournament_organization_foundation.sql") ?? "";
+    const constraint = /organization_member[\s\S]*?role text not null check \(role in \(([^)]*)\)\)/.exec(
+      foundation,
+    );
+    expect(constraint, "organization_member.role check constraint not found").not.toBeNull();
+
+    const allowed = (constraint?.[1] ?? "")
+      .split(",")
+      .map((role) => role.trim().replace(/^'|'$/g, ""))
+      .sort();
+
+    expect(allowed).toEqual([...HOST_ROLES].sort());
+  });
+
+  it("gives every role a name and a summary a person could read", () => {
+    for (const role of HOST_ROLES) {
+      expect(HOST_ROLE_LABEL[role].length).toBeGreaterThan(0);
+      expect(HOST_ROLE_SUMMARY[role].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("grants FINANCE the money, which no policy did before this release", () => {
+    // The regression this whole file exists to prevent coming back. FINANCE was in the
+    // check constraint from the first migration and named by no policy at all, so the role
+    // that exists for money could not read a single number.
+    const finance: HostRole = "FINANCE";
+    expect(hostCapabilities(finance).readMoney).toBe(true);
+    expect(rolesForPolicy("financial_org_read")).toContain("FINANCE");
+  });
+
+  it("keeps the money and the fishing in different hands", () => {
+    // A treasurer must not be able to judge a catch or change a rule, and event staff
+    // must not be able to read the ledger. If either of these ever passes trivially,
+    // somebody has widened a role rather than added one.
+    const finance = hostCapabilities("FINANCE");
+    expect(finance.judge).toBe(false);
+    expect(finance.changeEventSettings).toBe(false);
+    expect(finance.writeRoster).toBe(false);
+
+    const staff = hostCapabilities("STAFF");
+    expect(staff.readMoney).toBe(false);
+    expect(staff.approvePayout).toBe(false);
+    expect(staff.changeEventSettings).toBe(false);
+  });
+});

--- a/src/core/tournaments/host-role.test.ts
+++ b/src/core/tournaments/host-role.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  HOST_ROLES,
+  hostCapabilities,
+  isHost,
+  isHostRole,
+  visibleLanes,
+} from "./host-role";
+
+describe("who counts as a host", () => {
+  it("treats no membership as no capabilities at all", () => {
+    const none = hostCapabilities(null);
+    expect(Object.values(none).every((granted) => granted === false)).toBe(true);
+    expect(isHost(null)).toBe(false);
+    expect(visibleLanes(none)).toEqual([]);
+  });
+
+  it("recognises only the four roles the database allows", () => {
+    for (const role of HOST_ROLES) expect(isHostRole(role)).toBe(true);
+    // The shapes a role can arrive in from an RPC that returns `unknown`.
+    for (const notARole of ["owner", "JUDGE", "", null, undefined, 7, {}, ["OWNER"]]) {
+      expect(isHostRole(notARole)).toBe(false);
+    }
+  });
+
+  it("lets every role onto the host screen, and shows each of them different lanes", () => {
+    for (const role of HOST_ROLES) expect(isHost(role)).toBe(true);
+
+    expect(visibleLanes(hostCapabilities("OWNER"))).toEqual([
+      "event",
+      "roster",
+      "judging",
+      "money",
+      "team",
+    ]);
+    expect(visibleLanes(hostCapabilities("ADMIN"))).toEqual([
+      "event",
+      "roster",
+      "judging",
+      "money",
+      "team",
+    ]);
+    // The dock: the field and the fish, and nothing about money or access.
+    expect(visibleLanes(hostCapabilities("STAFF"))).toEqual(["event", "roster", "judging"]);
+    // The treasurer: no empty judging queue to wonder about, and no crew phone numbers.
+    expect(visibleLanes(hostCapabilities("FINANCE"))).toEqual(["event", "money"]);
+  });
+
+  it("never offers a lane the role cannot use", () => {
+    // The screen picks its opening lane from the front of this list. If a lane ever
+    // appeared without its capability, somebody would land on a tab that renders a
+    // permission error the moment its query runs.
+    for (const role of HOST_ROLES) {
+      const caps = hostCapabilities(role);
+      const lanes = visibleLanes(caps);
+      if (lanes.includes("money")) expect(caps.readMoney).toBe(true);
+      if (lanes.includes("roster")) expect(caps.readRoster).toBe(true);
+      if (lanes.includes("judging")) expect(caps.judge).toBe(true);
+      if (lanes.includes("team")) expect(caps.manageStaff).toBe(true);
+      expect(lanes.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps approving a payout narrower than running the event", () => {
+    // Being the organiser, or the judge, is not enough on its own — the sentence the
+    // operations screen has printed since it was written, now enforceable.
+    expect(hostCapabilities("STAFF").approvePayout).toBe(false);
+    expect(hostCapabilities("STAFF").runEvent).toBe(true);
+  });
+});

--- a/src/core/tournaments/host-role.ts
+++ b/src/core/tournaments/host-role.ts
@@ -1,0 +1,173 @@
+/**
+ * What a host may actually do, and who counts as a host.
+ *
+ * The database has had four organisation roles since the first tournament migration —
+ * OWNER, ADMIN, STAFF, FINANCE — and until this file existed, nothing on the screen ever
+ * asked which one you held. `/tournaments/[id]/operations` rendered "Host controls",
+ * the judging queue and the money panel to anybody who typed the URL. Row-level security
+ * meant the *data* behind those panels stayed empty for a stranger, so nothing leaked;
+ * what leaked was the impression that they were the host, which is its own kind of wrong
+ * on a screen with a "Cancel the tournament" button on it.
+ *
+ * The capability table below is the single answer to "may I", and the screen asks it
+ * rather than guessing from a status or a `hosting` flag. It is deliberately a plain
+ * lookup with no I/O: the server decides what a request may touch, and this decides what
+ * a person is shown. Those are different jobs and the second one must never be mistaken
+ * for the first.
+ *
+ * `host-role.sql.test.ts` reads the migrations and fails if the two drift apart.
+ */
+
+/** The organisation roles from `organization_member.role`'s check constraint. */
+export const HOST_ROLES = ["OWNER", "ADMIN", "STAFF", "FINANCE"] as const;
+
+export type HostRole = (typeof HOST_ROLES)[number];
+
+export function isHostRole(value: unknown): value is HostRole {
+  return typeof value === "string" && (HOST_ROLES as readonly string[]).includes(value);
+}
+
+export interface HostCapabilities {
+  /** Sees the host screen at all, rather than being sent back to the public page. */
+  readonly runEvent: boolean;
+  /** Moves the tournament between states, and edits rules, scoring and boundaries. */
+  readonly changeEventSettings: boolean;
+  /** Reads the entrant roster: boats, crews, check-in, entry status. */
+  readonly readRoster: boolean;
+  /** Changes an entry — approving, waitlisting, checking in, withdrawing. */
+  readonly writeRoster: boolean;
+  /** Reviews catches, records penalties, settles disputes. */
+  readonly judge: boolean;
+  /** Reads what has been collected, what is owed, and the prize pool. */
+  readonly readMoney: boolean;
+  /** Approves a payout instruction. Deliberately narrower than reading the money. */
+  readonly approvePayout: boolean;
+  /** Adds, removes or re-roles the people on the host team. */
+  readonly manageStaff: boolean;
+}
+
+const NOBODY: HostCapabilities = {
+  runEvent: false,
+  changeEventSettings: false,
+  readRoster: false,
+  writeRoster: false,
+  judge: false,
+  readMoney: false,
+  approvePayout: false,
+  manageStaff: false,
+};
+
+/*
+  Each row mirrors the role arrays in the RLS policies. Where the SQL says
+  `array['OWNER','ADMIN','STAFF']`, the three of them have the capability and the fourth
+  does not — see the SQL parity test.
+
+  FINANCE is the row this file was written for. It was in the check constraint from day
+  one and named by no policy anywhere, so granting it to a club treasurer gave them
+  strictly less than STAFF: they could not read an order, a payment, or a prize pool. The
+  only way to let somebody handle the money was to make them an ADMIN, which also hands
+  them the rules, the scoring and the power to cancel the event. This release gives
+  FINANCE the money and nothing else, which is the separation the operations screen has
+  been promising in prose since it was written.
+*/
+const CAPABILITIES: Readonly<Record<HostRole, HostCapabilities>> = {
+  OWNER: {
+    runEvent: true,
+    changeEventSettings: true,
+    readRoster: true,
+    writeRoster: true,
+    judge: true,
+    readMoney: true,
+    approvePayout: true,
+    manageStaff: true,
+  },
+  ADMIN: {
+    runEvent: true,
+    changeEventSettings: true,
+    readRoster: true,
+    writeRoster: true,
+    judge: true,
+    readMoney: true,
+    approvePayout: true,
+    manageStaff: true,
+  },
+  // Runs the event on the dock. Sees who is entered and judges the fish; the money is
+  // somebody else's job, and so is who else gets to be staff.
+  STAFF: {
+    runEvent: true,
+    changeEventSettings: false,
+    readRoster: true,
+    writeRoster: true,
+    judge: true,
+    readMoney: false,
+    approvePayout: false,
+    manageStaff: false,
+  },
+  // The treasurer. Reads every number and approves nothing about the fishing: cannot
+  // change a rule, cannot judge a catch, cannot touch an entry. Approving a payout is the
+  // one thing this role does that OWNER and ADMIN also do.
+  FINANCE: {
+    runEvent: true,
+    changeEventSettings: false,
+    readRoster: false,
+    writeRoster: false,
+    judge: false,
+    readMoney: true,
+    approvePayout: true,
+    manageStaff: false,
+  },
+};
+
+/**
+ * Capabilities for a role, or none at all for somebody who holds no active membership.
+ *
+ * `null` is the ordinary case, not an error: most people looking at a tournament are
+ * entrants or spectators.
+ */
+export function hostCapabilities(role: HostRole | null): HostCapabilities {
+  return role === null ? NOBODY : CAPABILITIES[role];
+}
+
+/** True when this role should be offered the host screen at all. */
+export function isHost(role: HostRole | null): boolean {
+  return hostCapabilities(role).runEvent;
+}
+
+/** How the role is named to the person holding it. Not a database value. */
+export const HOST_ROLE_LABEL: Readonly<Record<HostRole, string>> = {
+  OWNER: "Owner",
+  ADMIN: "Administrator",
+  STAFF: "Event staff",
+  FINANCE: "Treasurer",
+};
+
+/** One line explaining the role's limits, shown on the host screen. */
+export const HOST_ROLE_SUMMARY: Readonly<Record<HostRole, string>> = {
+  OWNER: "You can do everything here, including the money and who else gets access.",
+  ADMIN: "You can run the event, judge, and handle the money.",
+  STAFF: "You can run the event and judge. The money is somebody else's job.",
+  FINANCE: "You handle the money. Rules, judging and the roster are somebody else's job.",
+};
+
+export type HostLane = "event" | "roster" | "judging" | "money" | "team";
+
+const LANE_CAPABILITY: Readonly<Record<HostLane, keyof HostCapabilities>> = {
+  event: "runEvent",
+  roster: "readRoster",
+  judging: "judge",
+  money: "readMoney",
+  team: "manageStaff",
+};
+
+const LANE_ORDER: readonly HostLane[] = ["event", "roster", "judging", "money", "team"];
+
+/**
+ * The lanes this role may open, in reading order.
+ *
+ * A treasurer gets "Event" and "Money" and no empty judging queue to wonder about. The
+ * screen picks its opening lane from the front of this list, so nobody lands on a tab
+ * they are not allowed to use.
+ */
+export function visibleLanes(caps: HostCapabilities): readonly HostLane[] {
+  return LANE_ORDER.filter((lane) => caps[LANE_CAPABILITY[lane]]);
+}

--- a/src/features/tournaments/components/tournament-operations.tsx
+++ b/src/features/tournaments/components/tournament-operations.tsx
@@ -5,14 +5,28 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 
 import {
+  HOST_ROLES,
+  HOST_ROLE_LABEL,
+  HOST_ROLE_SUMMARY,
+  hostCapabilities,
+  visibleLanes,
+  type HostCapabilities,
+  type HostLane,
+  type HostRole,
+} from "@/core/tournaments/host-role";
+import {
   canTransitionTournament,
   TOURNAMENT_STATUSES,
   validateTournamentTransition,
   type TournamentStatus,
 } from "@/core/tournaments/lifecycle";
+import { formatMoney } from "../event-card";
 import { isTournamentStatus, tournamentPhase, type Phase } from "../format";
 import { getDemoTournamentCatches, type DemoTournamentCatch } from "../live-catch-demo";
+import { useHostRole } from "../queries/use-host-role";
+import { useRoster, type RosterBoat } from "../queries/use-roster";
 import { useStandings } from "../queries/use-standings";
+import { useTournamentMoney, type TournamentMoney } from "../queries/use-tournament-money";
 import { useDemoMode, useTournament } from "../use-tournament";
 import {
   CARD,
@@ -38,13 +52,13 @@ import {
   TonePill,
 } from "./tournament-chrome";
 
-type Lane = "organizer" | "judge" | "finance";
-
-const LANES: Array<{ value: Lane; label: string }> = [
-  { value: "organizer", label: "Event" },
-  { value: "judge", label: "Judging" },
-  { value: "finance", label: "Money" },
-];
+const LANE_LABEL: Readonly<Record<HostLane, string>> = {
+  event: "Event",
+  roster: "Who's entered",
+  judging: "Judging",
+  money: "Money",
+  team: "Access",
+};
 
 const PHASE_HEADING: Readonly<Record<Phase, string>> = {
   before: "Set the event up and get the field ready.",
@@ -63,38 +77,78 @@ const HOST_FLOW: ReadonlyArray<{
   { phase: "after", number: "3", title: "Settle", detail: "Reviews, final standings, and payouts." },
 ];
 
+/**
+ * The host screen, and who is allowed to see which half of it.
+ *
+ * Before this, the page rendered "Host controls", a judging queue and a money panel to
+ * anybody who typed the URL. Row-level security kept the *data* empty for a stranger, so
+ * nothing leaked — what leaked was the impression of being the host, on a screen with a
+ * "Cancel the tournament" button on it. The role is fetched first now, and a person who
+ * holds none is sent to the public page with a plain sentence rather than a locked room.
+ *
+ * The lanes come from `visibleLanes`, so a treasurer never sees an empty judging queue and
+ * event staff never see the takings. That table is checked against the database's own
+ * policies by `host-role.sql.test.ts` — the screen and the server have to agree, and a
+ * disagreement is a test failure rather than a support call.
+ */
 export function TournamentOperations({
   tournamentId,
-  initialPanel = "organizer",
+  initialPanel,
 }: {
   tournamentId: string;
-  initialPanel?: Lane;
+  initialPanel?: HostLane;
 }) {
   const load = useTournament(tournamentId);
   const demoMode = useDemoMode();
+  const roleLoad = useHostRole(tournamentId);
   const standingsLoad = useStandings(tournamentId);
   const standings = standingsLoad.state === "ready" ? standingsLoad.rows : [];
-  const [lane, setLane] = useState<Lane>(initialPanel);
+
+  /*
+    Demo mode only: look at the screen as each role, so the separation can be checked
+    without four accounts and a club. It is never offered against a real database, where
+    the role is whatever the server says it is and pretending otherwise would show somebody
+    a lane whose first query is going to be refused.
+  */
+  const [previewRole, setPreviewRole] = useState<HostRole | null>(null);
+  const role = demoMode && previewRole !== null ? previewRole : roleLoad.state === "ready" ? roleLoad.role : null;
+  const caps = hostCapabilities(role);
+  const lanes = useMemo(() => visibleLanes(caps), [caps]);
+
+  const [lane, setLane] = useState<HostLane | null>(initialPanel ?? null);
+  // The lane actually rendered: the chosen one while it is still allowed, otherwise the
+  // first this role may open. A treasurer who was on "Judging" as an admin lands on
+  // "Event", not on a blank panel.
+  const activeLane = lane !== null && lanes.includes(lane) ? lane : (lanes[0] ?? null);
+
   const [catches, setCatches] = useState<readonly DemoTournamentCatch[]>([]);
+
+  const rosterLoad = useRoster(tournamentId, caps.readRoster);
+  const moneyLoad = useTournamentMoney(tournamentId, caps.readMoney);
 
   useEffect(() => {
     let cancelled = false;
     void (async () => {
       await Promise.resolve();
       if (cancelled) return;
-      setCatches(getDemoTournamentCatches(tournamentId));
+      setCatches(caps.judge ? getDemoTournamentCatches(tournamentId) : []);
     })();
     return () => {
       cancelled = true;
     };
-  }, [demoMode, tournamentId]);
+  }, [demoMode, tournamentId, caps.judge]);
 
   const flagged = useMemo(() => catches.filter((item) => item.fair_play_messages.length > 0), [catches]);
 
-  if (load.state === "loading") return <LoadingScreen label="Loading organizer tools" />;
+  if (load.state === "loading" || roleLoad.state === "loading") {
+    return <LoadingScreen label="Loading organizer tools" />;
+  }
   if (load.state === "error") return <ErrorScreen message={load.message} />;
+  if (roleLoad.state === "error") return <ErrorScreen message={roleLoad.message} />;
 
   const tournament = load.tournament;
+  if (role === null) return <NotYours tournamentId={tournament.id} />;
+
   const phase = tournamentPhase(tournament.status);
 
   return (
@@ -111,20 +165,24 @@ export function TournamentOperations({
         <p className="text-body text-text-muted">{PHASE_HEADING[phase]}</p>
       </header>
 
-      <HostLifecycle activePhase={phase} />
+      <YourAccess role={role} />
+
+      {demoMode ? <RolePreview selected={previewRole} onSelect={setPreviewRole} /> : null}
+
+      {caps.changeEventSettings ? <HostLifecycle activePhase={phase} /> : null}
 
       <nav aria-label="Host work areas" className="flex flex-col gap-space-2">
         <span className="text-label text-text-primary">Host work areas</span>
         <ul className="flex flex-wrap gap-space-2">
-          {LANES.map((item) => (
-            <li key={item.value}>
+          {lanes.map((item) => (
+            <li key={item}>
               <button
                 type="button"
-                aria-pressed={lane === item.value}
-                onClick={() => setLane(item.value)}
-                className={`${CHIP} ${lane === item.value ? CHIP_ON : CHIP_OFF}`}
+                aria-pressed={activeLane === item}
+                onClick={() => setLane(item)}
+                className={`${CHIP} ${activeLane === item ? CHIP_ON : CHIP_OFF}`}
               >
-                {item.label}
+                {LANE_LABEL[item]}
               </button>
             </li>
           ))}
@@ -134,14 +192,110 @@ export function TournamentOperations({
         </p>
       </nav>
 
-      {lane === "organizer" ? (
-        <OrganizerLane tournament={tournament} phase={phase} catches={catches.length} flagged={flagged.length} standings={standings.length} />
+      {activeLane === "event" ? (
+        <OrganizerLane
+          tournament={tournament}
+          phase={phase}
+          caps={caps}
+          catches={catches.length}
+          flagged={flagged.length}
+          standings={standings.length}
+        />
       ) : null}
-      {lane === "judge" ? <JudgeLane flagged={flagged} /> : null}
-      {lane === "finance" ? <FinanceLane /> : null}
+      {activeLane === "roster" ? <RosterLane load={rosterLoad} /> : null}
+      {activeLane === "judging" ? <JudgeLane flagged={flagged} /> : null}
+      {activeLane === "money" ? <FinanceLane load={moneyLoad} caps={caps} /> : null}
+      {activeLane === "team" ? <AccessLane /> : null}
 
       {demoMode ? <DemoNote /> : null}
     </div>
+  );
+}
+
+/**
+ * What somebody who is not on the host team sees.
+ *
+ * Deliberately not an error and deliberately not a lock screen: most people who land here
+ * followed a link or kept an old bookmark, and the useful thing to hand them is the way
+ * back to the event itself.
+ */
+function NotYours({ tournamentId }: { tournamentId: string }) {
+  return (
+    <div className={PAGE}>
+      <BackLink href={`/tournaments/${tournamentId}/overview`} label="Tournament home" />
+      <EmptyState
+        title="You don't run this tournament"
+        body="These are the host's controls — setting the rules, judging catches, and handling the entry money. If you are entered in this event, everything you need is on the tournament's own pages."
+        action={
+          <div className="flex flex-wrap gap-space-2">
+            <Link href={`/tournaments/${tournamentId}/overview`} className={SECONDARY_BUTTON}>
+              Go to the tournament
+            </Link>
+            <Link href="/tournaments/mine" className={SECONDARY_BUTTON}>
+              My tournaments
+            </Link>
+          </div>
+        }
+      />
+      <p className="text-caption text-text-muted">
+        If you should have access, the person who set the event up can add you to the host team.
+      </p>
+    </div>
+  );
+}
+
+function YourAccess({ role }: { role: HostRole }) {
+  return (
+    <section className={`${INSET} flex flex-col gap-space-1`} aria-label="Your access">
+      <div className="flex flex-wrap items-center gap-space-2">
+        <span className="text-caption text-text-muted">Your access</span>
+        <TonePill tone="open">{HOST_ROLE_LABEL[role]}</TonePill>
+      </div>
+      <p className="text-caption text-text-muted">{HOST_ROLE_SUMMARY[role]}</p>
+    </section>
+  );
+}
+
+function RolePreview({
+  selected,
+  onSelect,
+}: {
+  selected: HostRole | null;
+  onSelect: (role: HostRole | null) => void;
+}) {
+  return (
+    <section className={`${CARD_PADDED} flex flex-col gap-space-2`} aria-label="Preview another role">
+      <SectionHeading>See it as somebody else</SectionHeading>
+      <p className="text-caption text-text-muted">
+        Demo only. Switches which lanes this screen offers, so the separation between running the
+        event and handling the money can be checked without four accounts. Against a real database
+        the role is whatever the server says it is.
+      </p>
+      <ul className="flex flex-wrap gap-space-2">
+        <li>
+          <button
+            type="button"
+            aria-pressed={selected === null}
+            onClick={() => onSelect(null)}
+            className={`${CHIP} ${selected === null ? CHIP_ON : CHIP_OFF}`}
+          >
+            Me
+          </button>
+        </li>
+        {HOST_ROLES.map((role) => (
+          <li key={role}>
+            <button
+              type="button"
+              aria-pressed={selected === role}
+              onClick={() => onSelect(role)}
+              className={`${CHIP} ${selected === role ? CHIP_ON : CHIP_OFF}`}
+            >
+              {HOST_ROLE_LABEL[role]}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
   );
 }
 
@@ -165,7 +319,7 @@ function HostLifecycle({ activePhase }: { activePhase: Phase }) {
               }`}
             >
               <span
-                className={`flex h-space-7 w-space-7 shrink-0 items-center justify-center rounded-full border text-caption ${
+                className={`flex h-space-8 w-space-8 shrink-0 items-center justify-center rounded-full border text-caption ${
                   active
                     ? "border-signal-orange text-signal-orange"
                     : complete
@@ -212,6 +366,7 @@ const HIGH_RISK: ReadonlySet<TournamentStatus> = new Set(["LIVE", "FINAL", "CANC
 function OrganizerLane({
   tournament,
   phase,
+  caps,
   catches,
   flagged,
   standings,
@@ -225,6 +380,7 @@ function OrganizerLane({
     readonly active_boundary_version_id: string | null;
   };
   phase: Phase;
+  caps: HostCapabilities;
   catches: number;
   flagged: number;
   standings: number;
@@ -249,11 +405,13 @@ function OrganizerLane({
     <div className="flex flex-col gap-space-5">
       <section className="grid grid-cols-2 gap-space-3 sm:grid-cols-3" aria-label="Event at a glance">
         <StatTile label="Catches logged" value={String(catches)} />
-        <StatTile label="For a judge" value={String(flagged)} tone={flagged > 0 ? "attention" : "neutral"} />
+        {caps.judge ? (
+          <StatTile label="For a judge" value={String(flagged)} tone={flagged > 0 ? "attention" : "neutral"} />
+        ) : null}
         <StatTile label="On the board" value={String(standings)} />
       </section>
 
-      {phase === "before" ? (
+      {phase === "before" && caps.changeEventSettings ? (
         <section className={`${CARD_PADDED} flex flex-col gap-space-3`}>
           <SectionHeading aside={`${READINESS.filter(([key]) => tournament[key] !== null).length} of 4`}>
             Ready for lines in
@@ -271,44 +429,133 @@ function OrganizerLane({
         </section>
       ) : null}
 
-      <section className={`${CARD_PADDED} flex flex-col gap-space-3`}>
-        <SectionHeading>What happens next</SectionHeading>
-        {moves.length === 0 ? (
-          <p className="text-body text-text-muted">This tournament is finished. Nothing moves from here.</p>
-        ) : (
-          <ul className="flex flex-col gap-space-3">
-            {moves.map(({ to, result }) => (
-              <li key={to} className="flex flex-col gap-space-2">
-                <button type="button" className={SECONDARY_BUTTON} disabled>
-                  {TRANSITION_LABEL[to]}
-                </button>
-                <p className="text-caption text-text-muted">
-                  {!result.ok ? (
-                    <span className="inline-flex items-start gap-space-2 text-amber-flag">
-                      <AlertIcon size="h-space-4 w-space-4" />
-                      Not yet — the rules, scoring, proof and boundaries all have to be locked first.
-                    </span>
-                  ) : HIGH_RISK.has(to) ? (
-                    "This one will ask you to confirm, and tell you what it changes, before it does anything."
-                  ) : (
-                    "Moves the whole tournament to this state for everybody."
-                  )}
-                </p>
-              </li>
-            ))}
-          </ul>
-        )}
-        <p className="inline-flex items-start gap-space-2 border-t border-hairline pt-space-3 text-caption text-text-muted">
+      {caps.changeEventSettings ? (
+        <section className={`${CARD_PADDED} flex flex-col gap-space-3`}>
+          <SectionHeading>What happens next</SectionHeading>
+          {moves.length === 0 ? (
+            <p className="text-body text-text-muted">This tournament is finished. Nothing moves from here.</p>
+          ) : (
+            <ul className="flex flex-col gap-space-3">
+              {moves.map(({ to, result }) => (
+                <li key={to} className="flex flex-col gap-space-2">
+                  <button type="button" className={SECONDARY_BUTTON} disabled>
+                    {TRANSITION_LABEL[to]}
+                  </button>
+                  <p className="text-caption text-text-muted">
+                    {!result.ok ? (
+                      <span className="inline-flex items-start gap-space-2 text-amber-flag">
+                        <AlertIcon size="h-space-4 w-space-4" />
+                        Not yet — the rules, scoring, proof and boundaries all have to be locked first.
+                      </span>
+                    ) : HIGH_RISK.has(to) ? (
+                      "This one will ask you to confirm, and tell you what it changes, before it does anything."
+                    ) : (
+                      "Moves the whole tournament to this state for everybody."
+                    )}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          )}
+          <p className="inline-flex items-start gap-space-2 border-t border-hairline pt-space-3 text-caption text-text-muted">
+            <LockIcon size="h-space-4 w-space-4" />
+            These controls are shown, and disabled, on purpose. Moving a tournament between states is
+            the server&apos;s decision, not the phone&apos;s, and that half is not switched on in this build yet.
+          </p>
+        </section>
+      ) : (
+        <p className={`${INSET} inline-flex items-start gap-space-2 text-caption text-text-muted`}>
           <LockIcon size="h-space-4 w-space-4" />
-          These controls are shown, and disabled, on purpose. Moving a tournament between states is
-          the server&apos;s decision, not the phone&apos;s, and that half is not switched on in this build yet.
+          Moving the tournament between states, and changing the rules, scoring and boundaries, is the
+          owner&apos;s and administrators&apos; to do.
         </p>
-      </section>
+      )}
 
       <Link href={`/tournaments/${tournament.id}/leaderboard`} className={SECONDARY_BUTTON}>
         Open public Results
       </Link>
     </div>
+  );
+}
+
+/**
+ * The dock list. Boats with something outstanding first, and a phone number that dials.
+ *
+ * `tel:` rather than a printed number on purpose: this screen gets used at 4am when
+ * weather cancels the event, one-handed, and retyping ten digits off a phone screen into
+ * the same phone is the moment a host gives up and uses a spreadsheet instead.
+ */
+function RosterLane({ load }: { load: ReturnType<typeof useRoster> }) {
+  if (load.state === "loading") return <p className="text-body text-text-muted">Loading the field…</p>;
+  if (load.state === "error") {
+    return (
+      <EmptyState
+        title="The field could not be loaded"
+        body={load.message}
+      />
+    );
+  }
+
+  const boats = load.boats;
+  const anglers = boats.reduce((total, boat) => total + boat.crew.length, 0);
+  const waiting = boats.filter((boat) => !boat.confirmed).length;
+
+  return (
+    <div className="flex flex-col gap-space-4">
+      <section className="grid grid-cols-2 gap-space-3 sm:grid-cols-3" aria-label="The field">
+        <StatTile label="Boats" value={String(boats.length)} />
+        <StatTile label="Anglers" value={String(anglers)} />
+        <StatTile label="Not confirmed" value={String(waiting)} tone={waiting > 0 ? "attention" : "neutral"} />
+      </section>
+
+      {boats.length === 0 ? (
+        <EmptyState
+          title="Nobody has entered yet"
+          body="Boats appear here as they register. Each one shows its crew, who the captain is, and a number that will be answered on the day."
+        />
+      ) : (
+        <ul className="flex flex-col gap-space-3">
+          {boats.map((boat) => (
+            <BoatCard key={boat.id} boat={boat} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function BoatCard({ boat }: { boat: RosterBoat }) {
+  return (
+    <li className={`${CARD} flex flex-col gap-space-3 p-space-4`}>
+      <div className="flex flex-wrap items-start justify-between gap-space-3">
+        <p className="text-body-strong text-text-primary">{boat.name}</p>
+        <TonePill tone={boat.confirmed ? "open" : "attention"}>
+          {boat.confirmed ? "Confirmed" : "Not confirmed"}
+        </TonePill>
+      </div>
+      <ul className="flex flex-col gap-space-2">
+        {boat.crew.map((angler) => (
+          <li key={angler.id} className="flex flex-wrap items-baseline justify-between gap-space-2">
+            <span className="text-body text-text-primary">
+              {angler.displayName}
+              {angler.captain ? <span className="text-caption text-text-muted"> · Captain</span> : null}
+            </span>
+            {angler.phone !== null ? (
+              <a href={`tel:${angler.phone}`} className={`text-caption ${TABULAR} text-text-link underline`}>
+                {angler.phone}
+              </a>
+            ) : (
+              <span className="text-caption text-text-muted">No number</span>
+            )}
+          </li>
+        ))}
+      </ul>
+      {!boat.confirmed ? (
+        <p className="text-caption text-text-muted">
+          Confirmed when the entry fee is settled. A boat stays here until the payment clears.
+        </p>
+      ) : null}
+    </li>
   );
 }
 
@@ -369,17 +616,35 @@ function JudgeLane({ flagged }: { flagged: readonly DemoTournamentCatch[] }) {
   );
 }
 
-function FinanceLane() {
+/**
+ * The takings, read from the ledger.
+ *
+ * This panel used to print "Nothing has been taken and nothing is owed" as a constant. The
+ * moment a real entry fee landed that sentence became a lie nobody would have caught,
+ * because it looks exactly like a quiet tournament. It reads `tournament_order` now, and
+ * when it cannot, it says so instead of showing a zero.
+ */
+function FinanceLane({
+  load,
+  caps,
+}: {
+  load: ReturnType<typeof useTournamentMoney>;
+  caps: HostCapabilities;
+}) {
   return (
     <div className="flex flex-col gap-space-4">
       <section className={`${CARD_PADDED} flex flex-col gap-space-3`}>
-        <SectionHeading>Entry money and payouts</SectionHeading>
-        <p className="text-body text-text-primary">
-          Nothing has been taken and nothing is owed. Payments are not switched on for this tournament.
-        </p>
-        <p className="text-caption text-text-muted">
-          When they are, this is where entry receipts and the prize pool are read from the ledger — never estimated on the phone.
-        </p>
+        <SectionHeading>Entry money</SectionHeading>
+        {load.state === "loading" ? (
+          <p className="text-body text-text-muted">Reading the ledger…</p>
+        ) : load.state === "error" ? (
+          <p className="inline-flex items-start gap-space-2 text-body text-amber-flag">
+            <AlertIcon size="h-space-4 w-space-4" />
+            The takings could not be read, so nothing is shown rather than a zero. {load.message}
+          </p>
+        ) : (
+          <MoneyFigures money={load.money} />
+        )}
       </section>
 
       <section className={`${CARD_PADDED} flex flex-col gap-space-3`}>
@@ -393,7 +658,7 @@ function FinanceLane() {
           <CheckRow
             state="done"
             label="A person with money permission has to approve it"
-            detail="Being the organizer, or the judge, is not enough on its own."
+            detail="Being the organizer, or the judge, is not enough on its own — event staff cannot read this screen at all."
           />
           <CheckRow
             state="done"
@@ -405,9 +670,89 @@ function FinanceLane() {
           Approve a payout
         </button>
         <p className="text-caption text-text-muted">
-          There is nothing to approve, and payouts are not switched on in this build.
+          {caps.approvePayout
+            ? "Your role can approve a payout. There is nothing to approve, and payouts are not switched on in this build."
+            : "Your role cannot approve a payout."}
         </p>
       </section>
+    </div>
+  );
+}
+
+function MoneyFigures({ money }: { money: TournamentMoney }) {
+  // No orders at all is a real state, and it is not the same as a zero total. Saying
+  // "nothing yet" beats printing $0.00, which reads as a tournament whose entries failed.
+  if (money.paidOrders === 0 && money.unpaidOrders === 0) {
+    return (
+      <p className="text-body text-text-primary">
+        Nothing has been taken yet. Entry fees appear here as they are paid.
+      </p>
+    );
+  }
+
+  const currency = money.currency ?? "USD";
+
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-space-3">
+        <StatTile label="Collected" value={formatMoney(money.collectedMinor, currency) ?? "—"} />
+        <StatTile
+          label="Still owed"
+          value={formatMoney(money.outstandingMinor, currency) ?? "—"}
+          tone={money.outstandingMinor > 0 ? "attention" : "neutral"}
+        />
+      </div>
+      <p className={`text-caption ${TABULAR} text-text-muted`}>
+        {money.paidOrders} paid · {money.unpaidOrders} waiting
+        {money.refundedOrders > 0 ? ` · ${money.refundedOrders} refunded` : ""}
+      </p>
+      {money.unpaidOrders > 0 ? (
+        <p className="text-caption text-text-muted">
+          Waiting means a checkout was started and the payment has not been confirmed. Those boats stay
+          off the confirmed field until it is.
+        </p>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * What each role on the host team can do — the same table the screen itself is driven by.
+ *
+ * Read-only, and says so. Inviting somebody is a server-side act with an email and a token
+ * behind it, and none of that half is built; a button that appeared to add an administrator
+ * and did nothing would be worse than no button.
+ */
+function AccessLane() {
+  return (
+    <div className="flex flex-col gap-space-4">
+      <section className="flex flex-col gap-space-3">
+        <SectionHeading>Who can do what</SectionHeading>
+        <ul className="flex flex-col gap-space-3">
+          {HOST_ROLES.map((role) => {
+            const caps = hostCapabilities(role);
+            const can = visibleLanes(caps)
+              .filter((entry) => entry !== "event")
+              .map((entry) => LANE_LABEL[entry]);
+            return (
+              <li key={role} className={`${CARD} flex flex-col gap-space-1 p-space-4`}>
+                <p className="text-body-strong text-text-primary">{HOST_ROLE_LABEL[role]}</p>
+                <p className="text-caption text-text-muted">{HOST_ROLE_SUMMARY[role]}</p>
+                <p className="text-caption text-text-muted">
+                  {can.length > 0 ? `Opens: ${can.join(", ")}.` : "Opens the event screen only."}
+                </p>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+
+      <p className={`${INSET} inline-flex items-start gap-space-2 text-caption text-text-muted`}>
+        <LockIcon size="h-space-4 w-space-4" />
+        Adding somebody to the host team is not switched on in this build. It needs an invitation with
+        an email and an expiring token behind it, and a button here that appeared to grant an
+        administrator without doing so would be worse than no button at all.
+      </p>
     </div>
   );
 }

--- a/src/features/tournaments/queries/use-host-role.ts
+++ b/src/features/tournaments/queries/use-host-role.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { isHostRole, type HostRole } from "@/core/tournaments/host-role";
+import { createClient } from "@/lib/supabase/client";
+
+import { hasSupabaseBrowserConfig } from "../demo-store";
+
+/**
+ * Which role, if any, the signed-in angler holds over this tournament.
+ *
+ * It goes through `my_tournament_host_role` rather than reading `tournament` and
+ * `organization_member` from the client, for a reason worth writing down: a non-member's
+ * select on `tournament` returns no rows, so "you are not a host" and "no such tournament"
+ * arrive as the same empty result. The screen would have to guess between sending somebody
+ * to the public page and telling them the event does not exist.
+ *
+ * The function answers only about the caller — a role or null, never who else is on the
+ * team, never whether the tournament exists — so a stranger who tries an id learns exactly
+ * what they already knew.
+ */
+export type HostRoleLoad =
+  | { readonly state: "loading" }
+  /** Settled. `role` is null for an entrant, a spectator, or a signed-out visitor. */
+  | { readonly state: "ready"; readonly role: HostRole | null }
+  | { readonly state: "error"; readonly message: string };
+
+export function useHostRole(tournamentId: string): HostRoleLoad {
+  const [load, setLoad] = useState<HostRoleLoad>({ state: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      await Promise.resolve();
+      if (cancelled) return;
+      setLoad({ state: "loading" });
+
+      // On-device demo data has no organisation and no membership behind it. The founder
+      // is looking at tournaments he created, so he is the owner of them.
+      if (!hasSupabaseBrowserConfig()) {
+        setLoad({ state: "ready", role: "OWNER" });
+        return;
+      }
+
+      try {
+        const supabase = createClient();
+        const { data, error } = await supabase.rpc("my_tournament_host_role", {
+          target_tournament_id: tournamentId,
+        });
+
+        if (cancelled) return;
+        if (error) {
+          setLoad({ state: "error", message: error.message });
+          return;
+        }
+
+        // A signed-out visitor, an entrant and a stranger all land here. That is not an
+        // error and must not read as one: null is the ordinary answer.
+        setLoad({ state: "ready", role: isHostRole(data) ? data : null });
+      } catch (cause) {
+        if (cancelled) return;
+        setLoad({
+          state: "error",
+          message:
+            cause instanceof Error ? cause.message : "Your access to this tournament could not be checked.",
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [tournamentId]);
+
+  return load;
+}

--- a/src/features/tournaments/queries/use-roster.ts
+++ b/src/features/tournaments/queries/use-roster.ts
@@ -1,0 +1,227 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { createClient } from "@/lib/supabase/client";
+
+import { getDemoEntry, hasSupabaseBrowserConfig } from "../demo-store";
+
+/**
+ * Who is actually entered, boat by boat.
+ *
+ * A host on a dock at 5am needs three things and no others: the boat's name, who is on it,
+ * and a phone number that will be answered. This returns exactly that, sorted so the boats
+ * still waiting on something come first — a confirmed field is a list you scroll past, and
+ * the entries that need a person are the reason the screen is open.
+ *
+ * Row-level security decides what comes back. A member of the host organisation with
+ * OWNER, ADMIN or STAFF sees the crews; everybody else gets nothing, and gets it without
+ * an error, because "no rows" is the correct answer for somebody who is not staff.
+ */
+
+export interface RosterAngler {
+  readonly id: string;
+  readonly displayName: string;
+  readonly phone: string | null;
+  readonly captain: boolean;
+  /** `tournament_entry.registration_status` — CONFIRMED once the payment is in. */
+  readonly status: string;
+}
+
+export interface RosterBoat {
+  readonly id: string;
+  readonly name: string;
+  readonly crew: readonly RosterAngler[];
+  /** True when every angler on the boat is CONFIRMED. */
+  readonly confirmed: boolean;
+}
+
+export type RosterLoad =
+  | { readonly state: "loading" }
+  | { readonly state: "ready"; readonly boats: readonly RosterBoat[] }
+  | { readonly state: "error"; readonly message: string };
+
+interface EntryRow {
+  readonly id: string;
+  readonly team_id: string | null;
+  readonly registration_status: string;
+}
+
+interface IdentityRow {
+  readonly tournament_entry_id: string;
+  readonly display_name: string;
+  readonly phone: string | null;
+}
+
+interface TeamRow {
+  readonly id: string;
+  readonly name: string;
+}
+
+interface MemberRow {
+  readonly tournament_team_id: string;
+  readonly tournament_entry_id: string;
+  readonly role: string;
+}
+
+/** Boats with something outstanding first, then alphabetically, so the order is stable. */
+function forTheDock(boats: readonly RosterBoat[]): readonly RosterBoat[] {
+  return [...boats].sort((left, right) => {
+    if (left.confirmed !== right.confirmed) return left.confirmed ? 1 : -1;
+    return left.name.localeCompare(right.name);
+  });
+}
+
+export function useRoster(tournamentId: string, enabled: boolean): RosterLoad {
+  const [load, setLoad] = useState<RosterLoad>({ state: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      await Promise.resolve();
+      if (cancelled) return;
+
+      // A treasurer never opens the roster lane, so it never asks. Fetching anyway would
+      // put a guaranteed-empty query on every load of the money screen.
+      if (!enabled) {
+        setLoad({ state: "ready", boats: [] });
+        return;
+      }
+
+      setLoad({ state: "loading" });
+
+      if (!hasSupabaseBrowserConfig()) {
+        const demo = getDemoEntry(tournamentId);
+        setLoad({
+          state: "ready",
+          boats:
+            demo === null
+              ? []
+              : [
+                  {
+                    id: demo.id,
+                    name: demo.display_name,
+                    confirmed: true,
+                    crew: [
+                      {
+                        id: demo.id,
+                        displayName: demo.display_name,
+                        phone: null,
+                        captain: true,
+                        status: "CONFIRMED",
+                      },
+                    ],
+                  },
+                ],
+        });
+        return;
+      }
+
+      try {
+        const supabase = createClient();
+
+        const entryResult = await supabase
+          .from("tournament_entry")
+          .select("id,team_id,registration_status")
+          .eq("tournament_id", tournamentId)
+          .is("deleted_at", null);
+
+        if (cancelled) return;
+        if (entryResult.error) {
+          setLoad({ state: "error", message: entryResult.error.message });
+          return;
+        }
+
+        const entries = (entryResult.data ?? []) as EntryRow[];
+        if (entries.length === 0) {
+          setLoad({ state: "ready", boats: [] });
+          return;
+        }
+
+        const entryIds = entries.map((entry) => entry.id);
+        const teamIds = [...new Set(entries.map((e) => e.team_id).filter((id): id is string => id !== null))];
+
+        const [identityResult, memberResult, teamResult] = await Promise.all([
+          supabase
+            .from("tournament_entry_identity")
+            .select("tournament_entry_id,display_name,phone")
+            .in("tournament_entry_id", entryIds),
+          supabase
+            .from("tournament_team_member")
+            .select("tournament_team_id,tournament_entry_id,role")
+            .in("tournament_entry_id", entryIds),
+          teamIds.length > 0
+            ? supabase.from("tournament_team").select("id,name").in("id", teamIds)
+            : Promise.resolve({ data: [] as TeamRow[], error: null }),
+        ]);
+
+        if (cancelled) return;
+
+        const names = new Map<string, IdentityRow>();
+        for (const row of (identityResult.data ?? []) as IdentityRow[]) {
+          names.set(row.tournament_entry_id, row);
+        }
+
+        const captains = new Set<string>();
+        for (const row of (memberResult.data ?? []) as MemberRow[]) {
+          if (row.role === "CAPTAIN") captains.add(row.tournament_entry_id);
+        }
+
+        const teamNames = new Map<string, string>();
+        for (const row of (teamResult.data ?? []) as TeamRow[]) teamNames.set(row.id, row.name);
+
+        // Group by team. An entry with no team is its own boat — a single angler who
+        // registered alone is still somebody the host has to account for, and dropping it
+        // would make the field size on this screen disagree with the one on the overview.
+        const grouped = new Map<string, RosterAngler[]>();
+        for (const entry of entries) {
+          const key = entry.team_id ?? `solo:${entry.id}`;
+          const identity = names.get(entry.id);
+          const crew = grouped.get(key) ?? [];
+          crew.push({
+            id: entry.id,
+            // An entry whose identity row is hidden or missing still has to appear: a boat
+            // silently absent from the dock list is the failure this screen must not have.
+            displayName: identity?.display_name ?? "Name not recorded",
+            phone: identity?.phone ?? null,
+            captain: captains.has(entry.id),
+            status: entry.registration_status,
+          });
+          grouped.set(key, crew);
+        }
+
+        const boats: RosterBoat[] = [...grouped.entries()].map(([key, crew]) => ({
+          id: key,
+          name:
+            teamNames.get(key) ??
+            crew.find((angler) => angler.captain)?.displayName ??
+            crew[0]?.displayName ??
+            "Entry",
+          crew: [...crew].sort((left, right) =>
+            left.captain === right.captain
+              ? left.displayName.localeCompare(right.displayName)
+              : left.captain
+                ? -1
+                : 1,
+          ),
+          confirmed: crew.every((angler) => angler.status === "CONFIRMED"),
+        }));
+
+        setLoad({ state: "ready", boats: forTheDock(boats) });
+      } catch (cause) {
+        if (cancelled) return;
+        setLoad({
+          state: "error",
+          message: cause instanceof Error ? cause.message : "The roster could not be loaded.",
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [tournamentId, enabled]);
+
+  return load;
+}

--- a/src/features/tournaments/queries/use-tournament-money.ts
+++ b/src/features/tournaments/queries/use-tournament-money.ts
@@ -1,0 +1,144 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { createClient } from "@/lib/supabase/client";
+
+import { hasSupabaseBrowserConfig } from "../demo-store";
+
+/**
+ * What has been collected, what is still owed, and what is in the pot.
+ *
+ * The money panel used to print "Nothing has been taken and nothing is owed" as a constant.
+ * On a real database that sentence was going to stay on the screen after the first entry
+ * fee landed, which is the worst kind of wrong: a plausible number nobody checks. It is
+ * read from `tournament_order` now, or it says it could not be read.
+ *
+ * Totals are minor units and stay integers the whole way. Dividing by 100 to add things up
+ * is how a ledger ends up eight cents short of the bank.
+ */
+
+export interface TournamentMoney {
+  /** ISO currency of the orders. Null when there are none to have one. */
+  readonly currency: string | null;
+  /** Sum of PAID orders, in minor units. */
+  readonly collectedMinor: number;
+  /** Sum of orders that have been started and not paid, in minor units. */
+  readonly outstandingMinor: number;
+  /** Orders that reached PAID. */
+  readonly paidOrders: number;
+  /** Orders started and not yet paid — a checkout somebody abandoned, or a pending webhook. */
+  readonly unpaidOrders: number;
+  /** Refunded or partly refunded orders, which a host will be asked about. */
+  readonly refundedOrders: number;
+}
+
+export type MoneyLoad =
+  | { readonly state: "loading" }
+  | { readonly state: "ready"; readonly money: TournamentMoney }
+  /** Distinct from zero. A host who cannot read the ledger must not be shown a zero. */
+  | { readonly state: "error"; readonly message: string };
+
+const NOTHING: TournamentMoney = {
+  currency: null,
+  collectedMinor: 0,
+  outstandingMinor: 0,
+  paidOrders: 0,
+  unpaidOrders: 0,
+  refundedOrders: 0,
+};
+
+interface OrderRow {
+  readonly currency: string;
+  readonly total_minor: number | string;
+  readonly status: string;
+}
+
+const PAID = new Set(["PAID", "PARTIALLY_REFUNDED"]);
+const OWED = new Set(["DRAFT", "PENDING_PAYMENT"]);
+const REFUNDED = new Set(["REFUNDED", "PARTIALLY_REFUNDED"]);
+
+export function useTournamentMoney(tournamentId: string, enabled: boolean): MoneyLoad {
+  const [load, setLoad] = useState<MoneyLoad>({ state: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      await Promise.resolve();
+      if (cancelled) return;
+
+      // Event staff cannot read the ledger, and the lane is hidden from them. Not asking
+      // keeps a denied query out of the console on every load of the dock screen.
+      if (!enabled) {
+        setLoad({ state: "ready", money: NOTHING });
+        return;
+      }
+
+      setLoad({ state: "loading" });
+
+      if (!hasSupabaseBrowserConfig()) {
+        // Demo data has no orders behind it, and inventing some would put a number on the
+        // screen that no payment produced.
+        setLoad({ state: "ready", money: NOTHING });
+        return;
+      }
+
+      try {
+        const supabase = createClient();
+        const { data, error } = await supabase
+          .from("tournament_order")
+          .select("currency,total_minor,status")
+          .eq("tournament_id", tournamentId);
+
+        if (cancelled) return;
+        if (error) {
+          setLoad({ state: "error", message: error.message });
+          return;
+        }
+
+        let collectedMinor = 0;
+        let outstandingMinor = 0;
+        let paidOrders = 0;
+        let unpaidOrders = 0;
+        let refundedOrders = 0;
+        let currency: string | null = null;
+
+        for (const row of (data ?? []) as OrderRow[]) {
+          // bigint arrives as a string once it passes the safe-integer range. Number() on
+          // the string is right; reading it as a number field is not.
+          const total = Number(row.total_minor);
+          if (!Number.isFinite(total)) continue;
+          currency ??= row.currency;
+
+          if (PAID.has(row.status)) {
+            collectedMinor += total;
+            paidOrders += 1;
+          }
+          if (OWED.has(row.status)) {
+            outstandingMinor += total;
+            unpaidOrders += 1;
+          }
+          if (REFUNDED.has(row.status)) refundedOrders += 1;
+        }
+
+        setLoad({
+          state: "ready",
+          money: { currency, collectedMinor, outstandingMinor, paidOrders, unpaidOrders, refundedOrders },
+        });
+      } catch (cause) {
+        if (cancelled) return;
+        setLoad({
+          state: "error",
+          message: cause instanceof Error ? cause.message : "The takings could not be read.",
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [tournamentId, enabled]);
+
+  return load;
+}

--- a/supabase/migrations/20260907170000_host_roles.sql
+++ b/supabase/migrations/20260907170000_host_roles.sql
@@ -1,0 +1,184 @@
+-- Host roles that mean something.
+--
+-- `organization_member.role` has allowed OWNER, ADMIN, STAFF and FINANCE since the first
+-- tournament migration. Three of them are used by policies. FINANCE is named by nothing:
+-- `grep -n FINANCE supabase/migrations/` outside the check constraint returned no rows
+-- before this file. Granting it to a club treasurer therefore gave them strictly less than
+-- STAFF — they could not read an order, a payment, a refund or a prize pool — so the only
+-- way to let somebody handle the money was to make them an ADMIN, which also hands over
+-- the rules, the scoring and the power to cancel the event.
+--
+-- This makes the money roles OWNER, ADMIN and FINANCE everywhere, uniformly, and takes
+-- STAFF off the order tables. That last part is a reduction, and it is deliberate: event
+-- staff run the dock, and whether a boat has paid is `tournament_entry.registration_status`,
+-- not the ledger. Nothing in the application read `tournament_order` as staff, so the
+-- change removes an unused capability rather than a working screen. An entrant's read of
+-- their own order is untouched: it hangs off `purchaser_angler_id = auth.uid()`.
+--
+-- `src/core/tournaments/host-role.sql.test.ts` reads the role arrays below and fails if
+-- the screen's capability table and these policies ever disagree.
+
+-- Money reads: the ledger, in every table it is spread across.
+
+drop policy if exists tournament_order_owner_read on public.tournament_order;
+create policy tournament_order_owner_read on public.tournament_order
+for select to authenticated using (
+  purchaser_angler_id = auth.uid()
+  or public.is_organization_member(organization_id, array['OWNER','ADMIN','FINANCE'])
+);
+
+drop policy if exists tournament_order_owner_write on public.tournament_order;
+create policy tournament_order_owner_write on public.tournament_order
+for all to authenticated using (
+  purchaser_angler_id = auth.uid()
+  or public.is_organization_member(organization_id, array['OWNER','ADMIN','FINANCE'])
+) with check (
+  purchaser_angler_id = auth.uid()
+  or public.is_organization_member(organization_id, array['OWNER','ADMIN','FINANCE'])
+);
+
+drop policy if exists tournament_order_item_read on public.tournament_order_item;
+create policy tournament_order_item_read on public.tournament_order_item
+for select to authenticated using (exists (
+  select 1 from public.tournament_order o where o.id = order_id and (
+    o.purchaser_angler_id = auth.uid()
+    or public.is_organization_member(o.organization_id, array['OWNER','ADMIN','FINANCE'])
+  )
+));
+
+drop policy if exists tournament_order_item_insert on public.tournament_order_item;
+create policy tournament_order_item_insert on public.tournament_order_item
+for insert to authenticated with check (exists (
+  select 1 from public.tournament_order o where o.id = order_id and (
+    o.purchaser_angler_id = auth.uid()
+    or public.is_organization_member(o.organization_id, array['OWNER','ADMIN','FINANCE'])
+  )
+));
+
+drop policy if exists financial_org_read on public.payment;
+create policy financial_org_read on public.payment
+for select to authenticated using (exists (
+  select 1 from public.tournament_order o where o.id = order_id and (
+    o.purchaser_angler_id = auth.uid()
+    or public.is_organization_member(o.organization_id, array['OWNER','ADMIN','FINANCE'])
+  )
+));
+
+drop policy if exists payment_attempt_read on public.payment_attempt;
+create policy payment_attempt_read on public.payment_attempt
+for select to authenticated using (exists (
+  select 1 from public.payment p join public.tournament_order o on o.id = p.order_id
+  where p.id = payment_id and (
+    o.purchaser_angler_id = auth.uid()
+    or public.is_organization_member(o.organization_id, array['OWNER','ADMIN','FINANCE'])
+  )
+));
+
+drop policy if exists payment_allocation_read on public.payment_allocation;
+create policy payment_allocation_read on public.payment_allocation
+for select to authenticated using (exists (
+  select 1 from public.payment p join public.tournament_order o on o.id = p.order_id
+  where p.id = payment_id and (
+    o.purchaser_angler_id = auth.uid()
+    or public.is_organization_member(o.organization_id, array['OWNER','ADMIN','FINANCE'])
+  )
+));
+
+drop policy if exists payment_refund_read on public.payment_refund;
+create policy payment_refund_read on public.payment_refund
+for select to authenticated using (exists (
+  select 1 from public.payment p join public.tournament_order o on o.id = p.order_id
+  where p.id = payment_id and (
+    o.purchaser_angler_id = auth.uid()
+    or public.is_organization_member(o.organization_id, array['OWNER','ADMIN','FINANCE'])
+  )
+));
+
+drop policy if exists platform_fee_admin_read on public.platform_fee;
+create policy platform_fee_admin_read on public.platform_fee
+for select to authenticated using (exists (
+  select 1 from public.payment p join public.tournament_order o on o.id = p.order_id
+  where p.id = payment_id
+    and public.is_organization_member(o.organization_id, array['OWNER','ADMIN','FINANCE'])
+));
+
+drop policy if exists financial_event_admin_read on public.financial_event;
+create policy financial_event_admin_read on public.financial_event
+for select to authenticated
+using (public.is_organization_member(organization_id, array['OWNER','ADMIN','FINANCE']));
+
+-- Payouts. Reading them is a money read; approving one is the separate, deliberate act
+-- the operations screen has always described, and it is the one thing besides reading
+-- that FINANCE is for.
+
+drop policy if exists payout_instruction_finance_read on public.payout_instruction;
+create policy payout_instruction_finance_read on public.payout_instruction
+for select to authenticated
+using (public.is_organization_member(organization_id, array['OWNER','ADMIN','FINANCE']));
+
+drop policy if exists payout_instruction_finance_write on public.payout_instruction;
+create policy payout_instruction_finance_write on public.payout_instruction
+for all to authenticated
+using (public.is_organization_member(organization_id, array['OWNER','ADMIN','FINANCE']))
+with check (public.is_organization_member(organization_id, array['OWNER','ADMIN','FINANCE']));
+
+drop policy if exists payout_finance_read on public.payout;
+create policy payout_finance_read on public.payout
+for select to authenticated using (exists (
+  select 1 from public.payout_instruction pi
+   where pi.id = payout_instruction_id
+     and public.is_organization_member(pi.organization_id, array['OWNER','ADMIN','FINANCE'])
+));
+
+drop policy if exists payout_event_finance_read on public.payout_event;
+create policy payout_event_finance_read on public.payout_event
+for select to authenticated using (exists (
+  select 1 from public.payout_instruction pi
+   where pi.id = payout_instruction_id
+     and public.is_organization_member(pi.organization_id, array['OWNER','ADMIN','FINANCE'])
+));
+
+-- Which role am I, for this tournament?
+--
+-- The host screen needs the answer before it can decide what to render, and it cannot get
+-- there by reading `tournament`: a non-member's select on that table returns nothing, so
+-- "no row" would be indistinguishable from "no such tournament" and every stranger would
+-- see a loading state resolve into a blank host page.
+--
+-- SECURITY DEFINER, so it must state its own authorization, and it does: the only row it
+-- can ever look at is the caller's own membership. It returns a role or null and nothing
+-- else — not the organisation, not who else is on the team, not whether the tournament
+-- exists. Told an id they have no business with, a stranger learns exactly what they
+-- already knew, which is that they are not on it.
+create or replace function public.my_tournament_host_role(target_tournament_id uuid)
+returns text
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select m.role
+    from public.tournament t
+    join public.organization_member m
+      on m.organization_id = t.organization_id
+   where t.id = target_tournament_id
+     and t.deleted_at is null
+     and m.angler_id = auth.uid()
+     and m.status = 'ACTIVE'
+     and m.deleted_at is null
+   limit 1;
+$$;
+
+revoke all on function public.my_tournament_host_role(uuid) from public;
+grant execute on function public.my_tournament_host_role(uuid) to authenticated;
+/*
+  `anon` too, deliberately. A signed-out visitor on a host URL has `auth.uid()` of null, so
+  the join can never match and the function returns null — the same answer an entrant gets,
+  carrying no information about anything. Without the grant the call fails on permissions
+  instead, and the screen would show a signed-out visitor a red error where it should show
+  them the way back to the event.
+*/
+grant execute on function public.my_tournament_host_role(uuid) to anon;
+
+comment on function public.my_tournament_host_role(uuid) is
+  'The calling angler''s active organisation role for a tournament, or null. Reveals nothing about anyone else.';

--- a/supabase/test/rpc-behaviour.sql
+++ b/supabase/test/rpc-behaviour.sql
@@ -261,4 +261,98 @@ begin
   perform pg_temp.check('signed out, you cannot register anybody', failed);
 end $$;
 
+
+-- ---------------------------------------------------------------- host roles
+/*
+  Who can see the money, proved by row-level security rather than by reading the policy
+  text. These run as the `authenticated` role — every check above calls a SECURITY DEFINER
+  function, which bypasses RLS entirely, so none of them would have noticed if a policy
+  were wrong.
+
+  FINANCE was in `organization_member.role`'s check constraint from the first tournament
+  migration and named by no policy anywhere, so a club treasurer could read no order, no
+  payment and no prize pool. The first two checks are that hole, closed.
+*/
+insert into auth.users (id, email) values
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'treasurer@example.test'),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'dockhand@example.test'),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'stranger@example.test');
+
+insert into public.organization_member (organization_id, angler_id, role, status) values
+  ('33333333-3333-3333-3333-333333333333', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'FINANCE', 'ACTIVE'),
+  ('33333333-3333-3333-3333-333333333333', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'STAFF', 'ACTIVE');
+
+insert into public.tournament_order (id, organization_id, tournament_id, purchaser_angler_id,
+                                     currency, subtotal_minor, total_minor, status, idempotency_key)
+values ('dddddddd-dddd-dddd-dddd-dddddddddddd', '33333333-3333-3333-3333-333333333333',
+        '55555555-5555-5555-5555-555555555555', '11111111-1111-1111-1111-111111111111',
+        'USD', 40000, 40000, 'PENDING_PAYMENT', 'host-role-fixture');
+
+grant select on public.tournament_order to authenticated;
+
+do $$
+declare n integer;
+begin
+  set local role authenticated;
+
+  set local request.jwt.claim.sub = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+  -- Scoped to the fixture row: the registration checks above created several real orders
+  -- in this same club, and a bare count would pass for the wrong reason.
+  select count(*) into n from public.tournament_order
+   where id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+  perform pg_temp.check('a treasurer can read an order for their club', n = 1);
+
+  -- And every other order the club has taken, which is the point of the role.
+  select count(*) into n from public.tournament_order
+   where organization_id = '33333333-3333-3333-3333-333333333333';
+  perform pg_temp.check('and every other order the club has taken', n > 1);
+
+  perform pg_temp.check('and knows they are the treasurer',
+    public.my_tournament_host_role('55555555-5555-5555-5555-555555555555') = 'FINANCE');
+
+  -- Event staff run the dock. Whether a boat has paid is the entry's registration status,
+  -- not the ledger, and this release takes them off it deliberately.
+  set local request.jwt.claim.sub = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+  select count(*) into n from public.tournament_order;
+  perform pg_temp.check('event staff cannot read the ledger at all', n = 0);
+
+  perform pg_temp.check('but staff still know they are staff',
+    public.my_tournament_host_role('55555555-5555-5555-5555-555555555555') = 'STAFF');
+
+  -- The purchaser keeps their own receipt. Tightening the host side must never take an
+  -- angler's own order away from them.
+  set local request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';
+  select count(*) into n from public.tournament_order
+   where id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+  perform pg_temp.check('an angler can still read the order they paid for', n = 1);
+
+  perform pg_temp.check('and an entrant is not a host',
+    public.my_tournament_host_role('55555555-5555-5555-5555-555555555555') is null);
+
+  set local request.jwt.claim.sub = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+  select count(*) into n from public.tournament_order;
+  perform pg_temp.check('a stranger reads no orders at all', n = 0);
+
+  /*
+    Told a tournament id they have no business with, a stranger learns nothing. The
+    function returns null whether the tournament exists or not, so it cannot be used to
+    discover which ids are real.
+  */
+  perform pg_temp.check('a stranger gets null, not an error',
+    public.my_tournament_host_role('55555555-5555-5555-5555-555555555555') is null);
+  perform pg_temp.check('and null for an id that does not exist either',
+    public.my_tournament_host_role('00000000-0000-0000-0000-000000000000') is null);
+
+  reset role;
+
+  -- Signed out. The screen calls this before it knows whether anybody is signed in, and a
+  -- permission failure here would put a red error in front of a visitor who has simply
+  -- followed a link to a host page.
+  set local role anon;
+  set local request.jwt.claim.sub = '';
+  perform pg_temp.check('signed out, the host role is null rather than an error',
+    public.my_tournament_host_role('55555555-5555-5555-5555-555555555555') is null);
+  reset role;
+end $$;
+
 rollback;

--- a/supabase/test/supabase-shim.sql
+++ b/supabase/test/supabase-shim.sql
@@ -14,4 +14,16 @@ $$;
 create or replace function auth.role() returns text language sql stable as $$
   select coalesce(nullif(current_setting('request.jwt.claim.role', true), ''), 'anon');
 $$;
+
+/*
+  Real Supabase lets the client roles call `auth.uid()`; without this they cannot, and an
+  RLS policy that says `purchaser_angler_id = auth.uid()` fails on permissions rather than
+  on the row. Granted here because a test that reads zero rows for the wrong reason is
+  worse than no test — it reports "correctly denied" for a policy that was never evaluated.
+*/
+grant usage on schema auth to anon, authenticated, service_role;
+grant execute on function auth.uid() to anon, authenticated, service_role;
+grant execute on function auth.role() to anon, authenticated, service_role;
+grant select on auth.users to authenticated, service_role;
+
 create extension if not exists pgcrypto;


### PR DESCRIPTION
Part 3 of the tournament redesign: the host admin page.

**Updated after #131 merged.** This branch now carries a merge of `main`. The two PRs conflicted in two places — both had appended checks to `supabase/test/rpc-behaviour.sql`, and both had written a worklog named `2026-09-07-05-head-dev.md`. The test file merged cleanly and I verified it *runs* rather than trusting git: 59 migrations apply and every check passes, the webhook's currency refusals and the host-role checks together. The webhook's worklog keeps `-05-`, this one became `-06-`, per the house rule of one file per session.

Building this turned up the reason the section could not be hardened as it stood — the permissions it was meant to sit on were partly fiction.

## The treasurer role existed and did nothing

`organization_member.role` has allowed `OWNER`, `ADMIN`, `STAFF` and `FINANCE` since the first tournament migration. Row-level security across twenty tables names the first three. **It names `FINANCE` nowhere** — searching every migration for the word, outside the check constraint that allows it, returned nothing at all.

So handing a club's treasurer the `FINANCE` role gave them *strictly less than event staff*: not one order, payment, refund, payout instruction or prize pool. The only way to let a person handle the money was to make them an `ADMIN` — which also hands over the rules, the scoring, the roster, and the power to cancel the event.

The separation of duty the role exists to express could not be expressed. The operations screen had been promising it in prose the whole time: *"Nothing on this screen can touch money — that is a different permission held by a different person."*

|  | Owner | Administrator | Event staff | Treasurer |
|---|---|---|---|---|
| Open the host screen | ✓ | ✓ | ✓ | ✓ |
| Rules, scoring, event state | ✓ | ✓ | | |
| Roster | ✓ | ✓ | ✓ | |
| Judging | ✓ | ✓ | ✓ | |
| Read the ledger | ✓ | ✓ | | ✓ |
| Approve a payout | ✓ | ✓ | | ✓ |
| Manage the host team | ✓ | ✓ | | |

`FINANCE` now reads the money everywhere the ledger is spread, and **nothing else**. A treasurer who could disqualify a boat is an administrator with a different name.

**Event staff come off the order tables in exchange.** A reduction, on purpose: their job is the dock, and whether a boat has paid is `tournament_entry.registration_status`, not the ledger. Nothing in the app read `tournament_order` as staff, so this removes an unused capability rather than a working screen. An entrant's read of their own order hangs off `purchaser_angler_id = auth.uid()` and is untouched.

## The screen asked nobody's permission

`/tournaments/[id]/operations` rendered the host heading, the lifecycle controls, the judging queue and the money panel to any visitor who knew the address. RLS kept the panels empty, so this was never a data leak — it was a page telling a stranger they were the host of an event, with **"Cancel the tournament"** on it.

The role is fetched first now, through `my_tournament_host_role(uuid)`. That function exists instead of a client-side join because a non-member's `select` on `tournament` returns no rows, making *"you are not a host"* and *"no such tournament"* indistinguishable. Being `security definer` it states its own authorization, and states the narrowest one available: the only row it can reach is the caller's own membership. Granted to `anon` too — a signed-out visitor's `auth.uid()` is null, the join cannot match, and null is the right answer; without the grant they meet a permission error where they should meet a way back to the event.

Somebody with no role gets a sentence and two links, not a locked room.

## The two halves have to agree, and a test makes them

The capability table in `core/tournaments/host-role.ts` and the database's policies are one rule written twice, a week apart, in two languages. `host-role.sql.test.ts` reads the role arrays out of the migrations and fails if they drift.

I checked both directions rather than trusting a green tick:

```
× 'financial_org_read' names exactly the roles with 'readMoney'      ← table flipped, 14 red
not ok event staff cannot read the ledger at all                     ← policy reverted
not ok signed out, the host role is null rather than an error        ← anon grant removed
```

## Two things found on the way

**The money panel was printing a constant.** *"Nothing has been taken and nothing is owed"* was hardcoded. That sentence would have survived the first real entry fee and looked exactly like a quiet tournament — the worst kind of wrong, because nobody reports it. It reads the orders now, and when it cannot read them it says so. A zero and "not allowed to look" must never render the same.

**The database test harness was granting a false pass.** The `authenticated` and `anon` roles were never given permission to use `auth.uid()`, so any RLS check would have read zero rows *for the wrong reason* and reported "correctly denied" for a policy that was never evaluated. Fixed in the shim — which is why the first version of these tests failed honestly instead of passing by accident. Every future RLS test in this repo depended on that.

## Also: the list a host actually needs

Boats, crews, who the captain is, and a `tel:` number that dials. Anything outstanding sorts to the top. This is the screen that gets used one-handed at 4am when weather cancels an event, and retyping ten digits off a phone screen into the same phone is the moment a host goes back to a spreadsheet.

## How it was checked

Figures below are for the merged head, so they include what #131 brought in.

- **59 migrations apply cleanly and all database behaviour checks pass** against real Postgres 16 (`npm run db:check`) — confirmed in the CI log, not just from the green tick. Eight of those checks are new here and impersonate a treasurer, event staff, an entrant, a stranger and a signed-out visitor under `authenticated`/`anon`; they are the first checks in this repo that exercise RLS at all, since `security definer` functions bypass it.
- `npm run verify` clean — **1026 tests across 97 files**. 8 lint warnings, all pre-existing. `npm run build` clean.
- 29 new tests on this branch.

## Still open, honestly

Nobody can be **added** to a host team from the app. That needs an invitation with an email and an expiring token, and none of that half exists — the screen says so rather than showing a button that would appear to grant an administrator and would not. The event-state controls stay visible and disabled for the same reason ADR 010 gives: activation is the server's act. Live catches are still device-local. None of this has been tried on a real phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NvrbeVyuL4CQXbpPMijvnv